### PR TITLE
Reporter abbreviation views for CAP/legalhist diff

### DIFF
--- a/db/migrations/20260521114705_cap_reporter_abbreviations.sql
+++ b/db/migrations/20260521114705_cap_reporter_abbreviations.sql
@@ -1,0 +1,24 @@
+-- migrate:up
+SET ROLE = law_admin;
+CREATE MATERIALIZED VIEW IF NOT EXISTS cap.reporter_abbreviations AS
+WITH extracted AS (
+  SELECT COALESCE(
+    substring(cite from '^[0-9]+\s+(.+?)\s+[0-9]+[A-Za-z-]*$'),
+    substring(cite from '^(.+?)\s+[0-9]+[A-Za-z-]*$'),
+    substring(cite from '^[0-9]{4}-(.+?)-[0-9]+$')
+  ) AS abbreviation
+  FROM cap.citations
+  WHERE type != 'parallel'
+)
+SELECT abbreviation, COUNT(*)::bigint AS n
+FROM extracted
+WHERE abbreviation ~ '^[A-Za-z]'
+GROUP BY abbreviation
+HAVING COUNT(*) > 1
+ORDER BY abbreviation;
+
+CREATE UNIQUE INDEX IF NOT EXISTS reporter_abbreviations_abbreviation_idx
+  ON cap.reporter_abbreviations (abbreviation);
+
+-- migrate:down
+DROP MATERIALIZED VIEW IF EXISTS cap.reporter_abbreviations;

--- a/db/migrations/20260521131903_legalhist_all_abbreviations_view.sql
+++ b/db/migrations/20260521131903_legalhist_all_abbreviations_view.sql
@@ -1,0 +1,14 @@
+-- migrate:up
+SET ROLE = law_admin;
+CREATE OR REPLACE VIEW legalhist.all_abbreviations AS
+SELECT abbreviation FROM (
+  SELECT DISTINCT reporter_standard AS abbreviation FROM legalhist.reporters
+  UNION
+  SELECT DISTINCT alt_abbr AS abbreviation
+    FROM legalhist.reporters_abbreviations
+    WHERE alt_abbr IS NOT NULL
+) u
+ORDER BY abbreviation;
+
+-- migrate:down
+DROP VIEW IF EXISTS legalhist.all_abbreviations;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,7 +1,7 @@
 \restrict dbmate
 
--- Dumped from database version 17.9 (Debian 17.9-0+deb13u1)
--- Dumped by pg_dump version 17.9 (Homebrew)
+-- Dumped from database version 17.9 (Debian 17.9-1.pgdg13+1)
+-- Dumped by pg_dump version 17.10 (Homebrew)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -621,6 +621,26 @@ CREATE TABLE cap.opinions (
 
 
 --
+-- Name: reporter_abbreviations; Type: MATERIALIZED VIEW; Schema: cap; Owner: -
+--
+
+CREATE MATERIALIZED VIEW cap.reporter_abbreviations AS
+ WITH extracted AS (
+         SELECT COALESCE("substring"(citations.cite, '^[0-9]+\s+(.+?)\s+[0-9]+[A-Za-z-]*$'::text), "substring"(citations.cite, '^(.+?)\s+[0-9]+[A-Za-z-]*$'::text), "substring"(citations.cite, '^[0-9]{4}-(.+?)-[0-9]+$'::text)) AS abbreviation
+           FROM cap.citations
+          WHERE (citations.type <> 'parallel'::text)
+        )
+ SELECT abbreviation,
+    count(*) AS n
+   FROM extracted
+  WHERE (abbreviation ~ '^[A-Za-z]'::text)
+  GROUP BY abbreviation
+ HAVING (count(*) > 1)
+  ORDER BY abbreviation
+  WITH NO DATA;
+
+
+--
 -- Name: reporters; Type: TABLE; Schema: cap; Owner: -
 --
 
@@ -852,6 +872,16 @@ CREATE TABLE legalhist.reporters (
     single_vol boolean,
     type text,
     reporter_cap text
+);
+
+
+--
+-- Name: reporters_abbreviations; Type: TABLE; Schema: legalhist; Owner: -
+--
+
+CREATE TABLE legalhist.reporters_abbreviations (
+    reporter_standard text NOT NULL,
+    alt_abbr text
 );
 
 
@@ -1702,6 +1732,13 @@ CREATE UNIQUE INDEX cap_volumes_to_jurisdictions_idx ON cap.volumes_to_jurisdict
 
 
 --
+-- Name: reporter_abbreviations_abbreviation_idx; Type: INDEX; Schema: cap; Owner: -
+--
+
+CREATE UNIQUE INDEX reporter_abbreviations_abbreviation_idx ON cap.reporter_abbreviations USING btree (abbreviation);
+
+
+--
 -- Name: reporters_short_name_idx; Type: INDEX; Schema: cap; Owner: -
 --
 
@@ -2107,11 +2144,11 @@ ALTER TABLE ONLY legalhist.whitelist
 
 
 --
--- Name: reporters_diffvols reporters_diffvols_reporter_title_fkey; Type: FK CONSTRAINT; Schema: legalhist; Owner: -
+-- Name: reporters_abbreviations reporters_abbreviations_reporter_standard_fk; Type: FK CONSTRAINT; Schema: legalhist; Owner: -
 --
 
-ALTER TABLE ONLY legalhist.reporters_diffvols
-    ADD CONSTRAINT reporters_diffvols_reporter_title_fkey FOREIGN KEY (reporter_title) REFERENCES legalhist.reporters_nominate(reporter_title) ON UPDATE CASCADE;
+ALTER TABLE ONLY legalhist.reporters_abbreviations
+    ADD CONSTRAINT reporters_abbreviations_reporter_standard_fk FOREIGN KEY (reporter_standard) REFERENCES legalhist.reporters(reporter_standard);
 
 
 --
@@ -2249,4 +2286,5 @@ INSERT INTO sys_admin.migrations_dbmate (version) VALUES
     ('20260312181004'),
     ('20260313120000'),
     ('20260325003434'),
-    ('20260325004157');
+    ('20260325004157'),
+    ('20260521114705');

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -789,6 +789,48 @@ CREATE TABLE english_reports.cases (
 
 
 --
+-- Name: reporters; Type: TABLE; Schema: legalhist; Owner: -
+--
+
+CREATE TABLE legalhist.reporters (
+    reporter_standard text NOT NULL,
+    reporter_title text,
+    level text,
+    jurisdiction text,
+    year_start integer,
+    year_end integer,
+    single_vol boolean,
+    type text,
+    reporter_cap text
+);
+
+
+--
+-- Name: reporters_abbreviations; Type: TABLE; Schema: legalhist; Owner: -
+--
+
+CREATE TABLE legalhist.reporters_abbreviations (
+    reporter_standard text NOT NULL,
+    alt_abbr text
+);
+
+
+--
+-- Name: all_abbreviations; Type: VIEW; Schema: legalhist; Owner: -
+--
+
+CREATE VIEW legalhist.all_abbreviations AS
+ SELECT abbreviation
+   FROM ( SELECT DISTINCT reporters.reporter_standard AS abbreviation
+           FROM legalhist.reporters
+        UNION
+         SELECT DISTINCT reporters_abbreviations.alt_abbr AS abbreviation
+           FROM legalhist.reporters_abbreviations
+          WHERE (reporters_abbreviations.alt_abbr IS NOT NULL)) u
+  ORDER BY abbreviation;
+
+
+--
 -- Name: page_ocrtext; Type: TABLE; Schema: moml; Owner: -
 --
 
@@ -855,33 +897,6 @@ ALTER TABLE legalhist.code_reporter ALTER COLUMN id ADD GENERATED ALWAYS AS IDEN
 CREATE TABLE legalhist.ocr_corrections (
     mistake text,
     correction text
-);
-
-
---
--- Name: reporters; Type: TABLE; Schema: legalhist; Owner: -
---
-
-CREATE TABLE legalhist.reporters (
-    reporter_standard text NOT NULL,
-    reporter_title text,
-    level text,
-    jurisdiction text,
-    year_start integer,
-    year_end integer,
-    single_vol boolean,
-    type text,
-    reporter_cap text
-);
-
-
---
--- Name: reporters_abbreviations; Type: TABLE; Schema: legalhist; Owner: -
---
-
-CREATE TABLE legalhist.reporters_abbreviations (
-    reporter_standard text NOT NULL,
-    alt_abbr text
 );
 
 
@@ -2287,4 +2302,5 @@ INSERT INTO sys_admin.migrations_dbmate (version) VALUES
     ('20260313120000'),
     ('20260325003434'),
     ('20260325004157'),
-    ('20260521114705');
+    ('20260521114705'),
+    ('20260521131903');


### PR DESCRIPTION
## Summary

Adds two views to support identifying standard reporters that don't work with CAP (refs #161, intentionally not closing — investigation is ongoing):

- `cap.reporter_abbreviations` (materialized view) — extracts reporter abbreviations from `cap.citations` via three coalesced regexes, with `n > 1` and starts-with-letter filters to drop OCR/typo noise. ~1,650 distinct abbreviations.
- `legalhist.all_abbreviations` (view) — union of `legalhist.reporters.reporter_standard` and `legalhist.reporters_abbreviations.alt_abbr`, deduplicated and alphabetized. ~1,238 rows.

Together they enable a straight `EXCEPT` diff to surface (a) abbreviations we recognize but CAP doesn't use and (b) high-frequency CAP abbreviations missing from the whitelist — see the comments on #161 for the diff queries.

## Test plan

- [ ] `dbmate up` applies both migrations cleanly
- [ ] `SELECT COUNT(*) FROM cap.reporter_abbreviations;` ≈ 1,650
- [ ] `SELECT COUNT(*) FROM legalhist.all_abbreviations;` ≈ 1,238
- [ ] Diff queries from issue #161 return expected ~864 / ~534 rows
- [ ] `dbmate rollback` drops each view cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)