### PR TITLE
Adapt cite-detector-moml to new reporters schema

### DIFF
--- a/cite-detector-moml/main.go
+++ b/cite-detector-moml/main.go
@@ -73,14 +73,17 @@ func main() {
 	detectors = append(detectors, citations.GenericDetector)
 	slog.Info("prepared general-purpose detector", "num_detectors", len(detectors))
 
-	// Create and load the single volume detectors
-	abbreviations, err := citationsDB.GetSingleVolReporters(ctx)
+	// Create and load the single volume detectors. Each row is a
+	// (reporter_standard, abbreviation) pair, so the saved reporter_abbr
+	// gets normalized to the canonical reporter_standard regardless of
+	// which spelling appeared in the OCR.
+	singleVolReporters, err := citationsDB.GetSingleVolReporterAbbrs(ctx)
 	if err != nil {
 		slog.Error("could not get single volume reporters from database", "error", err)
 		os.Exit(1)
 	}
-	for _, abbr := range abbreviations {
-		d := citations.NewSingleVolDetector(abbr, abbr)
+	for _, sv := range singleVolReporters {
+		d := citations.NewSingleVolDetector(sv.Standard, sv.Abbr)
 		detectors = append(detectors, d)
 	}
 	slog.Info("prepared single volume detectors", "num_detectors", len(detectors))

--- a/go/citations/detector.go
+++ b/go/citations/detector.go
@@ -31,9 +31,12 @@ func NewDetector(reporter string, abbreviation string) *Detector {
 // NewSingleVolDetector creates a new citation detector and initializes its
 // regular expression. The detector will not look for a volume number
 func NewSingleVolDetector(reporter string, abbreviation string) *Detector {
-	// Replace spaces in the abbreviation with [\s.]* to match variant forms:
+	// Escape regex metacharacters first so abbreviations containing parens,
+	// periods, etc. (e.g. "Bail Eq (SC)") match literally rather than being
+	// interpreted as capture groups or wildcards. Then replace literal spaces
+	// (which QuoteMeta leaves alone) with [\s.]* to match variant forms:
 	// e.g. "M & M" matches "M&M.", "M. & M.", etc.
-	flexAbbr := strings.ReplaceAll(abbreviation, " ", `[\s.]*`)
+	flexAbbr := strings.ReplaceAll(regexp.QuoteMeta(abbreviation), " ", `[\s.]*`)
 	detector := &Detector{
 		Reporter:     reporter,
 		Abbreviation: abbreviation,

--- a/go/citations/detector_test.go
+++ b/go/citations/detector_test.go
@@ -226,6 +226,30 @@ func TestSingleVolDetector_NormalizesReporterAbbr(t *testing.T) {
 			expectedRaw:  "Tothill 876",
 			expectedPage: 876,
 		},
+		{
+			name:         "alt with parenthesized jurisdiction (SC)",
+			canonical:    "Bail. Eq.",
+			abbreviation: "Bail Eq (SC)",
+			text:         "See Bail Eq (SC) 42 for the ruling.",
+			expectedRaw:  "Bail Eq (SC) 42",
+			expectedPage: 42,
+		},
+		{
+			name:         "alt with parenthesized jurisdiction (Eng)",
+			canonical:    "Al",
+			abbreviation: "Al (Eng)",
+			text:         "Reference Al (Eng) 17 in the early reports.",
+			expectedRaw:  "Al (Eng) 17",
+			expectedPage: 17,
+		},
+		{
+			name:         "alt with parenthesized jurisdiction (US)",
+			canonical:    "Baldw.",
+			abbreviation: "Baldw (US)",
+			text:         "The federal view in Baldw (US) 125 was different.",
+			expectedRaw:  "Baldw (US) 125",
+			expectedPage: 125,
+		},
 	}
 
 	for _, tt := range tests {

--- a/go/citations/detector_test.go
+++ b/go/citations/detector_test.go
@@ -280,3 +280,89 @@ func TestSingleVolDetector_RawPreservesOCR(t *testing.T) {
 	assert.Equal(t, "Bail. Eq.", cites[0].ReporterAbbr, "ReporterAbbr should be the canonical")
 	assert.Equal(t, "Bail Eq 42", cites[0].Raw, "Raw should preserve the OCR'd alt spelling")
 }
+
+// TestDetector_SpacingVariants documents the generic detector's behavior on
+// multi-token abbreviations like "Ga. App." where the OCR may drop the
+// whitespace between tokens. The detector matches both spellings but saves
+// ReporterAbbr exactly as it appeared in the text — there is no whitespace
+// normalization at detect time. The whitelist must therefore carry one row
+// per spelling (or normalize whitespace before the whitelist lookup at link
+// time).
+func TestDetector_SpacingVariants(t *testing.T) {
+	tests := []struct {
+		name             string
+		text             string
+		expectedReporter string
+		expectedVolume   int
+		expectedPage     int
+	}{
+		{
+			name:             "canonical spacing",
+			text:             "See 5 Ga. App. 100 for the rule.",
+			expectedReporter: "Ga. App.",
+			expectedVolume:   5,
+			expectedPage:     100,
+		},
+		{
+			name:             "no space between tokens",
+			text:             "See 5 Ga.App. 100 for the rule.",
+			expectedReporter: "Ga.App.",
+			expectedVolume:   5,
+			expectedPage:     100,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := sources.NewDoc("test-spacing", tt.text)
+			cites := GenericDetector.Detect(doc)
+			require.Len(t, cites, 1)
+			assert.Equal(t, tt.expectedReporter, cites[0].ReporterAbbr)
+			require.NotNil(t, cites[0].Volume)
+			assert.Equal(t, tt.expectedVolume, *cites[0].Volume)
+			assert.Equal(t, tt.expectedPage, cites[0].Page)
+		})
+	}
+}
+
+// TestSingleVolDetector_SpacingVariants documents that the single-volume
+// detector matches OCR text that omits the whitespace between abbreviation
+// tokens. NewSingleVolDetector substitutes [\s.]* for every literal space in
+// the abbreviation, so "Ga. App." compiles to `Ga\.[\s.]*App\.` and matches
+// both "Ga. App." and "Ga.App." Saved ReporterAbbr is normalized to the
+// canonical form regardless of which spelling appeared in the OCR.
+func TestSingleVolDetector_SpacingVariants(t *testing.T) {
+	tests := []struct {
+		name         string
+		text         string
+		expectedRaw  string
+		expectedPage int
+	}{
+		{
+			name:         "canonical spacing",
+			text:         "See Ga. App. 42 for the rule.",
+			expectedRaw:  "Ga. App. 42",
+			expectedPage: 42,
+		},
+		{
+			name:         "no space between tokens",
+			text:         "See Ga.App. 42 for the rule.",
+			expectedRaw:  "Ga.App. 42",
+			expectedPage: 42,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := sources.NewDoc("test-spacing-single", tt.text)
+			d := NewSingleVolDetector("Ga. App.", "Ga. App.")
+			cites := d.Detect(doc)
+			require.Len(t, cites, 1)
+			assert.Equal(t, "Ga. App.", cites[0].ReporterAbbr,
+				"ReporterAbbr should be canonical regardless of OCR spacing")
+			assert.Equal(t, tt.expectedRaw, cites[0].Raw,
+				"Raw should preserve the OCR's spacing")
+			assert.Equal(t, tt.expectedPage, cites[0].Page)
+			assert.Nil(t, cites[0].Volume,
+				"single-vol detector should produce nil Volume")
+		})
+	}
+}

--- a/go/citations/detector_test.go
+++ b/go/citations/detector_test.go
@@ -170,3 +170,89 @@ func TestSingleVolDetector_VolumeIsNil(t *testing.T) {
 	require.Len(t, cites, 1)
 	assert.Nil(t, cites[0].Volume, "single-vol detector should produce nil Volume")
 }
+
+// TestSingleVolDetector_NormalizesReporterAbbr verifies that when the canonical
+// reporter_standard differs from the abbreviation that actually matched in the
+// OCR, the resulting Citation carries the canonical form in ReporterAbbr while
+// Raw preserves the literal OCR'd substring. This is the contract that the
+// detector-creation loop in cite-detector-moml relies on for downstream
+// linking against legalhist.reporters.
+func TestSingleVolDetector_NormalizesReporterAbbr(t *testing.T) {
+	tests := []struct {
+		name         string
+		canonical    string
+		abbreviation string
+		text         string
+		expectedRaw  string
+		expectedPage int
+	}{
+		{
+			name:         "alt missing internal periods",
+			canonical:    "Bail. Eq.",
+			abbreviation: "Bail Eq",
+			text:         "Compare Bail Eq 17 with the earlier ruling.",
+			expectedRaw:  "Bail Eq 17",
+			expectedPage: 17,
+		},
+		{
+			name:         "alt matches canonical exactly",
+			canonical:    "Bail. Eq.",
+			abbreviation: "Bail. Eq.",
+			text:         "See Bail. Eq. 42 for the rule.",
+			expectedRaw:  "Bail. Eq. 42",
+			expectedPage: 42,
+		},
+		{
+			name:         "alt missing trailing period",
+			canonical:    "Baldw.",
+			abbreviation: "Baldw",
+			text:         "The federal view in Baldw 125 was different.",
+			expectedRaw:  "Baldw 125",
+			expectedPage: 125,
+		},
+		{
+			name:         "alt is longer form than canonical",
+			canonical:    "Hob.",
+			abbreviation: "Hobart",
+			text:         "The rule in Hobart 423 was the older precedent.",
+			expectedRaw:  "Hobart 423",
+			expectedPage: 423,
+		},
+		{
+			name:         `alt is much longer form (exercises \w*)`,
+			canonical:    "Toth",
+			abbreviation: "Tothill",
+			text:         "See Tothill 876 for the early statement.",
+			expectedRaw:  "Tothill 876",
+			expectedPage: 876,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := sources.NewDoc("test-normalize", tt.text)
+			d := NewSingleVolDetector(tt.canonical, tt.abbreviation)
+			cites := d.Detect(doc)
+			require.Len(t, cites, 1)
+			assert.Equal(t, tt.canonical, cites[0].ReporterAbbr,
+				"ReporterAbbr should be the canonical form, not the matched alt")
+			assert.Equal(t, tt.expectedRaw, cites[0].Raw,
+				"Raw should preserve the OCR'd alt spelling")
+			assert.Equal(t, tt.expectedPage, cites[0].Page)
+			assert.Nil(t, cites[0].Volume, "single-vol detector should produce nil Volume")
+		})
+	}
+}
+
+// TestSingleVolDetector_RawPreservesOCR is a focused unit test mirroring
+// TestSingleVolDetector_VolumeIsNil: it documents the Raw-preservation
+// invariant in isolation.
+func TestSingleVolDetector_RawPreservesOCR(t *testing.T) {
+	text := `See Bail Eq 42 for the ruling.`
+	doc := sources.NewDoc("test", text)
+	d := NewSingleVolDetector("Bail. Eq.", "Bail Eq")
+	cites := d.Detect(doc)
+	require.Len(t, cites, 1)
+	assert.Equal(t, "Bail. Eq.", cites[0].ReporterAbbr, "ReporterAbbr should be the canonical")
+	assert.Equal(t, "Bail Eq 42", cites[0].Raw, "Raw should preserve the OCR'd alt spelling")
+}

--- a/go/citations/store.go
+++ b/go/citations/store.go
@@ -2,8 +2,15 @@ package citations
 
 import "context"
 
+// SingleVolReporter pairs a canonical reporter_standard with one of its
+// recognized abbreviations (which may itself be the reporter_standard).
+type SingleVolReporter struct {
+	Standard string
+	Abbr     string
+}
+
 // Store is an interface describing a data store for objects relating to citations.
 type Store interface {
 	SaveCitation(ctx context.Context, c *Citation) error
-	GetSingleVolReporters(ctx context.Context) ([]string, error)
+	GetSingleVolReporterAbbrs(ctx context.Context) ([]SingleVolReporter, error)
 }

--- a/go/citations/store_db.go
+++ b/go/citations/store_db.go
@@ -32,11 +32,26 @@ func (r *DBStore) SaveCitation(ctx context.Context, c *Citation) error {
 	return err
 }
 
-// GetSingleVolReporters gets the abbreviations for all the single volume
-// reporters in the database.
-func (r *DBStore) GetSingleVolReporters(ctx context.Context) ([]string, error) {
-	query := `SELECT alt_abbr FROM legalhist.reporters_single_volume_abbr;`
-	var abbreviations []string
+// GetSingleVolReporterAbbrs returns one row per (reporter_standard, abbreviation)
+// pair for every single-volume reporter, covering both the canonical
+// reporter_standard form and every alt_abbr in legalhist.reporters_abbreviations.
+// Pairing each abbreviation with its canonical reporter_standard lets the
+// detector normalize the saved reporter_abbr to the canonical form regardless
+// of which spelling appeared in the OCR.
+func (r *DBStore) GetSingleVolReporterAbbrs(ctx context.Context) ([]SingleVolReporter, error) {
+	query := `
+	SELECT r.reporter_standard, r.reporter_standard AS abbr
+	  FROM legalhist.reporters r
+	 WHERE r.single_vol = true
+	UNION
+	SELECT r.reporter_standard, ra.alt_abbr
+	  FROM legalhist.reporters r
+	  JOIN legalhist.reporters_abbreviations ra
+	    ON ra.reporter_standard = r.reporter_standard
+	 WHERE r.single_vol = true
+	   AND ra.alt_abbr IS NOT NULL;
+	`
+	var reporters []SingleVolReporter
 
 	rows, err := r.DB.Query(ctx, query)
 	if err != nil {
@@ -44,14 +59,13 @@ func (r *DBStore) GetSingleVolReporters(ctx context.Context) ([]string, error) {
 	}
 	defer rows.Close()
 
-	var abbr string
 	for rows.Next() {
-		err = rows.Scan(&abbr)
-		if err != nil {
+		var sv SingleVolReporter
+		if err := rows.Scan(&sv.Standard, &sv.Abbr); err != nil {
 			return nil, err
 		}
-		abbreviations = append(abbreviations, abbr)
+		reporters = append(reporters, sv)
 	}
 
-	return abbreviations, nil
+	return reporters, nil
 }


### PR DESCRIPTION
## Summary

- Rewrite `citations.DBStore.GetSingleVolReporters` to query the new `legalhist.reporters` + `legalhist.reporters_abbreviations` tables instead of the deleted `legalhist.reporters_single_volume_abbr` view, and rename it to `GetSingleVolReporterAbbrs` returning `(reporter_standard, abbreviation)` pairs.
- Normalize the saved `reporter_abbr` for single-volume citations to the canonical `reporter_standard` (the OCR'd spelling is preserved in `raw`), so downstream linking aligns with `legalhist.reporters.reporter_standard`.
- Escape regex metacharacters in single-vol abbreviations so entries like `Bail Eq (SC)` compile and match literally.
- Add detector tests for canonical-form normalization (covering alts with parens, missing periods, longer forms) and for OCR whitespace-variant handling (`Ga. App.` vs `Ga.App.`).

This PR unblocks the re-run that #174 tracks but does **not** perform the re-run itself.

Closes #189.

Refs #174 — the actual MOML-corpus re-run is still pending; keep that issue open until the re-run lands.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — full citations suite green, including new spacing-variant tests
- [x] Read-only check against production via `LAW_CLAUDE`: the new query returns 460 `(reporter_standard, abbreviation)` pairs
- [ ] Spot-check the re-run output on a small slice (e.g. a handful of `psmid` values) before launching across the full corpus — especially for the 24 newly active alt detectors (`Bur`, `Busb`, `Chev`, `Phil`, `Tay`, ...)
- [ ] Decide truncate-vs-additive for `moml_citations.citations_unlinked` (currently 59,398,897 rows from 2026-03-04) before launching the re-run; new code adds detectors not present in the old set, so additive will produce net-new rows
- [ ] Review related findings posted on #170 (old single-vol detector alts that won't be re-caught by the new schema) and on the new #190 (cite-linker stale-schema queries) before invoking cite-linker against the re-run output

🤖 Generated with [Claude Code](https://claude.com/claude-code)