### PR TITLE
Refine reporter abbreviation views and close #161

### DIFF
--- a/db/migrations/20260522170100_update_cap_reporter_abbreviations.sql
+++ b/db/migrations/20260522170100_update_cap_reporter_abbreviations.sql
@@ -1,0 +1,49 @@
+-- migrate:up
+SET ROLE = law_admin;
+DROP MATERIALIZED VIEW IF EXISTS cap.reporter_abbreviations;
+
+CREATE MATERIALIZED VIEW cap.reporter_abbreviations AS
+WITH extracted AS (
+  SELECT COALESCE(
+    substring(c.cite from '^[0-9]+\s+(.+?)\s+[0-9]+[A-Za-z-]*$'),
+    substring(c.cite from '^(.+?)\s+[0-9]+[A-Za-z-]*$'),
+    substring(c.cite from '^[0-9]{4}-(.+?)-[0-9]+$')
+  ) AS abbreviation
+  FROM cap.citations c
+  JOIN cap.cases cs ON cs.id = c."case"
+  WHERE c.cite NOT LIKE '%;%'
+    AND cs.decision_year <= 1925
+)
+SELECT abbreviation, COUNT(*)::bigint AS n
+FROM extracted
+WHERE abbreviation ~ '^[A-Za-z]'
+GROUP BY abbreviation
+HAVING COUNT(*) > 1
+ORDER BY abbreviation;
+
+CREATE UNIQUE INDEX reporter_abbreviations_abbreviation_idx
+  ON cap.reporter_abbreviations (abbreviation);
+
+-- migrate:down
+SET ROLE = law_admin;
+DROP MATERIALIZED VIEW IF EXISTS cap.reporter_abbreviations;
+
+CREATE MATERIALIZED VIEW cap.reporter_abbreviations AS
+WITH extracted AS (
+  SELECT COALESCE(
+    substring(cite from '^[0-9]+\s+(.+?)\s+[0-9]+[A-Za-z-]*$'),
+    substring(cite from '^(.+?)\s+[0-9]+[A-Za-z-]*$'),
+    substring(cite from '^[0-9]{4}-(.+?)-[0-9]+$')
+  ) AS abbreviation
+  FROM cap.citations
+  WHERE type != 'parallel'
+)
+SELECT abbreviation, COUNT(*)::bigint AS n
+FROM extracted
+WHERE abbreviation ~ '^[A-Za-z]'
+GROUP BY abbreviation
+HAVING COUNT(*) > 1
+ORDER BY abbreviation;
+
+CREATE UNIQUE INDEX reporter_abbreviations_abbreviation_idx
+  ON cap.reporter_abbreviations (abbreviation);

--- a/db/migrations/20260522170200_all_abbreviations_add_uk.sql
+++ b/db/migrations/20260522170200_all_abbreviations_add_uk.sql
@@ -1,0 +1,26 @@
+-- migrate:up
+SET ROLE = law_admin;
+CREATE OR REPLACE VIEW legalhist.all_abbreviations AS
+SELECT abbreviation, jurisdiction, jurisdiction LIKE 'uk%' AS uk
+FROM (
+  SELECT r.reporter_standard AS abbreviation, r.jurisdiction
+  FROM legalhist.reporters r
+  UNION
+  SELECT ra.alt_abbr AS abbreviation, r.jurisdiction
+  FROM legalhist.reporters_abbreviations ra
+  JOIN legalhist.reporters r ON r.reporter_standard = ra.reporter_standard
+  WHERE ra.alt_abbr IS NOT NULL
+) u
+ORDER BY abbreviation;
+
+-- migrate:down
+SET ROLE = law_admin;
+CREATE OR REPLACE VIEW legalhist.all_abbreviations AS
+SELECT abbreviation FROM (
+  SELECT DISTINCT reporter_standard AS abbreviation FROM legalhist.reporters
+  UNION
+  SELECT DISTINCT alt_abbr AS abbreviation
+    FROM legalhist.reporters_abbreviations
+    WHERE alt_abbr IS NOT NULL
+) u
+ORDER BY abbreviation;

--- a/db/migrations/20260522170300_abbreviation_diff_views.sql
+++ b/db/migrations/20260522170300_abbreviation_diff_views.sql
@@ -1,0 +1,23 @@
+-- migrate:up
+SET ROLE = law_admin;
+
+CREATE OR REPLACE VIEW legalhist.abbrs_legalhist_not_in_cap AS
+SELECT abbreviation
+FROM legalhist.all_abbreviations
+WHERE NOT uk
+EXCEPT
+SELECT abbreviation FROM cap.reporter_abbreviations
+ORDER BY abbreviation;
+
+CREATE OR REPLACE VIEW legalhist.abbrs_cap_not_in_legalhist AS
+SELECT abbreviation, n
+FROM cap.reporter_abbreviations
+WHERE abbreviation NOT IN (
+  SELECT abbreviation FROM legalhist.all_abbreviations WHERE NOT uk
+)
+ORDER BY abbreviation;
+
+-- migrate:down
+SET ROLE = law_admin;
+DROP VIEW IF EXISTS legalhist.abbrs_cap_not_in_legalhist;
+DROP VIEW IF EXISTS legalhist.abbrs_legalhist_not_in_cap;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -838,6 +838,34 @@ CREATE VIEW legalhist.all_abbreviations AS
 
 
 --
+-- Name: abbrs_cap_not_in_legalhist; Type: VIEW; Schema: legalhist; Owner: -
+--
+
+CREATE VIEW legalhist.abbrs_cap_not_in_legalhist AS
+ SELECT abbreviation,
+    n
+   FROM cap.reporter_abbreviations
+  WHERE (NOT (abbreviation IN ( SELECT all_abbreviations.abbreviation
+           FROM legalhist.all_abbreviations
+          WHERE (NOT all_abbreviations.uk))))
+  ORDER BY abbreviation;
+
+
+--
+-- Name: abbrs_legalhist_not_in_cap; Type: VIEW; Schema: legalhist; Owner: -
+--
+
+CREATE VIEW legalhist.abbrs_legalhist_not_in_cap AS
+ SELECT all_abbreviations.abbreviation
+   FROM legalhist.all_abbreviations
+  WHERE (NOT all_abbreviations.uk)
+EXCEPT
+ SELECT reporter_abbreviations.abbreviation
+   FROM cap.reporter_abbreviations
+  ORDER BY 1;
+
+
+--
 -- Name: page_ocrtext; Type: TABLE; Schema: moml; Owner: -
 --
 
@@ -2323,4 +2351,5 @@ INSERT INTO sys_admin.migrations_dbmate (version) VALUES
     ('20260522152000'),
     ('20260522170000'),
     ('20260522170100'),
-    ('20260522170200');
+    ('20260522170200'),
+    ('20260522170300');

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -626,9 +626,10 @@ CREATE TABLE cap.opinions (
 
 CREATE MATERIALIZED VIEW cap.reporter_abbreviations AS
  WITH extracted AS (
-         SELECT COALESCE("substring"(citations.cite, '^[0-9]+\s+(.+?)\s+[0-9]+[A-Za-z-]*$'::text), "substring"(citations.cite, '^(.+?)\s+[0-9]+[A-Za-z-]*$'::text), "substring"(citations.cite, '^[0-9]{4}-(.+?)-[0-9]+$'::text)) AS abbreviation
-           FROM cap.citations
-          WHERE (citations.type <> 'parallel'::text)
+         SELECT COALESCE("substring"(c.cite, '^[0-9]+\s+(.+?)\s+[0-9]+[A-Za-z-]*$'::text), "substring"(c.cite, '^(.+?)\s+[0-9]+[A-Za-z-]*$'::text), "substring"(c.cite, '^[0-9]{4}-(.+?)-[0-9]+$'::text)) AS abbreviation
+           FROM (cap.citations c
+             JOIN cap.cases cs ON ((cs.id = c."case")))
+          WHERE ((c.cite !~~ '%;%'::text) AND (cs.decision_year <= 1925))
         )
  SELECT abbreviation,
     count(*) AS n
@@ -2315,4 +2316,5 @@ INSERT INTO sys_admin.migrations_dbmate (version) VALUES
     ('20260521131903'),
     ('20260522151323'),
     ('20260522152000'),
-    ('20260522170000');
+    ('20260522170000'),
+    ('20260522170100');

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -822,13 +822,18 @@ CREATE TABLE legalhist.reporters_abbreviations (
 --
 
 CREATE VIEW legalhist.all_abbreviations AS
- SELECT abbreviation
-   FROM ( SELECT DISTINCT reporters.reporter_standard AS abbreviation
-           FROM legalhist.reporters
+ SELECT abbreviation,
+    jurisdiction,
+    (jurisdiction ~~ 'uk%'::text) AS uk
+   FROM ( SELECT r.reporter_standard AS abbreviation,
+            r.jurisdiction
+           FROM legalhist.reporters r
         UNION
-         SELECT DISTINCT reporters_abbreviations.alt_abbr AS abbreviation
-           FROM legalhist.reporters_abbreviations
-          WHERE (reporters_abbreviations.alt_abbr IS NOT NULL)) u
+         SELECT ra.alt_abbr AS abbreviation,
+            r.jurisdiction
+           FROM (legalhist.reporters_abbreviations ra
+             JOIN legalhist.reporters r ON ((r.reporter_standard = ra.reporter_standard)))
+          WHERE (ra.alt_abbr IS NOT NULL)) u
   ORDER BY abbreviation;
 
 
@@ -2317,4 +2322,5 @@ INSERT INTO sys_admin.migrations_dbmate (version) VALUES
     ('20260522151323'),
     ('20260522152000'),
     ('20260522170000'),
-    ('20260522170100');
+    ('20260522170100'),
+    ('20260522170200');


### PR DESCRIPTION
Closes #161

## Summary

Builds on the four-view scaffolding for diffing CAP-extracted reporter abbreviations against the curated `legalhist` list:

- Tightens `cap.reporter_abbreviations` to pre-1925, single-cite rows (semicolon-exclusion replaces the parallel-type filter; join to `cap.cases` for `decision_year <= 1925`).
- Adds `jurisdiction` and `uk` columns to `legalhist.all_abbreviations`, so the diff views can filter UK-only abbreviations out (CAP is US-only).
- Adds two new views `legalhist.abbrs_legalhist_not_in_cap` and `legalhist.abbrs_cap_not_in_legalhist` for the actual diff.

The analysis posted to #161 walks through the mismatches the views surface — three buckets: genuine reporter gaps (highest-value whitelist candidates), formatting variants (`Amer.` vs `Am.`, paren vs no-paren `(N. S.)`, etc.), and state-suffixed legalhist forms that CAP doesn't carry. It also surfaces a data-quality finding now tracked in #170: 52 `legalhist.reporters` rows have blank `jurisdiction`, which causes ~24 high-frequency false positives in the diff views.

## Test plan

- [ ] `dbmate up` applies all four new migrations cleanly
- [ ] `SELECT COUNT(*) FROM cap.reporter_abbreviations;` reflects the tighter filters
- [ ] `SELECT * FROM legalhist.all_abbreviations LIMIT 5;` shows three columns (`abbreviation`, `jurisdiction`, `uk`)
- [ ] `SELECT * FROM legalhist.abbrs_cap_not_in_legalhist ORDER BY n DESC LIMIT 20;` returns the top-frequency unknown reporters
- [ ] `SELECT * FROM legalhist.abbrs_legalhist_not_in_cap LIMIT 20;` returns the unmatched curated abbreviations
- [ ] `dbmate rollback` cleanly reverses each migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)