### PR TITLE
Fix cite-linker for renamed whitelist table (#190)

### DIFF
--- a/chambers/README.md
+++ b/chambers/README.md
@@ -83,7 +83,7 @@ The `moml.page` and `moml.page_ocrtext` joins must include `psmid` (treatise ID)
 Maps linking status to CSS classes for color-coded display:
 - `status-linked` (green) — status starts with `linked`
 - `status-nomatch` (red) — `no_match`
-- `status-skip` (blue) — `skipped_junk` or `skipped_statute`
+- `status-skip` (blue) — `skipped_junk`
 - `status-unprocessed` (yellow) — nil status or unknown
 
 ## Adding a new page

--- a/chambers/queries.go
+++ b/chambers/queries.go
@@ -213,7 +213,7 @@ func (r *ReporterCite) StatusClass() string {
 	if s == "no_match" {
 		return "status-nomatch"
 	}
-	if s == "skipped_junk" || s == "skipped_statute" {
+	if s == "skipped_junk" {
 		return "status-skip"
 	}
 	return "status-unprocessed"
@@ -472,7 +472,6 @@ type DashboardData struct {
 	SkippedNotWhiteListed int
 	NoMatch               int
 	SkippedJunk           int
-	SkippedStatute        int
 	TotalRawCites         int
 	Reporters             []ReporterStats `json:"Reporters,omitempty"`
 }
@@ -513,8 +512,6 @@ func getDashboardData(ctx context.Context, db *pgxpool.Pool) (*DashboardData, er
 			d.NoMatch = n
 		case "skipped_junk":
 			d.SkippedJunk = n
-		case "skipped_statute":
-			d.SkippedStatute = n
 		}
 	}
 	if err := rows.Err(); err != nil {
@@ -570,7 +567,6 @@ func getDashboardData(ctx context.Context, db *pgxpool.Pool) (*DashboardData, er
 		"skipped_not_whitelisted", d.SkippedNotWhiteListed,
 		"no_match", d.NoMatch,
 		"skipped_junk", d.SkippedJunk,
-		"skipped_statutes", d.SkippedStatute,
 		"total_raw_cites", d.TotalRawCites,
 		"reporters", len(d.Reporters),
 	)

--- a/chambers/templates/dashboard.html
+++ b/chambers/templates/dashboard.html
@@ -46,12 +46,6 @@
                 <div class="big-label">Skipped as junk</div>
             </div>
         </div>
-        <div class="col-md-3">
-            <div class="stat-card stat-neutral">
-                <div class="big-number placeholder-number" id="stat-statutes">&mdash;</div>
-                <div class="big-label">Skipped as statutes</div>
-            </div>
-        </div>
     </div>
 
     <h2 class="h6 text-secondary mb-2">Potential cites linked</h2>
@@ -147,7 +141,7 @@ SELECT count(*) FROM moml_citations.citations_unlinked;</code></pre>
 
             const totalLinked = d.LinkedCAP + d.LinkedEnglishReports + d.LinkedCodeReporter;
 
-            const totalPotential = d.TotalRawCites - d.SkippedJunk - d.SkippedStatute;
+            const totalPotential = d.TotalRawCites - d.SkippedJunk;
 
             function pctOfRaw(n) {
                 if (d.TotalRawCites === 0) return "0%";
@@ -173,7 +167,6 @@ SELECT count(*) FROM moml_citations.citations_unlinked;</code></pre>
             setStat("stat-raw", d.TotalRawCites);
             setStatWithPct("stat-potential-raw", totalPotential, pctOfRaw);
             setStatWithPct("stat-junk", d.SkippedJunk, pctOfRaw);
-            setStatWithPct("stat-statutes", d.SkippedStatute, pctOfRaw);
 
             // Row 2: potential cites breakdown with percentages
             setStat("stat-potential", totalPotential);

--- a/chambers/templates/reporter-cites.html
+++ b/chambers/templates/reporter-cites.html
@@ -30,7 +30,7 @@
         <span style="color:#721c24;font-weight:600">red</span> means no matching case was found
         (<code>no_match</code>);
         <span style="color:#004085;font-weight:600">blue</span> means the citation was classified as
-        junk or a statute (<code>skipped_junk</code> or <code>skipped_statute</code>);
+        junk (<code>skipped_junk</code>);
         <span style="color:#856404;font-weight:600">yellow</span> means the citation has not yet been
         processed by the linker. Click any citation to see its full detail page.
     </p>

--- a/cite-linker/main.go
+++ b/cite-linker/main.go
@@ -232,10 +232,6 @@ func linkCitation(
 		result.Status = citations.StatusSkippedNotWhitelisted
 		return result
 	}
-	if entry.Statute {
-		result.Status = citations.StatusSkippedStatute
-		return result
-	}
 	if entry.Junk {
 		result.Status = citations.StatusSkippedJunk
 		return result

--- a/go/citations/linker.go
+++ b/go/citations/linker.go
@@ -7,7 +7,6 @@ import "github.com/google/uuid"
 type WhitelistEntry struct {
 	ReporterStandard *string
 	ReporterCAP      *string
-	Statute          bool
 	UK               bool
 	Junk             bool
 	CAPDifferent     bool
@@ -45,11 +44,10 @@ type LinkResult struct {
 
 // Status constants for link results.
 const (
-	StatusLinkedCAP            = "linked_cap"
-	StatusLinkedCodeReporter   = "linked_code_reporter"
-	StatusLinkedEnglishReports = "linked_english_reports"
+	StatusLinkedCAP             = "linked_cap"
+	StatusLinkedCodeReporter    = "linked_code_reporter"
+	StatusLinkedEnglishReports  = "linked_english_reports"
 	StatusSkippedNotWhitelisted = "skipped_not_whitelisted"
-	StatusSkippedStatute       = "skipped_statute"
-	StatusSkippedJunk          = "skipped_junk"
-	StatusNoMatch              = "no_match"
+	StatusSkippedJunk           = "skipped_junk"
+	StatusNoMatch               = "no_match"
 )

--- a/go/citations/linker_store_db.go
+++ b/go/citations/linker_store_db.go
@@ -20,8 +20,18 @@ func NewLinkerDBStore(db *pgxpool.Pool) *LinkerDBStore {
 
 func (s *LinkerDBStore) GetReporterWhitelist(ctx context.Context) (map[string]*WhitelistEntry, error) {
 	query := `
-	SELECT reporter_found, reporter_standard, reporter_cap, statute, uk, junk, cap_different
-	FROM legalhist.reporters_citation_to_cap
+	SELECT
+		w.reporter_found,
+		w.reporter_standard,
+		r.reporter_cap,
+		w.junk,
+		COALESCE(r.jurisdiction LIKE 'uk%', false) AS uk,
+		EXISTS (
+			SELECT 1 FROM legalhist.reporters_diffvols d
+			WHERE d.reporter_standard = w.reporter_standard
+		) AS cap_different
+	FROM legalhist.whitelist w
+	LEFT JOIN legalhist.reporters r ON r.reporter_standard = w.reporter_standard
 	`
 	rows, err := s.DB.Query(ctx, query)
 	if err != nil {
@@ -33,13 +43,9 @@ func (s *LinkerDBStore) GetReporterWhitelist(ctx context.Context) (map[string]*W
 	for rows.Next() {
 		var found string
 		var e WhitelistEntry
-		var capDiff *bool
-		err := rows.Scan(&found, &e.ReporterStandard, &e.ReporterCAP, &e.Statute, &e.UK, &e.Junk, &capDiff)
+		err := rows.Scan(&found, &e.ReporterStandard, &e.ReporterCAP, &e.Junk, &e.UK, &e.CAPDifferent)
 		if err != nil {
 			return nil, fmt.Errorf("scanning reporter whitelist row: %w", err)
-		}
-		if capDiff != nil {
-			e.CAPDifferent = *capDiff
 		}
 		whitelist[found] = &e
 	}
@@ -246,16 +252,15 @@ func (s *LinkerDBStore) BatchSkipNonWhitelisted(ctx context.Context) (int64, err
 	INSERT INTO moml_citations.citation_links (citation_id, status)
 	SELECT cu.id,
 	       CASE
-	         WHEN wl.statute = true THEN 'skipped_statute'
 	         WHEN wl.junk = true THEN 'skipped_junk'
 	         ELSE 'skipped_not_whitelisted'
 	       END
 	FROM moml_citations.citations_unlinked cu
-	LEFT JOIN legalhist.reporters_citation_to_cap wl ON cu.reporter_abbr = wl.reporter_found
+	LEFT JOIN legalhist.whitelist wl ON cu.reporter_abbr = wl.reporter_found
 	WHERE NOT EXISTS (
 		SELECT 1 FROM moml_citations.citation_links cl WHERE cl.citation_id = cu.id
 	)
-	AND (wl.reporter_found IS NULL OR wl.statute = true OR wl.junk = true)
+	AND (wl.reporter_found IS NULL OR wl.junk = true)
 	ON CONFLICT (citation_id) DO NOTHING
 	`
 	tag, err := s.DB.Exec(ctx, query)


### PR DESCRIPTION
## Summary

- Rewrites `GetReporterWhitelist` as a JOIN against `legalhist.reporters` and `legalhist.reporters_diffvols` to recover the four columns dropped from the renamed `legalhist.whitelist` table (migration `20260325003434`). `reporter_cap` comes from `reporters`; `uk` is derived from `jurisdiction LIKE 'uk%'` (same convention as `legalhist.all_abbreviations`); `cap_different` is derived from an `EXISTS` against `reporters_diffvols`.
- Updates `BatchSkipNonWhitelisted` to use the new table name.
- Retires the `statute` distinction entirely — no replacement exists in the schema. Drops the `Statute` field on `WhitelistEntry`, the `StatusSkippedStatute` constant, the `linkCitation` branch, and the dashboard/help-text references in chambers.

Fixes #190.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] New `GetReporterWhitelist` SQL returns 10,136 rows against live DB (matches `legalhist.whitelist` count exactly), with 2,343 junk / 2,100 UK / 932 cap_different / 700 with `reporter_cap`
- [x] New `BatchSkipNonWhitelisted` SELECT subquery has a valid query plan (uses the expected indexes)
- [ ] Manual: run `cite-linker` against unprocessed citations once #189 has populated them; confirm it loads the whitelist and processes a batch without errors
- [ ] Manual: run `cite-linker --skip-unlisted` against a small test dataset; confirm only `skipped_junk` and `skipped_not_whitelisted` rows are produced (no `skipped_statute`)
- [ ] Manual: load the chambers dashboard and confirm the status breakdown renders without the statute tile and totals reconcile

🤖 Generated with [Claude Code](https://claude.com/claude-code)