### PR TITLE
Increase dashboard query timeout to 5 minutes

### DIFF
--- a/chambers/main.go
+++ b/chambers/main.go
@@ -252,7 +252,7 @@ func handleDashboard(w http.ResponseWriter, r *http.Request, tmpl *template.Temp
 
 func handleDashboardAPI(w http.ResponseWriter, r *http.Request) {
 	slog.Debug("handling request", "path", r.URL.Path, "handler", "dashboard-api")
-	ctx, cancel := context.WithTimeout(r.Context(), 2*time.Minute)
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Minute)
 	defer cancel()
 
 	slog.Debug("fetching dashboard data from database")


### PR DESCRIPTION
The linking dashboard's per-reporter linking stats query can exceed the
previous 2-minute request timeout against the production database, causing
the request context to be canceled mid-query. Bump the dashboard API
handler timeout to 5 minutes to allow the query to complete.

https://claude.ai/code/session_01Evb2S9cS1roRTwdcromiHb