### PR TITLE
Add citations_unmatched_top materialized view and refresh it from cite-linker

### DIFF
--- a/chambers/main.go
+++ b/chambers/main.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -72,6 +73,8 @@ func parseTemplates() map[string]*template.Template {
 		"cite-lookup.html",
 		"reporters.html",
 		"reporter-cites.html",
+		"unmatched.html",
+		"unmatched-cites.html",
 		"dashboard.html",
 		"whitelist-extender.html",
 	}
@@ -124,6 +127,12 @@ func main() {
 	})
 	mux.HandleFunc("/reporters/check", func(w http.ResponseWriter, r *http.Request) {
 		handleReporterCites(w, r, tmpls["reporter-cites.html"])
+	})
+	mux.HandleFunc("/unmatched", func(w http.ResponseWriter, r *http.Request) {
+		handleUnmatched(w, r, tmpls["unmatched.html"])
+	})
+	mux.HandleFunc("/unmatched/cites", func(w http.ResponseWriter, r *http.Request) {
+		handleUnmatchedCites(w, r, tmpls["unmatched-cites.html"])
 	})
 	mux.HandleFunc("/linking-dashboard", func(w http.ResponseWriter, r *http.Request) {
 		handleDashboard(w, r, tmpls["dashboard.html"])
@@ -309,6 +318,101 @@ func handleReporterCites(w http.ResponseWriter, r *http.Request, tmpl *template.
 	}{Reporter: reporter, Variants: variants, Cites: cites}
 	if err := tmpl.ExecuteTemplate(w, "baseof", data); err != nil {
 		slog.Error("error rendering reporter cites", "reporter", reporter, "error", err)
+	}
+}
+
+func handleUnmatched(w http.ResponseWriter, r *http.Request, tmpl *template.Template) {
+	slog.Debug("handling request", "path", r.URL.Path, "handler", "unmatched")
+	filter := NormalizeUnmatchedFilter(r.URL.Query().Get("filter"))
+
+	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+	defer cancel()
+
+	cites, err := getTopUnmatched(ctx, pool, filter)
+	if err != nil {
+		slog.Error("error querying top unmatched citations", "error", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	summary, err := getUnmatchedSummary(ctx, pool, filter)
+	if err != nil {
+		slog.Error("error querying unmatched summary", "error", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	total, err := getUnmatchedSummary(ctx, pool, "all")
+	if err != nil {
+		slog.Error("error querying overall unmatched summary", "error", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	slog.Debug("rendering unmatched page", "filter", filter, "shown", len(cites))
+	data := struct {
+		Filter  string
+		Cites   []UnmatchedCitation
+		Summary UnmatchedSummary
+		Total   UnmatchedSummary
+		Shown   int
+	}{Filter: filter, Cites: cites, Summary: summary, Total: total, Shown: len(cites)}
+	if err := tmpl.ExecuteTemplate(w, "baseof", data); err != nil {
+		slog.Error("error rendering unmatched", "error", err)
+	}
+}
+
+func handleUnmatchedCites(w http.ResponseWriter, r *http.Request, tmpl *template.Template) {
+	slog.Debug("handling request", "path", r.URL.Path, "handler", "unmatched-cites")
+	q := r.URL.Query()
+
+	pageStr := q.Get("page")
+	if pageStr == "" {
+		slog.Debug("no page specified, redirecting to /unmatched")
+		http.Redirect(w, r, "/unmatched", http.StatusFound)
+		return
+	}
+	page, err := strconv.Atoi(pageStr)
+	if err != nil {
+		slog.Debug("invalid page", "page", pageStr)
+		http.Error(w, fmt.Sprintf("Invalid page: %s", pageStr), http.StatusBadRequest)
+		return
+	}
+
+	// volume and reporter are omitted from the URL when NULL; treat absence
+	// (and an unparseable/empty value) as NULL.
+	var volume *int
+	if q.Has("volume") {
+		if v, err := strconv.Atoi(q.Get("volume")); err == nil {
+			volume = &v
+		}
+	}
+	var reporter *string
+	if s := q.Get("reporter"); s != "" {
+		reporter = &s
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+	defer cancel()
+
+	cites, total, err := getUnmatchedCites(ctx, pool, volume, reporter, page)
+	if err != nil {
+		slog.Error("error querying unmatched cites", "page", page, "error", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	agg := &UnmatchedCitation{Volume: volume, ReporterStandard: reporter, Page: page, N: total}
+	slog.Debug("rendering unmatched cites", "cite", agg.Cite(), "shown", len(cites), "total", total)
+	data := struct {
+		Agg       *UnmatchedCitation
+		Cites     []UnmatchedCite
+		Shown     int
+		Total     int
+		Truncated bool
+	}{Agg: agg, Cites: cites, Shown: len(cites), Total: total, Truncated: total > len(cites)}
+	if err := tmpl.ExecuteTemplate(w, "baseof", data); err != nil {
+		slog.Error("error rendering unmatched cites", "error", err)
 	}
 }
 

--- a/chambers/queries.go
+++ b/chambers/queries.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/agnivade/levenshtein"
@@ -30,13 +32,13 @@ type CitationDetail struct {
 	CiteLinked     *string
 
 	// CAP case info
-	CAPCaseName   *string
-	CAPCaseAbbr   *string
-	CAPYear       *int
-	CAPVolume     *string
-	CAPURL        *string
-	CAPReporter   *string
-	CAPCourt      *string
+	CAPCaseName     *string
+	CAPCaseAbbr     *string
+	CAPYear         *int
+	CAPVolume       *string
+	CAPURL          *string
+	CAPReporter     *string
+	CAPCourt        *string
 	CAPJurisdiction *string
 
 	// Code reporter case info
@@ -201,12 +203,12 @@ type ReporterCite struct {
 	Status *string
 }
 
-// StatusClass returns a CSS class based on the linking status.
-func (r *ReporterCite) StatusClass() string {
-	if r.Status == nil {
+// statusClass maps a linking status to a CSS class.
+func statusClass(status *string) string {
+	if status == nil {
 		return "status-unprocessed"
 	}
-	s := *r.Status
+	s := *status
 	if strings.HasPrefix(s, "linked") {
 		return "status-linked"
 	}
@@ -217,6 +219,11 @@ func (r *ReporterCite) StatusClass() string {
 		return "status-skip"
 	}
 	return "status-unprocessed"
+}
+
+// StatusClass returns a CSS class based on the linking status.
+func (r *ReporterCite) StatusClass() string {
+	return statusClass(r.Status)
 }
 
 func getReporterVariants(ctx context.Context, db *pgxpool.Pool, reporterStandard string) ([]string, error) {
@@ -572,6 +579,190 @@ func getDashboardData(ctx context.Context, db *pgxpool.Pool) (*DashboardData, er
 	)
 
 	return d, nil
+}
+
+// UnmatchedCitation is one aggregated row from
+// moml_citations.citations_unmatched_top: a distinct (volume, reporter_standard,
+// page) citation that still needs to be linked, with the count n of raw
+// citations it aggregates.
+type UnmatchedCitation struct {
+	Volume           *int
+	ReporterStandard *string
+	Page             int
+	N                int
+}
+
+// VolumeDisplay returns the volume for display, or an em dash for single-volume
+// reporters (NULL volume).
+func (u *UnmatchedCitation) VolumeDisplay() string {
+	if u.Volume == nil {
+		return "—"
+	}
+	return strconv.Itoa(*u.Volume)
+}
+
+// ReporterDisplay returns the standard reporter, or a placeholder when it is
+// NULL (a non-junk whitelist entry with no standard assigned).
+func (u *UnmatchedCitation) ReporterDisplay() string {
+	if u.ReporterStandard == nil {
+		return "(no standard)"
+	}
+	return *u.ReporterStandard
+}
+
+// Cite renders the aggregated citation as it would appear, e.g. "4 Wil. 877".
+func (u *UnmatchedCitation) Cite() string {
+	if u.Volume == nil {
+		return fmt.Sprintf("%s %d", u.ReporterDisplay(), u.Page)
+	}
+	return fmt.Sprintf("%d %s %d", *u.Volume, u.ReporterDisplay(), u.Page)
+}
+
+// DetailURL builds the URL to the reverse-aggregation page for this citation.
+// Volume and reporter are omitted when NULL so the handler treats them as NULL.
+func (u *UnmatchedCitation) DetailURL() string {
+	v := url.Values{}
+	v.Set("page", strconv.Itoa(u.Page))
+	if u.Volume != nil {
+		v.Set("volume", strconv.Itoa(*u.Volume))
+	}
+	if u.ReporterStandard != nil {
+		v.Set("reporter", *u.ReporterStandard)
+	}
+	return "/unmatched/cites?" + v.Encode()
+}
+
+// unmatchedFilters maps a filter key to its SQL predicate on the view. Values
+// are fixed literals (never user input) so they are safe to interpolate.
+var unmatchedFilters = map[string]string{
+	"multi":  "volume IS NOT NULL",
+	"single": "volume IS NULL",
+	"all":    "true",
+}
+
+// NormalizeUnmatchedFilter returns filter if it is a known key, else "multi".
+func NormalizeUnmatchedFilter(filter string) string {
+	if _, ok := unmatchedFilters[filter]; ok {
+		return filter
+	}
+	return "multi"
+}
+
+func getTopUnmatched(ctx context.Context, db *pgxpool.Pool, filter string) ([]UnmatchedCitation, error) {
+	pred := unmatchedFilters[NormalizeUnmatchedFilter(filter)]
+	slog.Debug("querying top unmatched citations", "filter", filter)
+	query := `
+	SELECT volume, reporter_standard, page, n
+	FROM moml_citations.citations_unmatched_top
+	WHERE ` + pred + `
+	ORDER BY n DESC, reporter_standard, volume, page
+	LIMIT 1000
+	`
+	rows, err := db.Query(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("querying top unmatched citations: %w", err)
+	}
+	defer rows.Close()
+
+	var results []UnmatchedCitation
+	for rows.Next() {
+		var u UnmatchedCitation
+		if err := rows.Scan(&u.Volume, &u.ReporterStandard, &u.Page, &u.N); err != nil {
+			return nil, fmt.Errorf("scanning unmatched citation: %w", err)
+		}
+		results = append(results, u)
+	}
+	slog.Debug("fetched top unmatched citations", "filter", filter, "count", len(results))
+	return results, rows.Err()
+}
+
+// UnmatchedSummary holds aggregate counts over the unmatched-citations view.
+type UnmatchedSummary struct {
+	Groups int   // number of grouped (distinct) citations
+	Cites  int64 // total raw unmatched citations across those groups (sum of n)
+}
+
+func getUnmatchedSummary(ctx context.Context, db *pgxpool.Pool, filter string) (UnmatchedSummary, error) {
+	pred := unmatchedFilters[NormalizeUnmatchedFilter(filter)]
+	slog.Debug("querying unmatched summary", "filter", filter)
+	var s UnmatchedSummary
+	err := db.QueryRow(ctx, `
+		SELECT count(*), COALESCE(sum(n), 0)
+		FROM moml_citations.citations_unmatched_top
+		WHERE `+pred).Scan(&s.Groups, &s.Cites)
+	if err != nil {
+		return s, fmt.Errorf("querying unmatched summary: %w", err)
+	}
+	slog.Debug("fetched unmatched summary", "filter", filter, "groups", s.Groups, "cites", s.Cites)
+	return s, nil
+}
+
+// UnmatchedCite is a single raw citation occurrence on the reverse-aggregation
+// page, with the MOML treatise and page where it was found.
+type UnmatchedCite struct {
+	ID       uuid.UUID
+	Raw      string
+	Status   *string
+	Treatise string // MOML treatise short (display) title
+	Page     string // printed source page, or the MOML page id as a fallback
+}
+
+// StatusClass returns a CSS class based on the linking status.
+func (c *UnmatchedCite) StatusClass() string {
+	return statusClass(c.Status)
+}
+
+// unmatchedCitesLimit caps how many raw citations the reverse-aggregation page
+// renders, matching the reporter-cites page. Groups larger than this are
+// truncated for display; the true total is reported separately.
+const unmatchedCitesLimit = 10000
+
+// getUnmatchedCites reverses the aggregation: it returns the raw, still-to-be-
+// linked citations that the view aggregated under (volume, reporter_standard,
+// page), capped at unmatchedCitesLimit, plus the true total (the view's n).
+// Each occurrence carries the MOML treatise title and page where it was found,
+// since the raw string is often identical across many treatises. volume and
+// reporter may be nil to match NULL values. The unmatched predicate matches
+// the view, so total equals the row's n.
+func getUnmatchedCites(ctx context.Context, db *pgxpool.Pool, volume *int, reporter *string, page int) ([]UnmatchedCite, int, error) {
+	slog.Debug("querying cites for unmatched citation", "page", page)
+	query := `
+	SELECT cu.id, cu.raw, cl.status,
+	       COALESCE(bc.displaytitle, '') AS treatise,
+	       COALESCE(NULLIF(mp.sourcepage, ''), cu.moml_page) AS found_page,
+	       count(*) OVER() AS total
+	FROM moml_citations.citations_unlinked cu
+	JOIN legalhist.whitelist wl
+	  ON cu.reporter_abbr = wl.reporter_found AND wl.junk = false
+	LEFT JOIN moml_citations.citation_links cl ON cl.citation_id = cu.id
+	LEFT JOIN moml.book_citation bc ON bc.psmid = cu.moml_treatise
+	LEFT JOIN moml.page mp ON mp.psmid = cu.moml_treatise AND mp.pageid = cu.moml_page
+	WHERE wl.reporter_standard IS NOT DISTINCT FROM $1::text
+	  AND cu.volume IS NOT DISTINCT FROM $2::int
+	  AND cu.page = $3
+	  AND (cl.citation_id IS NULL OR cl.status = 'no_match')
+	ORDER BY bc.displaytitle NULLS LAST, mp.sourcepage, cu.id
+	LIMIT $4
+	`
+	rows, err := db.Query(ctx, query, reporter, volume, page, unmatchedCitesLimit)
+	if err != nil {
+		return nil, 0, fmt.Errorf("querying cites for unmatched citation: %w", err)
+	}
+	defer rows.Close()
+
+	var results []UnmatchedCite
+	var total int
+	for rows.Next() {
+		var c UnmatchedCite
+		if err := rows.Scan(&c.ID, &c.Raw, &c.Status, &c.Treatise, &c.Page, &total); err != nil {
+			return nil, 0, fmt.Errorf("scanning unmatched cite: %w", err)
+		}
+		c.Raw = strings.ReplaceAll(c.Raw, "\n", " ")
+		c.Raw = strings.ReplaceAll(c.Raw, "\r", " ")
+		results = append(results, c)
+	}
+	slog.Debug("fetched cites for unmatched citation", "page", page, "shown", len(results), "total", total)
+	return results, total, rows.Err()
 }
 
 func getCitationDetail(ctx context.Context, db *pgxpool.Pool, id uuid.UUID) (*CitationDetail, error) {

--- a/chambers/templates/home.html
+++ b/chambers/templates/home.html
@@ -28,6 +28,14 @@
         <div class="col-md-4">
             <div class="card h-100">
                 <div class="card-body">
+                    <h5 class="card-title"><a href="/unmatched" class="text-decoration-none">Top unmatched citations</a></h5>
+                    <p class="card-text text-secondary small">Browse the most frequent citations still to be linked, ranked by count.</p>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="card h-100">
+                <div class="card-body">
                     <h5 class="card-title"><a href="/linking-dashboard" class="text-decoration-none">Linking dashboard</a></h5>
                     <p class="card-text text-secondary small">Dashboard of citation linking progress.</p>
                 </div>

--- a/chambers/templates/unmatched-cites.html
+++ b/chambers/templates/unmatched-cites.html
@@ -1,0 +1,78 @@
+{{define "title"}}{{.Agg.Cite}} &mdash; Chambers{{end}}
+
+{{define "styles"}}
+        .cites { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-top: 0.5rem; }
+        .cite { width: 16rem; box-sizing: border-box; padding: 0.25rem 0.5rem; border-radius: 4px; font-size: 0.8rem; }
+        .cite a { text-decoration: none; color: inherit; display: block; }
+        .cite a:hover .raw { text-decoration: underline; }
+        .cite .raw { font-weight: 600; font-family: monospace; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+        .cite .src { display: block; font-size: 0.72rem; opacity: 0.85; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+        .status-linked { background: #d4edda; color: #155724; }
+        .status-nomatch { background: #f8d7da; color: #721c24; }
+        .status-skip { background: #cce5ff; color: #004085; }
+        .status-unprocessed { background: #fff3cd; color: #856404; }
+{{end}}
+
+{{define "nav"}}
+    <a href="/" class="small text-decoration-none">&larr; Back to Chambers</a>
+{{end}}
+
+{{define "content"}}
+    <a href="/unmatched" class="small">&larr; All unmatched citations</a>
+    <h1 class="h5 mt-2 font-monospace">{{.Agg.Cite}}</h1>
+
+    <p class="small text-secondary">
+        This page reverses the aggregation from <code>moml_citations.citations_unmatched_top</code>:
+        it shows every raw, still-to-be-linked citation that aggregates to
+        <strong>{{.Agg.Cite}}</strong> &mdash; that is, citations whose <code>reporter_abbr</code>
+        maps (via the non-junk <code>legalhist.whitelist</code>) to
+        {{if .Agg.ReporterStandard}}reporter standard &ldquo;{{.Agg.ReporterDisplay}}&rdquo;{{else}}no standard reporter{{end}},
+        with {{if .Agg.Volume}}volume {{.Agg.VolumeDisplay}}{{else}}no volume{{end}} and page {{.Agg.Page}}.
+        Only unmatched citations are shown (no row in <code>citation_links</code>, or
+        <code>no_match</code>), so the count below equals the view&rsquo;s <code>n</code>. Each button
+        shows the <code>raw</code> column &mdash; the exact string detected in the MOML OCR &mdash;
+        along with the MOML treatise title and the page where it was found, since the raw string is
+        often identical across many treatises. Click any citation to open its detail page, keyed by
+        citation UUID.
+    </p>
+    <details class="small my-2">
+        <summary class="text-secondary">Show SQL query</summary>
+        <pre class="bg-light border rounded p-2 mt-1 small"><code>SELECT cu.id, cu.raw, cl.status,
+       bc.displaytitle AS treatise,
+       COALESCE(NULLIF(mp.sourcepage, ''), cu.moml_page) AS found_page
+FROM moml_citations.citations_unlinked cu
+JOIN legalhist.whitelist wl
+  ON cu.reporter_abbr = wl.reporter_found AND wl.junk = false
+LEFT JOIN moml_citations.citation_links cl ON cl.citation_id = cu.id
+LEFT JOIN moml.book_citation bc ON bc.psmid = cu.moml_treatise
+LEFT JOIN moml.page mp ON mp.psmid = cu.moml_treatise AND mp.pageid = cu.moml_page
+WHERE wl.reporter_standard IS NOT DISTINCT FROM {{if .Agg.ReporterStandard}}'{{.Agg.ReporterDisplay}}'{{else}}NULL{{end}}
+  AND cu.volume IS NOT DISTINCT FROM {{if .Agg.Volume}}{{.Agg.VolumeDisplay}}{{else}}NULL{{end}}
+  AND cu.page = {{.Agg.Page}}
+  AND (cl.citation_id IS NULL OR cl.status = 'no_match')
+ORDER BY bc.displaytitle NULLS LAST, mp.sourcepage, cu.id
+LIMIT 10000</code></pre>
+    </details>
+
+    <p class="text-secondary small mb-2">
+        <strong>{{.Total}}</strong> raw unmatched citations aggregate to <code>{{.Agg.Cite}}</code>
+        (the view&rsquo;s <code>n</code> = {{.Agg.N}}).
+        {{if .Truncated}}<span class="text-danger">Showing the first {{.Shown}}; the list is capped at 10,000.</span>{{end}}
+    </p>
+    <div class="d-flex gap-2 mb-2 small text-secondary">
+        <span class="status-nomatch cite">no match</span>
+        <span class="status-unprocessed cite">unprocessed</span>
+    </div>
+    <div class="cites">
+    {{range .Cites}}
+        <span class="cite {{.StatusClass}}">
+            <a href="/cite?id={{.ID}}" title="{{.Treatise}} (p. {{.Page}})">
+                <span class="raw">{{.Raw}}</span>
+                <span class="src">{{if .Treatise}}{{.Treatise}}{{else}}(unknown treatise){{end}} &middot; p. {{.Page}}</span>
+            </a>
+        </span>
+    {{else}}
+        <span class="text-secondary small">No citations found.</span>
+    {{end}}
+    </div>
+{{end}}

--- a/chambers/templates/unmatched.html
+++ b/chambers/templates/unmatched.html
@@ -1,0 +1,69 @@
+{{define "title"}}Top unmatched citations &mdash; Chambers{{end}}
+
+{{define "nav"}}
+    <a href="/" class="small text-decoration-none">&larr; Back to Chambers</a>
+{{end}}
+
+{{define "content"}}
+    <h1 class="h5 mt-2">Top unmatched citations</h1>
+
+    <p class="small text-secondary">
+        This page lists the most frequent citations still to be linked, drawn from the
+        <code>moml_citations.citations_unmatched_top</code> materialized view. Each row is a distinct
+        citation &mdash; a <code>(volume, reporter_standard, page)</code> combination &mdash; and
+        <code>n</code> is the number of raw, detected citations that aggregate to it. A citation
+        counts as &ldquo;unmatched&rdquo; when it has no row in <code>citation_links</code> or its
+        link attempt resulted in <code>no_match</code>. The list is capped at the top 1,000 by
+        <code>n</code> for the selected filter. Click a citation to see all the raw citations that
+        aggregate to it.
+    </p>
+    <details class="small my-2">
+        <summary class="text-secondary">Show SQL query</summary>
+        <pre class="bg-light border rounded p-2 mt-1 small"><code>SELECT volume, reporter_standard, page, n
+FROM moml_citations.citations_unmatched_top
+WHERE {{if eq .Filter "multi"}}volume IS NOT NULL{{else if eq .Filter "single"}}volume IS NULL{{else}}true{{end}}
+ORDER BY n DESC, reporter_standard, volume, page
+LIMIT 1000</code></pre>
+    </details>
+
+    <div class="btn-group btn-group-sm my-2" role="group" aria-label="Volume filter">
+        <a href="/unmatched?filter=multi" class="btn {{if eq .Filter "multi"}}btn-primary{{else}}btn-outline-secondary{{end}}">Multi-volume reporters</a>
+        <a href="/unmatched?filter=single" class="btn {{if eq .Filter "single"}}btn-primary{{else}}btn-outline-secondary{{end}}">Single-volume reporters</a>
+        <a href="/unmatched?filter=all" class="btn {{if eq .Filter "all"}}btn-primary{{else}}btn-outline-secondary{{end}}">All</a>
+    </div>
+
+    <p class="small text-secondary mb-2">
+        {{if eq .Filter "multi"}}Showing citations with a volume number (multi-volume reporters).
+        {{else if eq .Filter "single"}}Showing citations with no volume number (single-volume reporters).
+        {{else}}Showing all citations.{{end}}
+        This filter matches <strong>{{.Summary.Groups}}</strong> grouped citations
+        ({{.Summary.Cites}} raw unmatched citations); displaying the top <strong>{{.Shown}}</strong>.
+        Across the whole view there are <strong>{{.Total.Groups}}</strong> grouped citations
+        ({{.Total.Cites}} raw unmatched citations).
+    </p>
+
+    <table class="table table-sm table-hover align-middle">
+        <thead>
+            <tr>
+                <th>Citation</th>
+                <th>Volume</th>
+                <th>Reporter</th>
+                <th class="text-end">Page</th>
+                <th class="text-end">Count (n)</th>
+            </tr>
+        </thead>
+        <tbody>
+        {{range .Cites}}
+            <tr>
+                <td><a href="{{.DetailURL}}" class="font-monospace">{{.Cite}}</a></td>
+                <td>{{.VolumeDisplay}}</td>
+                <td>{{.ReporterDisplay}}</td>
+                <td class="text-end">{{.Page}}</td>
+                <td class="text-end">{{.N}}</td>
+            </tr>
+        {{else}}
+            <tr><td colspan="5" class="text-secondary">No unmatched citations for this filter.</td></tr>
+        {{end}}
+        </tbody>
+    </table>
+{{end}}

--- a/cite-linker/main.go
+++ b/cite-linker/main.go
@@ -62,6 +62,16 @@ func main() {
 
 	store := citations.NewLinkerDBStore(pool)
 
+	// Refresh the unmatched-citations view up front so it reflects the state
+	// of the data before this run begins. A failed refresh should not block
+	// linking, so log and continue.
+	slog.Info("refreshing citations_unmatched_top materialized view")
+	if err := store.RefreshUnmatchedView(ctx); err != nil {
+		slog.Warn("could not refresh citations_unmatched_top view", "error", err)
+	} else {
+		slog.Info("refreshed citations_unmatched_top materialized view")
+	}
+
 	// Handle --skip-unlisted: bulk skip, then continue to linking
 	if skipUnlisted {
 		slog.Info("batch-marking non-whitelisted citations as skipped")
@@ -212,6 +222,15 @@ func main() {
 
 	wp.StopWait()
 	slog.Info("done linking citations")
+
+	// Refresh the unmatched-citations view again so it reflects the links
+	// produced by this run. Log and continue on failure.
+	slog.Info("refreshing citations_unmatched_top materialized view")
+	if err := store.RefreshUnmatchedView(ctx); err != nil {
+		slog.Warn("could not refresh citations_unmatched_top view", "error", err)
+	} else {
+		slog.Info("refreshed citations_unmatched_top materialized view")
+	}
 }
 
 // linkCitation processes a single citation through the linking pipeline.

--- a/db/migrations/20260609115030_create_citations_unmatched_top_matview.sql
+++ b/db/migrations/20260609115030_create_citations_unmatched_top_matview.sql
@@ -28,8 +28,10 @@ WITH NO DATA;
 
 -- Unique index on the grouping key. Each (volume, reporter_standard, page) is
 -- unique by construction (it is the GROUP BY key). NULLS NOT DISTINCT treats
--- the NULL volume of single-volume reporters as a single value. This unique
--- index is required for REFRESH MATERIALIZED VIEW CONCURRENTLY.
+-- the NULL volume of single-volume reporters as a single value. The cite-linker
+-- refreshes this view with a plain (non-concurrent) REFRESH, so this index is
+-- not required for that; it documents the grouping invariant and keeps the
+-- option of a manual REFRESH MATERIALIZED VIEW CONCURRENTLY open.
 CREATE UNIQUE INDEX IF NOT EXISTS citations_unmatched_top_uq
   ON moml_citations.citations_unmatched_top (volume, reporter_standard, page) NULLS NOT DISTINCT;
 
@@ -37,11 +39,10 @@ CREATE UNIQUE INDEX IF NOT EXISTS citations_unmatched_top_uq
 CREATE INDEX IF NOT EXISTS citations_unmatched_top_n_idx
   ON moml_citations.citations_unmatched_top (n DESC);
 
--- After this migration, populate the view once with a plain (non-concurrent)
--- refresh, since CONCURRENTLY cannot run against a never-populated view:
+-- After this migration the view is empty. The cite-linker refreshes it at the
+-- start and end of each run, so it will be populated the next time cite-linker
+-- runs. To populate it manually in the meantime:
 --   REFRESH MATERIALIZED VIEW moml_citations.citations_unmatched_top;
--- Subsequent refreshes (e.g. after a linking batch) can be non-blocking:
---   REFRESH MATERIALIZED VIEW CONCURRENTLY moml_citations.citations_unmatched_top;
 
 -- migrate:down
 DROP MATERIALIZED VIEW IF EXISTS moml_citations.citations_unmatched_top;

--- a/db/migrations/20260609115030_create_citations_unmatched_top_matview.sql
+++ b/db/migrations/20260609115030_create_citations_unmatched_top_matview.sql
@@ -1,0 +1,47 @@
+-- migrate:up
+SET ROLE = law_admin;
+
+-- Aggregated, ranked list of MOML citations still to be linked. A citation is
+-- "to be linked" when it either has no row in citation_links (no attempt
+-- recorded) or its attempt resulted in status 'no_match'. Reporter
+-- abbreviations are joined to the whitelist (excluding junk) to get the
+-- standard reporter, then grouped by volume, standard reporter, and page so
+-- each distinct normalized citation is counted once. Built WITH NO DATA; run
+-- REFRESH MATERIALIZED VIEW to populate (see note in migrate:down).
+CREATE MATERIALIZED VIEW IF NOT EXISTS moml_citations.citations_unmatched_top AS
+SELECT
+  cu.volume,
+  w.reporter_standard,
+  cu.page,
+  count(*) AS n
+FROM moml_citations.citations_unlinked cu
+LEFT JOIN moml_citations.citation_links cl ON cl.citation_id = cu.id
+JOIN legalhist.whitelist w
+  ON w.reporter_found = cu.reporter_abbr
+ AND w.junk = false
+WHERE cl.citation_id IS NULL      -- no link attempt recorded
+   OR cl.status = 'no_match'      -- attempted but not matched
+GROUP BY cu.volume, w.reporter_standard, cu.page
+HAVING count(*) >= 5
+ORDER BY n DESC
+WITH NO DATA;
+
+-- Unique index on the grouping key. Each (volume, reporter_standard, page) is
+-- unique by construction (it is the GROUP BY key). NULLS NOT DISTINCT treats
+-- the NULL volume of single-volume reporters as a single value. This unique
+-- index is required for REFRESH MATERIALIZED VIEW CONCURRENTLY.
+CREATE UNIQUE INDEX IF NOT EXISTS citations_unmatched_top_uq
+  ON moml_citations.citations_unmatched_top (volume, reporter_standard, page) NULLS NOT DISTINCT;
+
+-- Supports ranked reads / pagination (ORDER BY n DESC).
+CREATE INDEX IF NOT EXISTS citations_unmatched_top_n_idx
+  ON moml_citations.citations_unmatched_top (n DESC);
+
+-- After this migration, populate the view once with a plain (non-concurrent)
+-- refresh, since CONCURRENTLY cannot run against a never-populated view:
+--   REFRESH MATERIALIZED VIEW moml_citations.citations_unmatched_top;
+-- Subsequent refreshes (e.g. after a linking batch) can be non-blocking:
+--   REFRESH MATERIALIZED VIEW CONCURRENTLY moml_citations.citations_unmatched_top;
+
+-- migrate:down
+DROP MATERIALIZED VIEW IF EXISTS moml_citations.citations_unmatched_top;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1327,6 +1327,25 @@ CREATE VIEW moml_citations.citation_links_status AS
 
 
 --
+-- Name: citations_unmatched_top; Type: MATERIALIZED VIEW; Schema: moml_citations; Owner: -
+--
+
+CREATE MATERIALIZED VIEW moml_citations.citations_unmatched_top AS
+ SELECT cu.volume,
+    w.reporter_standard,
+    cu.page,
+    count(*) AS n
+   FROM ((moml_citations.citations_unlinked cu
+     LEFT JOIN moml_citations.citation_links cl ON ((cl.citation_id = cu.id)))
+     JOIN legalhist.whitelist w ON (((w.reporter_found = cu.reporter_abbr) AND (w.junk = false))))
+  WHERE ((cl.citation_id IS NULL) OR (cl.status = 'no_match'::text))
+  GROUP BY cu.volume, w.reporter_standard, cu.page
+ HAVING (count(*) >= 5)
+  ORDER BY (count(*)) DESC
+  WITH NO DATA;
+
+
+--
 -- Name: database_size; Type: VIEW; Schema: stats; Owner: -
 --
 
@@ -1999,6 +2018,20 @@ CREATE UNIQUE INDEX citations_unlinked_uq ON moml_citations.citations_unlinked U
 
 
 --
+-- Name: citations_unmatched_top_n_idx; Type: INDEX; Schema: moml_citations; Owner: -
+--
+
+CREATE INDEX citations_unmatched_top_n_idx ON moml_citations.citations_unmatched_top USING btree (n DESC);
+
+
+--
+-- Name: citations_unmatched_top_uq; Type: INDEX; Schema: moml_citations; Owner: -
+--
+
+CREATE UNIQUE INDEX citations_unmatched_top_uq ON moml_citations.citations_unmatched_top USING btree (volume, reporter_standard, page) NULLS NOT DISTINCT;
+
+
+--
 -- Name: idx_citation_links_cap; Type: INDEX; Schema: moml_citations; Owner: -
 --
 
@@ -2352,4 +2385,5 @@ INSERT INTO sys_admin.migrations_dbmate (version) VALUES
     ('20260522170000'),
     ('20260522170100'),
     ('20260522170200'),
-    ('20260522170300');
+    ('20260522170300'),
+    ('20260609115030');

--- a/go/citations/linker_store.go
+++ b/go/citations/linker_store.go
@@ -39,4 +39,9 @@ type LinkerStore interface {
 	// BatchSkipNonWhitelisted marks all non-whitelisted citations as skipped
 	// in a single bulk operation. Returns the number of rows affected.
 	BatchSkipNonWhitelisted(ctx context.Context) (int64, error)
+
+	// RefreshUnmatchedView refreshes the moml_citations.citations_unmatched_top
+	// materialized view so its ranked list of citations still to be linked
+	// reflects the current state of citation_links.
+	RefreshUnmatchedView(ctx context.Context) error
 }

--- a/go/citations/linker_store_db.go
+++ b/go/citations/linker_store_db.go
@@ -269,3 +269,18 @@ func (s *LinkerDBStore) BatchSkipNonWhitelisted(ctx context.Context) (int64, err
 	}
 	return tag.RowsAffected(), nil
 }
+
+// RefreshUnmatchedView refreshes the moml_citations.citations_unmatched_top
+// materialized view. The refresh is blocking: the call does not return until
+// the view has been rebuilt, so the linker does no further work until it is
+// done. This is a plain (non-concurrent) refresh, which takes an exclusive
+// lock that blocks readers while it runs. That is acceptable here because the
+// view is not read during a linker run, and a plain refresh is faster than a
+// CONCURRENTLY refresh.
+func (s *LinkerDBStore) RefreshUnmatchedView(ctx context.Context) error {
+	const view = "moml_citations.citations_unmatched_top"
+	if _, err := s.DB.Exec(ctx, "REFRESH MATERIALIZED VIEW "+view); err != nil {
+		return fmt.Errorf("refreshing %s: %w", view, err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Adds a materialized view that aggregates MOML citations still to be linked, ranked by how many times each distinct citation occurs, and refreshes it from the cite-linker. Implements #163.

## What's here

- **Migration** `db/migrations/20260609115030_create_citations_unmatched_top_matview.sql` creates `moml_citations.citations_unmatched_top`. A citation counts as "to be linked" when it either has **no row** in `citation_links` or its attempt resulted in **`status = 'no_match'`**. Reporter abbreviations are joined to the non-junk whitelist to resolve the standard reporter, then grouped by `(volume, reporter_standard, page)` with groups smaller than 5 excluded, sorted by count `n` descending. Built `WITH NO DATA` so the migration is instant.
- **Indexes:** a `NULLS NOT DISTINCT` unique index on the grouping key (documents the invariant; also allows a manual `REFRESH ... CONCURRENTLY`) and a `(n DESC)` index for ranked reads.
- **`LinkerStore.RefreshUnmatchedView`** (`go/citations/`) runs a plain, blocking `REFRESH MATERIALIZED VIEW`. `cite-linker` calls it at the **start and end** of each run so the list reflects the data before the run and the links produced by it. The refresh is non-fatal — a failure is logged and linking continues.

A plain (non-concurrent) refresh is used deliberately: the view is not read during a linker run, so blocking readers is fine, and a plain refresh is faster and has no "must already be populated" requirement.

## Notes

- The view currently surfaces some rows with a NULL `reporter_standard`, caused by 24 whitelist rows that are non-junk but unmapped. That whitelist data cleanup is tracked separately (see the issue thread); a permanent `AND w.reporter_standard IS NOT NULL` guard on the view is a reasonable follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
