### PR TITLE
Optimize the chambers linking dashboard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,5 +48,8 @@ db-down:
 db-status:
 	dbmate --env DBMATE_URL --migrations-dir db/migrations status
 
+db-schema:
+	dbmate --env DBMATE_URL dump
+
 chambers:
 	cd ./chambers && go run github.com/air-verse/air

--- a/chambers/main.go
+++ b/chambers/main.go
@@ -261,7 +261,7 @@ func handleDashboard(w http.ResponseWriter, r *http.Request, tmpl *template.Temp
 
 func handleDashboardAPI(w http.ResponseWriter, r *http.Request) {
 	slog.Debug("handling request", "path", r.URL.Path, "handler", "dashboard-api")
-	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
 
 	slog.Debug("fetching dashboard data from database")

--- a/chambers/queries.go
+++ b/chambers/queries.go
@@ -491,22 +491,27 @@ func (d *DashboardData) TotalLinked() int {
 func getDashboardData(ctx context.Context, db *pgxpool.Pool) (*DashboardData, error) {
 	d := &DashboardData{}
 
-	// Get counts by status from the view
-	slog.Debug("querying citation links status view")
-	rows, err := db.Query(ctx, `SELECT status, n FROM moml_citations.citation_links_status`)
+	// Get summary metrics (total raw cites and per-status counts) from the
+	// precomputed materialized view. The view is refreshed by the cite-linker;
+	// reading it here is a small indexed scan instead of aggregating the ~62M-row
+	// citations_unlinked and citation_links tables on every request.
+	slog.Debug("querying linking dashboard summary view")
+	rows, err := db.Query(ctx, `SELECT metric, n FROM moml_citations.linking_dashboard_summary`)
 	if err != nil {
-		return nil, fmt.Errorf("querying citation links status: %w", err)
+		return nil, fmt.Errorf("querying dashboard summary: %w", err)
 	}
 	defer rows.Close()
 
 	for rows.Next() {
-		var status string
+		var metric string
 		var n int
-		if err := rows.Scan(&status, &n); err != nil {
-			return nil, fmt.Errorf("scanning citation links status: %w", err)
+		if err := rows.Scan(&metric, &n); err != nil {
+			return nil, fmt.Errorf("scanning dashboard summary: %w", err)
 		}
-		slog.Debug("citation links status row", "status", status, "n", n)
-		switch status {
+		slog.Debug("dashboard summary row", "metric", metric, "n", n)
+		switch metric {
+		case "total_raw_cites":
+			d.TotalRawCites = n
 		case "linked_cap":
 			d.LinkedCAP = n
 		case "linked_english_reports":
@@ -522,33 +527,17 @@ func getDashboardData(ctx context.Context, db *pgxpool.Pool) (*DashboardData, er
 		}
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterating citation links status: %w", err)
+		return nil, fmt.Errorf("iterating dashboard summary: %w", err)
 	}
-	slog.Debug("finished querying citation links status view")
+	slog.Debug("finished querying linking dashboard summary view")
 
-	// Get total raw citations count
-	slog.Debug("counting total raw citations")
-	err = db.QueryRow(ctx, `SELECT count(*) FROM moml_citations.citations_unlinked`).Scan(&d.TotalRawCites)
-	if err != nil {
-		return nil, fmt.Errorf("counting raw citations: %w", err)
-	}
-	// Get per-reporter linking stats
+	// Get per-reporter linking stats from the precomputed materialized view,
+	// ordered by total citations descending (linked + no_match + unprocessed).
 	slog.Debug("querying per-reporter linking stats")
 	reporterRows, err := db.Query(ctx, `
-		SELECT
-			wl.reporter_standard,
-			count(*) FILTER (WHERE cl.status LIKE 'linked%') AS linked,
-			count(*) FILTER (WHERE cl.status = 'no_match') AS no_match,
-			count(*) FILTER (WHERE cl.status IS NULL) AS unprocessed,
-			COALESCE(bool_or(r.jurisdiction LIKE 'uk:%'), false) AS uk
-		FROM moml_citations.citations_unlinked cu
-		JOIN legalhist.whitelist wl ON cu.reporter_abbr = wl.reporter_found
-		JOIN legalhist.reporters r ON r.reporter_standard = wl.reporter_standard
-		LEFT JOIN moml_citations.citation_links cl ON cl.citation_id = cu.id
-		WHERE wl.reporter_standard IS NOT NULL
-		  AND wl.junk = false
-		GROUP BY wl.reporter_standard
-		ORDER BY count(*) DESC
+		SELECT reporter_standard, linked, no_match, unprocessed, uk
+		FROM moml_citations.linking_dashboard_reporters
+		ORDER BY linked + no_match + unprocessed DESC
 	`)
 	if err != nil {
 		return nil, fmt.Errorf("querying reporter stats: %w", err)

--- a/cite-linker/main.go
+++ b/cite-linker/main.go
@@ -62,14 +62,14 @@ func main() {
 
 	store := citations.NewLinkerDBStore(pool)
 
-	// Refresh the unmatched-citations view up front so it reflects the state
-	// of the data before this run begins. A failed refresh should not block
-	// linking, so log and continue.
-	slog.Info("refreshing citations_unmatched_top materialized view")
-	if err := store.RefreshUnmatchedView(ctx); err != nil {
-		slog.Warn("could not refresh citations_unmatched_top view", "error", err)
+	// Refresh the dashboard materialized views up front so they reflect the
+	// state of the data before this run begins. A failed refresh should not
+	// block linking, so log and continue.
+	slog.Info("refreshing dashboard materialized views")
+	if err := store.RefreshDashboardViews(ctx); err != nil {
+		slog.Warn("could not refresh dashboard materialized views", "error", err)
 	} else {
-		slog.Info("refreshed citations_unmatched_top materialized view")
+		slog.Info("refreshed dashboard materialized views")
 	}
 
 	// Handle --skip-unlisted: bulk skip, then continue to linking
@@ -223,13 +223,13 @@ func main() {
 	wp.StopWait()
 	slog.Info("done linking citations")
 
-	// Refresh the unmatched-citations view again so it reflects the links
+	// Refresh the dashboard materialized views again so they reflect the links
 	// produced by this run. Log and continue on failure.
-	slog.Info("refreshing citations_unmatched_top materialized view")
-	if err := store.RefreshUnmatchedView(ctx); err != nil {
-		slog.Warn("could not refresh citations_unmatched_top view", "error", err)
+	slog.Info("refreshing dashboard materialized views")
+	if err := store.RefreshDashboardViews(ctx); err != nil {
+		slog.Warn("could not refresh dashboard materialized views", "error", err)
 	} else {
-		slog.Info("refreshed citations_unmatched_top materialized view")
+		slog.Info("refreshed dashboard materialized views")
 	}
 }
 

--- a/db/migrations/20260609133000_create_linking_dashboard_matviews.sql
+++ b/db/migrations/20260609133000_create_linking_dashboard_matviews.sql
@@ -1,0 +1,66 @@
+-- migrate:up
+SET ROLE = law_admin;
+
+-- Precomputed aggregates for the chambers linking dashboard
+-- (/linking-dashboard). The dashboard previously aggregated the ~62M-row
+-- moml_citations.citations_unlinked and ~61M-row moml_citations.citation_links
+-- tables on every page load, which took over a minute and timed out in the
+-- browser. These materialized views move that work off the request path; the
+-- cite-linker refreshes them at the start and end of each run, alongside
+-- moml_citations.citations_unmatched_top. Both are built WITH NO DATA; run
+-- REFRESH MATERIALIZED VIEW to populate (see note before migrate:down).
+
+-- Per-reporter linking breakdown. For each whitelisted (non-junk) standard
+-- reporter, counts how many of its raw citations are linked, ended in
+-- 'no_match', or have no link attempt yet (unprocessed), plus a flag for UK
+-- jurisdiction reporters. Mirrors the query the dashboard formerly ran inline.
+CREATE MATERIALIZED VIEW IF NOT EXISTS moml_citations.linking_dashboard_reporters AS
+SELECT
+  wl.reporter_standard,
+  count(*) FILTER (WHERE cl.status LIKE 'linked%') AS linked,
+  count(*) FILTER (WHERE cl.status = 'no_match')   AS no_match,
+  count(*) FILTER (WHERE cl.status IS NULL)         AS unprocessed,
+  COALESCE(bool_or(r.jurisdiction LIKE 'uk:%'), false) AS uk
+FROM moml_citations.citations_unlinked cu
+JOIN legalhist.whitelist wl ON cu.reporter_abbr = wl.reporter_found
+JOIN legalhist.reporters r ON r.reporter_standard = wl.reporter_standard
+LEFT JOIN moml_citations.citation_links cl ON cl.citation_id = cu.id
+WHERE wl.reporter_standard IS NOT NULL
+  AND wl.junk = false
+GROUP BY wl.reporter_standard
+WITH NO DATA;
+
+-- Unique index on the grouping key (reporter_standard is the GROUP BY key, so
+-- it is unique by construction). Documents the invariant and keeps the option
+-- of a manual REFRESH MATERIALIZED VIEW CONCURRENTLY open.
+CREATE UNIQUE INDEX IF NOT EXISTS linking_dashboard_reporters_uq
+  ON moml_citations.linking_dashboard_reporters (reporter_standard);
+
+-- Dashboard summary metrics as key/value rows. Captures the total count of raw
+-- detected citations plus the count of citation_links in each status
+-- (no_match, linked_cap, linked_english_reports, linked_code_reporter,
+-- skipped_not_whitelisted, skipped_junk). The dashboard reads this single small
+-- view instead of running a count over citations_unlinked and a GROUP BY over
+-- citation_links on every load.
+CREATE MATERIALIZED VIEW IF NOT EXISTS moml_citations.linking_dashboard_summary AS
+SELECT 'total_raw_cites'::text AS metric, count(*) AS n
+  FROM moml_citations.citations_unlinked
+UNION ALL
+SELECT status AS metric, count(*) AS n
+  FROM moml_citations.citation_links
+ GROUP BY status
+WITH NO DATA;
+
+-- Unique index on the metric key. Each metric appears once by construction.
+CREATE UNIQUE INDEX IF NOT EXISTS linking_dashboard_summary_uq
+  ON moml_citations.linking_dashboard_summary (metric);
+
+-- After this migration both views are empty. The cite-linker refreshes them at
+-- the start and end of each run, so they will be populated the next time
+-- cite-linker runs. To populate them manually in the meantime:
+--   REFRESH MATERIALIZED VIEW moml_citations.linking_dashboard_reporters;
+--   REFRESH MATERIALIZED VIEW moml_citations.linking_dashboard_summary;
+
+-- migrate:down
+DROP MATERIALIZED VIEW IF EXISTS moml_citations.linking_dashboard_summary;
+DROP MATERIALIZED VIEW IF EXISTS moml_citations.linking_dashboard_reporters;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1346,6 +1346,41 @@ CREATE MATERIALIZED VIEW moml_citations.citations_unmatched_top AS
 
 
 --
+-- Name: linking_dashboard_reporters; Type: MATERIALIZED VIEW; Schema: moml_citations; Owner: -
+--
+
+CREATE MATERIALIZED VIEW moml_citations.linking_dashboard_reporters AS
+ SELECT wl.reporter_standard,
+    count(*) FILTER (WHERE (cl.status ~~ 'linked%'::text)) AS linked,
+    count(*) FILTER (WHERE (cl.status = 'no_match'::text)) AS no_match,
+    count(*) FILTER (WHERE (cl.status IS NULL)) AS unprocessed,
+    COALESCE(bool_or((r.jurisdiction ~~ 'uk:%'::text)), false) AS uk
+   FROM (((moml_citations.citations_unlinked cu
+     JOIN legalhist.whitelist wl ON ((cu.reporter_abbr = wl.reporter_found)))
+     JOIN legalhist.reporters r ON ((r.reporter_standard = wl.reporter_standard)))
+     LEFT JOIN moml_citations.citation_links cl ON ((cl.citation_id = cu.id)))
+  WHERE ((wl.reporter_standard IS NOT NULL) AND (wl.junk = false))
+  GROUP BY wl.reporter_standard
+  WITH NO DATA;
+
+
+--
+-- Name: linking_dashboard_summary; Type: MATERIALIZED VIEW; Schema: moml_citations; Owner: -
+--
+
+CREATE MATERIALIZED VIEW moml_citations.linking_dashboard_summary AS
+ SELECT 'total_raw_cites'::text AS metric,
+    count(*) AS n
+   FROM moml_citations.citations_unlinked
+UNION ALL
+ SELECT citation_links.status AS metric,
+    count(*) AS n
+   FROM moml_citations.citation_links
+  GROUP BY citation_links.status
+  WITH NO DATA;
+
+
+--
 -- Name: database_size; Type: VIEW; Schema: stats; Owner: -
 --
 
@@ -2060,6 +2095,20 @@ CREATE INDEX idx_citation_links_status ON moml_citations.citation_links USING bt
 
 
 --
+-- Name: linking_dashboard_reporters_uq; Type: INDEX; Schema: moml_citations; Owner: -
+--
+
+CREATE UNIQUE INDEX linking_dashboard_reporters_uq ON moml_citations.linking_dashboard_reporters USING btree (reporter_standard);
+
+
+--
+-- Name: linking_dashboard_summary_uq; Type: INDEX; Schema: moml_citations; Owner: -
+--
+
+CREATE UNIQUE INDEX linking_dashboard_summary_uq ON moml_citations.linking_dashboard_summary USING btree (metric);
+
+
+--
 -- Name: moml_page_to_cap_case_case_idx; Type: INDEX; Schema: moml_citations; Owner: -
 --
 
@@ -2386,4 +2435,5 @@ INSERT INTO sys_admin.migrations_dbmate (version) VALUES
     ('20260522170100'),
     ('20260522170200'),
     ('20260522170300'),
-    ('20260609115030');
+    ('20260609115030'),
+    ('20260609133000');

--- a/go/citations/linker_store.go
+++ b/go/citations/linker_store.go
@@ -40,8 +40,9 @@ type LinkerStore interface {
 	// in a single bulk operation. Returns the number of rows affected.
 	BatchSkipNonWhitelisted(ctx context.Context) (int64, error)
 
-	// RefreshUnmatchedView refreshes the moml_citations.citations_unmatched_top
-	// materialized view so its ranked list of citations still to be linked
-	// reflects the current state of citation_links.
-	RefreshUnmatchedView(ctx context.Context) error
+	// RefreshDashboardViews refreshes the materialized views that back the
+	// chambers dashboard (citations_unmatched_top, linking_dashboard_reporters,
+	// linking_dashboard_summary) so their precomputed aggregates reflect the
+	// current state of citation_links.
+	RefreshDashboardViews(ctx context.Context) error
 }

--- a/go/citations/linker_store_db.go
+++ b/go/citations/linker_store_db.go
@@ -270,17 +270,28 @@ func (s *LinkerDBStore) BatchSkipNonWhitelisted(ctx context.Context) (int64, err
 	return tag.RowsAffected(), nil
 }
 
-// RefreshUnmatchedView refreshes the moml_citations.citations_unmatched_top
-// materialized view. The refresh is blocking: the call does not return until
-// the view has been rebuilt, so the linker does no further work until it is
-// done. This is a plain (non-concurrent) refresh, which takes an exclusive
-// lock that blocks readers while it runs. That is acceptable here because the
-// view is not read during a linker run, and a plain refresh is faster than a
+// dashboardViews are the materialized views that precompute aggregates read by
+// the chambers linking dashboard and unmatched-citations pages. They are
+// refreshed together by RefreshDashboardViews.
+var dashboardViews = []string{
+	"moml_citations.citations_unmatched_top",
+	"moml_citations.linking_dashboard_reporters",
+	"moml_citations.linking_dashboard_summary",
+}
+
+// RefreshDashboardViews refreshes the materialized views that back the chambers
+// dashboard so their precomputed aggregates reflect the current state of
+// citation_links. Each refresh is blocking: the call does not return until the
+// views have been rebuilt, so the linker does no further work until it is done.
+// These are plain (non-concurrent) refreshes, which take an exclusive lock that
+// blocks readers while they run. That is acceptable here because the views are
+// not read during a linker run, and a plain refresh is faster than a
 // CONCURRENTLY refresh.
-func (s *LinkerDBStore) RefreshUnmatchedView(ctx context.Context) error {
-	const view = "moml_citations.citations_unmatched_top"
-	if _, err := s.DB.Exec(ctx, "REFRESH MATERIALIZED VIEW "+view); err != nil {
-		return fmt.Errorf("refreshing %s: %w", view, err)
+func (s *LinkerDBStore) RefreshDashboardViews(ctx context.Context) error {
+	for _, view := range dashboardViews {
+		if _, err := s.DB.Exec(ctx, "REFRESH MATERIALIZED VIEW "+view); err != nil {
+			return fmt.Errorf("refreshing %s: %w", view, err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #196.

## Problem

The `/linking-dashboard` view in chambers was nearly unusable: its queries took minutes to run and browsers timed out after a minute. Measured against the live database, the API endpoint ran three queries serially over two ~62M-row tables:

| Query | Source | Measured time |
|-------|--------|--------------|
| Status counts | GROUP BY over 61.5M `citation_links` | 8.8s |
| Total raw cites | `count(*)` over 62.8M `citations_unlinked` | 5.2s |
| Per-reporter stats | 62.8M ⋈ 61.5M join + GROUP BY | 60s |

That's ~74s combined — past the 60s browser timeout. No index fixes a full-table aggregate over 62M rows.

## Fix

Move the aggregation off the request path into materialized views, following the existing `citations_unmatched_top` pattern:

- **`linking_dashboard_reporters`** — per-reporter linked/no_match/unprocessed breakdown (replaces the 60s query).
- **`linking_dashboard_summary`** — key/value view with total raw cites plus per-status counts (replaces the 8.8s + 5.2s queries).

The cite-linker refreshes them at the start and end of each run (the `RefreshUnmatchedView` method is generalized to `RefreshDashboardViews`, refreshing all three dashboard matviews together). The dashboard now reads two small precomputed tables and loads in milliseconds. The JSON response shape is unchanged, so the template needs no edits.

## Commits

1. Add the two materialized views (migration).
2. Refresh them from cite-linker.
3. Read the dashboard from the precomputed views; drop the API timeout from 5 min to 30s.

## Deploy notes

The migration creates the views `WITH NO DATA`, so after `dbmate up`, populate them once (otherwise the dashboard shows zeros until the next cite-linker run):

```sql
REFRESH MATERIALIZED VIEW moml_citations.linking_dashboard_reporters;
REFRESH MATERIALIZED VIEW moml_citations.linking_dashboard_summary;
```

Thereafter cite-linker keeps them current.

**Tradeoff:** dashboard numbers now reflect the last linking run rather than live state — the same staleness model already used for `citations_unmatched_top`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)