### PR TITLE
Add script to refresh all materialized views

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,17 @@ Internal web app for browsing and inspecting citation data. Located in `chambers
 
 **Frontend:** Use the latest version of Bootstrap CSS via CDN (no Bootstrap JavaScript). Use Observable Plot (`@observablehq/plot`) for data visualizations when possible, and D3.js otherwise.
 
+## GitHub
+
+Use the `gh` CLI for GitHub operations — creating pull requests, viewing issues, checking CI status, and commenting. It is authenticated via the `GH_TOKEN` environment variable.
+
+- Open a PR: `gh pr create --base main --head <branch> --title "..." --body "..."`
+- Reference the issue a PR closes in the commit or PR body with `Closes #<n>` so it auto-closes on merge.
+- View an issue: `gh issue view <n>`
+- Check CI on a PR: `gh pr checks <n>`
+
+Do not hand-build GitHub API calls with `curl`; prefer `gh`.
+
 ## CI
 
 GitHub Actions (`.github/workflows/go.yml`) runs on push/PR to main:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BIN_DIR = bin
 DARWIN_TARGETS = $(foreach bin,$(BINARIES),$(BIN_DIR)/darwin-arm64/$(bin))
 LINUX_TARGETS = $(foreach bin,$(BINARIES),$(BIN_DIR)/linux-amd64/$(bin))
 
-.PHONY: binaries clean test vet sync-hopper db-up db-down db-status chambers
+.PHONY: binaries clean test vet sync-hopper db-up db-down db-status db-schema db-refresh chambers
 
 binaries: $(DARWIN_TARGETS) $(LINUX_TARGETS)
 
@@ -50,6 +50,11 @@ db-status:
 
 db-schema:
 	dbmate --env DBMATE_URL dump
+
+# Refresh all materialized views, in dependency order and in parallel within
+# each level. Uses LAW_DBSTR directly (needs write access).
+db-refresh:
+	./db/refresh-matviews.sh
 
 chambers:
 	cd ./chambers && go run github.com/air-verse/air

--- a/db/refresh-matviews.sh
+++ b/db/refresh-matviews.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+#
+# Refresh every materialized view in the database.
+#
+# The set of materialized views and their dependencies are discovered at
+# runtime from the system catalogs, so this script never needs editing when a
+# view is added, removed, or renamed. Views are grouped into dependency levels:
+# a view is only refreshed once the materialized views it reads from have been
+# refreshed. Within a level (views with no dependency on one another) the
+# refreshes run in parallel, each on its own connection.
+#
+# The connection string comes from LAW_DBSTR (or the first argument). The
+# pgx-only pool_max_conns parameter is stripped because psql does not
+# understand it, matching how the Makefile feeds the string to dbmate.
+#
+# REFRESH MATERIALIZED VIEW takes an ACCESS EXCLUSIVE lock on each view, so
+# readers are blocked for the duration of that view's refresh. This is intended
+# as a maintenance task rather than something to run under live load.
+#
+# Usage:
+#   db/refresh-matviews.sh [connection-string]
+
+set -euo pipefail
+
+CONN="${1:-${LAW_DBSTR:-}}"
+if [[ -z "$CONN" ]]; then
+  echo "error: no connection string; set LAW_DBSTR or pass one as the first argument" >&2
+  exit 1
+fi
+# Strip the pgx-only pool_max_conns parameter that psql cannot parse.
+CONN="$(printf '%s' "$CONN" | sed 's/[&?]pool_max_conns=[0-9]\{1,3\}//')"
+
+PSQL=(psql "$CONN" -X -v ON_ERROR_STOP=1)
+
+# Discover materialized views and the dependency level of each. Level 0 views
+# depend on no other materialized view; a view at level N depends on at least
+# one view at level N-1. max(level) gives the longest path, ensuring a view is
+# ordered after every materialized view it transitively reads from.
+read -r -d '' PLAN_SQL <<'SQL' || true
+WITH RECURSIVE
+matviews AS (
+  SELECT c.oid, format('%I.%I', n.nspname, c.relname) AS qname
+  FROM pg_class c
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE c.relkind = 'm'
+),
+deps AS (
+  SELECT DISTINCT child.oid AS child_oid, parent.oid AS parent_oid
+  FROM pg_depend d
+  JOIN pg_rewrite r ON r.oid = d.objid
+  JOIN pg_class child ON child.oid = r.ev_class AND child.relkind = 'm'
+  JOIN pg_class parent ON parent.oid = d.refobjid AND parent.relkind = 'm'
+  WHERE d.deptype = 'n' AND child.oid <> parent.oid
+),
+depth(oid, level) AS (
+  SELECT m.oid, 0
+  FROM matviews m
+  WHERE NOT EXISTS (SELECT 1 FROM deps d WHERE d.child_oid = m.oid)
+  UNION ALL
+  SELECT d.child_oid, depth.level + 1
+  FROM deps d
+  JOIN depth ON depth.oid = d.parent_oid
+)
+SELECT max(level) AS level, m.qname
+FROM depth
+JOIN matviews m ON m.oid = depth.oid
+GROUP BY m.qname
+ORDER BY level, m.qname;
+SQL
+
+PLAN="$("${PSQL[@]}" -At -F $'\t' -c "$PLAN_SQL")"
+
+if [[ -z "$PLAN" ]]; then
+  echo "No materialized views found; nothing to refresh."
+  exit 0
+fi
+
+# Read the plan into parallel indexed arrays (avoiding bash-4-only features so
+# this runs under the bash 3.2 that ships with macOS).
+levels=()
+views=()
+while IFS=$'\t' read -r level qname; do
+  [[ -z "$qname" ]] && continue
+  levels+=("$level")
+  views+=("$qname")
+done <<EOF
+$PLAN
+EOF
+
+total="${#views[@]}"
+echo "Refreshing $total materialized view(s)."
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Refresh a single view, recording status and elapsed seconds to <out>.status
+# and any psql output to <out>.log.
+refresh_one() {
+  local view="$1" out="$2" start end
+  start=$(date +%s)
+  if "${PSQL[@]}" -q -c "REFRESH MATERIALIZED VIEW $view;" >"$out.log" 2>&1; then
+    end=$(date +%s)
+    printf 'ok\t%s\n' "$((end - start))" >"$out.status"
+  else
+    end=$(date +%s)
+    printf 'fail\t%s\n' "$((end - start))" >"$out.status"
+  fi
+}
+
+failed=0
+overall_start=$(date +%s)
+idx=0
+
+# Iterate the plan one dependency level at a time. Launch all of a level's
+# views in parallel, then wait for the whole level before starting the next so
+# dependencies are always satisfied.
+n="${#views[@]}"
+i=0
+while [[ "$i" -lt "$n" ]]; do
+  level="${levels[$i]}"
+  batch_views=()
+  batch_outs=()
+  batch_pids=()
+
+  # Collect every view at the current level.
+  while [[ "$i" -lt "$n" && "${levels[$i]}" == "$level" ]]; do
+    out="$TMP/$idx"
+    idx=$((idx + 1))
+    echo "[level $level] starting ${views[$i]}"
+    refresh_one "${views[$i]}" "$out" &
+    batch_pids+=("$!")
+    batch_views+=("${views[$i]}")
+    batch_outs+=("$out")
+    i=$((i + 1))
+  done
+
+  # Wait for the level to finish and report each view's result.
+  for p in "${batch_pids[@]}"; do
+    wait "$p" || true
+  done
+  for j in "${!batch_views[@]}"; do
+    status=""
+    secs="?"
+    if [[ -f "${batch_outs[$j]}.status" ]]; then
+      IFS=$'\t' read -r status secs <"${batch_outs[$j]}.status"
+    fi
+    if [[ "$status" == "ok" ]]; then
+      printf '  done   %-46s %ss\n' "${batch_views[$j]}" "$secs"
+    else
+      failed=$((failed + 1))
+      printf '  FAILED %-46s %ss\n' "${batch_views[$j]}" "$secs"
+      sed 's/^/         /' "${batch_outs[$j]}.log" >&2
+    fi
+  done
+done
+
+overall_end=$(date +%s)
+elapsed=$((overall_end - overall_start))
+
+echo
+if [[ "$failed" -eq 0 ]]; then
+  echo "Done. All $total materialized view(s) refreshed in ${elapsed}s."
+else
+  echo "Done with errors: $failed of $total materialized view(s) failed (${elapsed}s)." >&2
+  exit 1
+fi


### PR DESCRIPTION
Closes #202

## What

Adds `db/refresh-matviews.sh`, a script that refreshes every materialized view in the database, plus a `make db-refresh` target that runs it.

## How it works

- **Self-maintaining discovery** — queries `pg_class`/`pg_depend`/`pg_rewrite` at runtime to find all materialized views, so it never needs editing when a view is added, renamed, or removed.
- **Dependency ordering** — a recursive CTE assigns each view a level by its longest dependency path; a view is only refreshed after the materialized views it reads from. (Currently all 9 views are at level 0 — none depends on another materialized view — so they all refresh together. The ordering kicks in automatically if that ever changes.)
- **Parallel within a level** — each view refreshes on its own `psql` connection; the script waits for a level to complete before starting the next so dependencies are always satisfied.
- **Definitive output** — prints each view as it starts, `done`/`FAILED` with elapsed seconds as each finishes (capturing error text on failure), and a final `Done. All N materialized view(s) refreshed in Ts` summary. Exits nonzero if any refresh failed.

Reads `LAW_DBSTR` (or a connection string as the first argument) and strips the pgx-only `pool_max_conns` parameter, matching the Makefile's dbmate handling.

## Notes

- `REFRESH MATERIALIZED VIEW` takes an `ACCESS EXCLUSIVE` lock per view, so this is intended as a maintenance task rather than something to run under live load.
- Portable to the bash 3.2 / BSD `date` on macOS (integer-second timing, no bash-4 features).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
