### PR TITLE
Add Columbia EZproxy links for MOML page images in chambers

### DIFF
--- a/chambers/README.md
+++ b/chambers/README.md
@@ -75,8 +75,9 @@ The `moml.page` and `moml.page_ocrtext` joins must include `psmid` (treatise ID)
 
 - `HasLink()` — true if status is any `linked_*` value
 - `IsCAP()` / `IsCodeReporter()` / `IsEnglishReports()` — which case source was matched
-- `MomlVolumeURL()` — Gale MOML URL for the volume (transforms the stored `productlink` from old `link.galegroup.com` domain to `link.gale.com`, adds `u=viva_gmu`)
-- `MomlPageURL()` — Same as volume URL but appends `&pg=N` where N is derived from `pageid` by stripping the trailing `0` and leading `0`s (e.g., `06870` becomes `687`)
+- `MomlVolumeURL()` — Gale MOML URL for the volume routed through GMU's library proxy (transforms the stored `productlink` from old `link.galegroup.com` domain to `link.gale.com`, adds `u=viva_gmu`)
+- `MomlVolumeURLColumbia()` — Same volume URL routed through Columbia University's EZproxy (`go-gale-com.ezproxy.cul.columbia.edu`, no `u=` param)
+- `MomlPageURL()` / `MomlPageURLColumbia()` — Same as the GMU/Columbia volume URLs but append `&pg=N` where N is derived from `pageid` by stripping the trailing `0` and leading `0`s (e.g., `06870` becomes `687`)
 
 ### ReporterCite.StatusClass
 

--- a/chambers/queries.go
+++ b/chambers/queries.go
@@ -82,22 +82,37 @@ func (c *CitationDetail) IsEnglishReports() bool {
 	return c.Status != nil && *c.Status == "linked_english_reports"
 }
 
-// MomlVolumeURL returns a Gale MOML URL for the volume as a whole.
-func (c *CitationDetail) MomlVolumeURL() string {
+// momlVolumeURL builds a Gale MOML volume URL from the stored productlink,
+// rewriting the legacy link.galegroup.com host to the given host and inserting
+// the optional Gale user query fragment (e.g. "u=viva_gmu&") before the sid
+// parameter. host and userParam select which institution's proxy the link
+// routes through.
+func (c *CitationDetail) momlVolumeURL(host, userParam string) string {
 	if c.ProductLink == nil {
 		return ""
 	}
 	url := *c.ProductLink
-	url = strings.Replace(url, "http://link.galegroup.com", "https://link.gale.com", 1)
-	url = strings.Replace(url, "?sid=dhxml", "?u=viva_gmu&sid=dhxml", 1)
+	url = strings.Replace(url, "http://link.galegroup.com", host, 1)
+	url = strings.Replace(url, "?sid=dhxml", "?"+userParam+"sid=dhxml", 1)
 	return url
 }
 
-// MomlPageURL constructs a Gale MOML URL linking to the specific page.
+// MomlVolumeURL returns a Gale MOML URL for the volume as a whole, routed
+// through GMU's library proxy.
+func (c *CitationDetail) MomlVolumeURL() string {
+	return c.momlVolumeURL("https://link.gale.com", "u=viva_gmu&")
+}
+
+// MomlVolumeURLColumbia returns a Gale MOML URL for the volume as a whole,
+// routed through Columbia University's EZproxy.
+func (c *CitationDetail) MomlVolumeURLColumbia() string {
+	return c.momlVolumeURL("https://go-gale-com.ezproxy.cul.columbia.edu", "")
+}
+
+// momlPageURL appends the page (pg) parameter to a Gale MOML volume URL.
 // The pg parameter uses MomlPage (pageid), with the trailing 0 stripped
 // and leading 0s removed. E.g., pageid "06870" becomes pg=687.
-func (c *CitationDetail) MomlPageURL() string {
-	base := c.MomlVolumeURL()
+func (c *CitationDetail) momlPageURL(base string) string {
 	if base == "" {
 		return ""
 	}
@@ -110,6 +125,18 @@ func (c *CitationDetail) MomlPageURL() string {
 		}
 	}
 	return base
+}
+
+// MomlPageURL constructs a Gale MOML URL linking to the specific page, routed
+// through GMU's library proxy.
+func (c *CitationDetail) MomlPageURL() string {
+	return c.momlPageURL(c.MomlVolumeURL())
+}
+
+// MomlPageURLColumbia constructs a Gale MOML URL linking to the specific page,
+// routed through Columbia University's EZproxy.
+func (c *CitationDetail) MomlPageURLColumbia() string {
+	return c.momlPageURL(c.MomlVolumeURLColumbia())
 }
 
 const citationDetailQuery = `

--- a/chambers/queries_test.go
+++ b/chambers/queries_test.go
@@ -1,0 +1,51 @@
+package main
+
+import "testing"
+
+func strptr(s string) *string { return &s }
+
+func TestMomlPageURLs(t *testing.T) {
+	productLink := "http://link.galegroup.com/apps/doc/F0103227568/MOML?sid=dhxml"
+
+	tests := []struct {
+		name        string
+		productLink *string
+		momlPage    string
+		gmu         string
+		columbia    string
+	}{
+		{
+			name:        "with page",
+			productLink: strptr(productLink),
+			momlPage:    "06870",
+			gmu:         "https://link.gale.com/apps/doc/F0103227568/MOML?u=viva_gmu&sid=dhxml&pg=687",
+			columbia:    "https://go-gale-com.ezproxy.cul.columbia.edu/apps/doc/F0103227568/MOML?sid=dhxml&pg=687",
+		},
+		{
+			name:        "no page",
+			productLink: strptr(productLink),
+			momlPage:    "",
+			gmu:         "https://link.gale.com/apps/doc/F0103227568/MOML?u=viva_gmu&sid=dhxml",
+			columbia:    "https://go-gale-com.ezproxy.cul.columbia.edu/apps/doc/F0103227568/MOML?sid=dhxml",
+		},
+		{
+			name:        "nil product link",
+			productLink: nil,
+			momlPage:    "06870",
+			gmu:         "",
+			columbia:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &CitationDetail{ProductLink: tt.productLink, MomlPage: tt.momlPage}
+			if got := c.MomlPageURL(); got != tt.gmu {
+				t.Errorf("MomlPageURL() = %q, want %q", got, tt.gmu)
+			}
+			if got := c.MomlPageURLColumbia(); got != tt.columbia {
+				t.Errorf("MomlPageURLColumbia() = %q, want %q", got, tt.columbia)
+			}
+		})
+	}
+}

--- a/chambers/templates/detail.html
+++ b/chambers/templates/detail.html
@@ -113,7 +113,7 @@ LIMIT 1</code></pre>
         <span class="label text-secondary">Title</span><span>{{if .Cite.MomlVolumeURL}}<a href="{{.Cite.MomlVolumeURL}}" target="_blank">{{ptrOr .Cite.BookTitle "&mdash;"}}</a>{{else}}{{ptrOr .Cite.BookTitle "&mdash;"}}{{end}}{{if .Cite.PubYear}} ({{deref .Cite.PubYear}}){{end}}</span>
         <span class="label text-secondary">Author</span><span>{{ptrOr .Cite.Author "&mdash;"}}</span>
         <span class="label text-secondary">Printed page</span><span>{{ptrOr .Cite.SourcePage "&mdash;"}}</span>
-        <span class="label text-secondary">Image page</span><span>{{if .Cite.MomlPageURL}}<a href="{{.Cite.MomlPageURL}}" target="_blank">{{.Cite.MomlPage}}</a>{{else}}{{.Cite.MomlPage}}{{end}}</span>
+        <span class="label text-secondary">Image page</span><span>{{.Cite.MomlPage}}{{if .Cite.MomlPageURL}} (<a href="{{.Cite.MomlPageURL}}" target="_blank">GMU</a>, <a href="{{.Cite.MomlPageURLColumbia}}" target="_blank">Columbia</a>){{end}}</span>
         <span class="label text-secondary">Treatise</span><span>{{.Cite.MomlTreatise}}</span>
     </div>
 


### PR DESCRIPTION
## Summary

Page image links to Gale's *Making of Modern Law* previously routed only through GMU's library proxy, so Columbia RAs could not open them. The **Image page** row on the citation detail page (`/cite?id=…`) now shows the page id as plain text followed by two proxy links:

```
03600 (GMU, Columbia)
```

`GMU` carries the original link; `Columbia` is the new link routing through Columbia University's EZproxy (`go-gale-com.ezproxy.cul.columbia.edu`, the base URL from Kellen on the issue).

## Changes

- **`chambers/queries.go`** — Extracted a shared `momlVolumeURL(host, userParam)` helper that rewrites the stored `productlink` host and inserts the optional Gale `u=` fragment. Added `MomlVolumeURLColumbia()` / `MomlPageURLColumbia()`; existing GMU methods are unchanged.
- **`chambers/templates/detail.html`** — Updated the Image page row to render `pageid (GMU, Columbia)`.
- **`chambers/queries_test.go`** — New table-driven test covering both proxies for the with-page, no-page, and nil-productlink cases.
- **`chambers/README.md`** — Documented the new Columbia methods.

## Note on the Columbia `u=` param

Kellen provided only the base URL, so the Columbia link omits any Gale `u=` institution code (`viva_gmu` is George Mason's VIVA code and would be wrong for Columbia; EZproxy identifies the institution at the session level). A resulting link looks like:

```
https://go-gale-com.ezproxy.cul.columbia.edu/apps/doc/F0103227568/MOML?sid=dhxml&pg=687
```

If Gale still wants an institution code through Columbia's proxy, that one value should be added to `MomlVolumeURLColumbia()`.

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)