### PR TITLE
Scope Columbia MOML links via the Gale u=columbiau param

### DIFF
--- a/chambers/README.md
+++ b/chambers/README.md
@@ -76,7 +76,7 @@ The `moml.page` and `moml.page_ocrtext` joins must include `psmid` (treatise ID)
 - `HasLink()` — true if status is any `linked_*` value
 - `IsCAP()` / `IsCodeReporter()` / `IsEnglishReports()` — which case source was matched
 - `MomlVolumeURL()` — Gale MOML URL for the volume routed through GMU's library proxy (transforms the stored `productlink` from old `link.galegroup.com` domain to `link.gale.com`, adds `u=viva_gmu`)
-- `MomlVolumeURLColumbia()` — Same volume URL routed through Columbia University's EZproxy (`go-gale-com.ezproxy.cul.columbia.edu`, no `u=` param)
+- `MomlVolumeURLColumbia()` — Same volume URL scoped to Columbia via the Gale institutional param `u=columbiau` (otherwise identical to the GMU link)
 - `MomlPageURL()` / `MomlPageURLColumbia()` — Same as the GMU/Columbia volume URLs but append `&pg=N` where N is derived from `pageid` by stripping the trailing `0` and leading `0`s (e.g., `06870` becomes `687`)
 
 ### ReporterCite.StatusClass

--- a/chambers/queries.go
+++ b/chambers/queries.go
@@ -104,9 +104,10 @@ func (c *CitationDetail) MomlVolumeURL() string {
 }
 
 // MomlVolumeURLColumbia returns a Gale MOML URL for the volume as a whole,
-// routed through Columbia University's EZproxy.
+// scoped to Columbia University via the Gale institutional u= parameter
+// (u=columbiau), the same way MomlVolumeURL scopes to GMU with u=viva_gmu.
 func (c *CitationDetail) MomlVolumeURLColumbia() string {
-	return c.momlVolumeURL("https://go-gale-com.ezproxy.cul.columbia.edu", "")
+	return c.momlVolumeURL("https://link.gale.com", "u=columbiau&")
 }
 
 // momlPageURL appends the page (pg) parameter to a Gale MOML volume URL.

--- a/chambers/queries_test.go
+++ b/chambers/queries_test.go
@@ -19,14 +19,14 @@ func TestMomlPageURLs(t *testing.T) {
 			productLink: strptr(productLink),
 			momlPage:    "06870",
 			gmu:         "https://link.gale.com/apps/doc/F0103227568/MOML?u=viva_gmu&sid=dhxml&pg=687",
-			columbia:    "https://go-gale-com.ezproxy.cul.columbia.edu/apps/doc/F0103227568/MOML?sid=dhxml&pg=687",
+			columbia:    "https://link.gale.com/apps/doc/F0103227568/MOML?u=columbiau&sid=dhxml&pg=687",
 		},
 		{
 			name:        "no page",
 			productLink: strptr(productLink),
 			momlPage:    "",
 			gmu:         "https://link.gale.com/apps/doc/F0103227568/MOML?u=viva_gmu&sid=dhxml",
-			columbia:    "https://go-gale-com.ezproxy.cul.columbia.edu/apps/doc/F0103227568/MOML?sid=dhxml",
+			columbia:    "https://link.gale.com/apps/doc/F0103227568/MOML?u=columbiau&sid=dhxml",
 		},
 		{
 			name:        "nil product link",


### PR DESCRIPTION
## What

The Columbia page-image links in Chambers' citation viewer did not open for Columbia RAs. This routes them through the Gale **institutional `u=` parameter** on plain `link.gale.com` instead — `u=columbiau`, the Columbia equivalent of GMU's `u=viva_gmu`.

Earlier attempts (EZproxy host-rewriting via `go-gale-com.ezproxy.cul.columbia.edu`, then a `resolver.library.columbia.edu/` prefix) did not work. Columbia authenticates Gale through the institutional param directly, so `MomlVolumeURLColumbia`/`MomlPageURLColumbia` now mirror the GMU links exactly, swapping only `u=viva_gmu` → `u=columbiau`.

## Example

For product link `http://link.galegroup.com/apps/doc/F0150292201/MOML?sid=dhxml`, page id `05480`:

```
https://link.gale.com/apps/doc/F0150292201/MOML?u=columbiau&sid=dhxml&pg=548
```

## Notes

A working example URL from Gale's "Bookmark" tool also carried `sid=bookmark-MOML` and an `xid` token. Those are omitted deliberately: `xid` is a per-document integrity token we can't reproduce for arbitrary documents (and doc URLs resolve without it), and `sid` is only source-tracking and does not gate access. The access-critical change is `u=columbiau`.

## Testing

`gofmt`, `go vet ./chambers/`, and `go test ./chambers/` all pass; the `TestMomlPageURLs` expectations are updated. The chambers README is updated to describe the new scheme.

Closes #206