### PR TITLE
Chambers: browse treatises, pages, cases, and normalized citations

### DIFF
--- a/chambers/browse_handlers.go
+++ b/chambers/browse_handlers.go
@@ -1,0 +1,286 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"html/template"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Page sizes for the browse lists.
+const (
+	treatisesPageSize  = 100
+	casesPageSize      = 100
+	normalizedPageSize = 200
+)
+
+// Pagination holds the prev/next state for a paginated list, preserving the
+// request's other query parameters.
+type Pagination struct {
+	Page    int
+	HasPrev bool
+	HasNext bool
+	PrevURL string
+	NextURL string
+}
+
+// buildPagination derives prev/next links for the current request. HasNext is a
+// heuristic: a full page of rows implies there may be more. gotRows is how many
+// rows this page returned, pageSize the requested limit.
+func buildPagination(r *http.Request, page, gotRows, pageSize int) Pagination {
+	p := Pagination{Page: page, HasPrev: page > 1, HasNext: gotRows >= pageSize}
+	if p.HasPrev {
+		p.PrevURL = pageURL(r, page-1)
+	}
+	if p.HasNext {
+		p.NextURL = pageURL(r, page+1)
+	}
+	return p
+}
+
+// pageURL rewrites the request URL with a new page number, keeping other params.
+func pageURL(r *http.Request, page int) string {
+	q := r.URL.Query()
+	q.Set("page", strconv.Itoa(page))
+	return r.URL.Path + "?" + q.Encode()
+}
+
+// handleTreatises renders the U.S. treatises browse list.
+func handleTreatises(w http.ResponseWriter, r *http.Request, tmpl *template.Template) {
+	slog.Debug("handling request", "path", r.URL.Path, "handler", "treatises")
+	q := strings.TrimSpace(r.URL.Query().Get("q"))
+	sort := NormalizeTreatiseSort(r.URL.Query().Get("sort"))
+	page := parsePageParam(r.URL.Query().Get("page"))
+
+	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+	defer cancel()
+
+	items, err := getUSTreatises(ctx, pool, q, sort, treatisesPageSize, (page-1)*treatisesPageSize)
+	if err != nil {
+		slog.Error("error querying treatises", "error", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	slog.Debug("rendering treatises", "count", len(items), "page", page)
+	data := struct {
+		Q     string
+		Sort  string
+		Items []TreatiseListItem
+		Nav   Pagination
+	}{Q: q, Sort: sort, Items: items, Nav: buildPagination(r, page, len(items), treatisesPageSize)}
+	if err := tmpl.ExecuteTemplate(w, "baseof", data); err != nil {
+		slog.Error("error rendering treatises", "error", err)
+	}
+}
+
+// handleTreatise renders one treatise work: its volumes and citation-bearing pages.
+func handleTreatise(w http.ResponseWriter, r *http.Request, tmpl *template.Template) {
+	slog.Debug("handling request", "path", r.URL.Path, "handler", "treatise")
+	id := r.URL.Query().Get("id")
+	if id == "" {
+		http.Redirect(w, r, "/treatises", http.StatusFound)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+	defer cancel()
+
+	d, err := getTreatiseDetail(ctx, pool, id)
+	if err != nil {
+		slog.Error("error querying treatise", "id", id, "error", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+	if d == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	slog.Debug("rendering treatise", "id", id, "volumes", len(d.Volumes))
+	data := struct{ T *TreatiseDetail }{T: d}
+	if err := tmpl.ExecuteTemplate(w, "baseof", data); err != nil {
+		slog.Error("error rendering treatise", "id", id, "error", err)
+	}
+}
+
+// handleTreatisePage renders the citations detected on one treatise page.
+func handleTreatisePage(w http.ResponseWriter, r *http.Request, tmpl *template.Template) {
+	slog.Debug("handling request", "path", r.URL.Path, "handler", "treatise-page")
+	q := r.URL.Query()
+	psmid := q.Get("psmid")
+	pageid := q.Get("pageid")
+	if psmid == "" || pageid == "" {
+		http.Redirect(w, r, "/treatises", http.StatusFound)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+	defer cancel()
+
+	v, err := getTreatisePage(ctx, pool, psmid, pageid)
+	if err != nil {
+		slog.Error("error querying treatise page", "psmid", psmid, "pageid", pageid, "error", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+	if v == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	slog.Debug("rendering treatise page", "psmid", psmid, "pageid", pageid, "citations", len(v.Citations))
+	data := struct{ Page *TreatisePageView }{Page: v}
+	if err := tmpl.ExecuteTemplate(w, "baseof", data); err != nil {
+		slog.Error("error rendering treatise page", "psmid", psmid, "pageid", pageid, "error", err)
+	}
+}
+
+// handlePageText serves a treatise page's OCR text as JSON, on demand.
+func handlePageText(w http.ResponseWriter, r *http.Request) {
+	slog.Debug("handling request", "path", r.URL.Path, "handler", "page-text")
+	q := r.URL.Query()
+	psmid := q.Get("psmid")
+	pageid := q.Get("pageid")
+	if psmid == "" || pageid == "" {
+		http.Error(w, "psmid and pageid are required", http.StatusBadRequest)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+
+	text, err := getPageOCRText(ctx, pool, psmid, pageid)
+	if err != nil {
+		slog.Error("error querying page OCR text", "psmid", psmid, "pageid", pageid, "error", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Cache-Control", "max-age=3600")
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(struct {
+		Text string `json:"text"`
+	}{Text: text}); err != nil {
+		slog.Error("error encoding page text JSON", "error", err)
+	}
+}
+
+// handleCases renders the cases browse list, ranked by treatise-page citations.
+func handleCases(w http.ResponseWriter, r *http.Request, tmpl *template.Template) {
+	slog.Debug("handling request", "path", r.URL.Path, "handler", "cases")
+	page := parsePageParam(r.URL.Query().Get("page"))
+
+	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+	defer cancel()
+
+	items, err := getTopCases(ctx, pool, casesPageSize, (page-1)*casesPageSize)
+	if err != nil {
+		slog.Error("error querying cases", "error", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	slog.Debug("rendering cases", "count", len(items), "page", page)
+	data := struct {
+		Items []CaseListItem
+		Nav   Pagination
+	}{Items: items, Nav: buildPagination(r, page, len(items), casesPageSize)}
+	if err := tmpl.ExecuteTemplate(w, "baseof", data); err != nil {
+		slog.Error("error rendering cases", "error", err)
+	}
+}
+
+// handleCase renders one case and the treatise pages that cite it.
+func handleCase(w http.ResponseWriter, r *http.Request, tmpl *template.Template) {
+	slog.Debug("handling request", "path", r.URL.Path, "handler", "case")
+	q := r.URL.Query()
+	source := q.Get("source")
+	id := q.Get("id")
+	if !ValidCaseSource(source) || id == "" {
+		http.Redirect(w, r, "/cases", http.StatusFound)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+	defer cancel()
+
+	d, err := getCaseDetail(ctx, pool, source, id)
+	if err != nil {
+		slog.Error("error querying case", "source", source, "id", id, "error", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	slog.Debug("rendering case", "source", source, "id", id, "pages", d.PageCount)
+	data := struct {
+		Case      *CaseDetail
+		Truncated bool
+	}{Case: d, Truncated: d.PageCount >= caseDetailCitingLimit}
+	if err := tmpl.ExecuteTemplate(w, "baseof", data); err != nil {
+		slog.Error("error rendering case", "source", source, "id", id, "error", err)
+	}
+}
+
+// handleNormalized renders the normalized-citations browse list.
+func handleNormalized(w http.ResponseWriter, r *http.Request, tmpl *template.Template) {
+	slog.Debug("handling request", "path", r.URL.Path, "handler", "normalized")
+	query := strings.TrimSpace(r.URL.Query().Get("q"))
+	page := parsePageParam(r.URL.Query().Get("page"))
+
+	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+	defer cancel()
+
+	items, err := getTopNormalized(ctx, pool, query, normalizedPageSize, (page-1)*normalizedPageSize)
+	if err != nil {
+		slog.Error("error querying normalized citations", "error", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	slog.Debug("rendering normalized citations", "count", len(items), "page", page)
+	data := struct {
+		Q     string
+		Items []NormalizedListItem
+		Nav   Pagination
+	}{Q: query, Items: items, Nav: buildPagination(r, page, len(items), normalizedPageSize)}
+	if err := tmpl.ExecuteTemplate(w, "baseof", data); err != nil {
+		slog.Error("error rendering normalized citations", "error", err)
+	}
+}
+
+// handleNormalizedCite renders the treatise-page instances of one normalized citation.
+func handleNormalizedCite(w http.ResponseWriter, r *http.Request, tmpl *template.Template) {
+	slog.Debug("handling request", "path", r.URL.Path, "handler", "normalized-cite")
+	cite := r.URL.Query().Get("c")
+	if cite == "" {
+		http.Redirect(w, r, "/normalized", http.StatusFound)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+	defer cancel()
+
+	cites, total, err := getNormalizedCites(ctx, pool, cite)
+	if err != nil {
+		slog.Error("error querying normalized citation instances", "cite", cite, "error", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	slog.Debug("rendering normalized cite", "cite", cite, "shown", len(cites), "total", total)
+	data := struct {
+		Cite      string
+		Cites     []NormalizedCite
+		Shown     int
+		Total     int
+		Truncated bool
+	}{Cite: cite, Cites: cites, Shown: len(cites), Total: total, Truncated: total > len(cites)}
+	if err := tmpl.ExecuteTemplate(w, "baseof", data); err != nil {
+		slog.Error("error rendering normalized cite", "cite", cite, "error", err)
+	}
+}

--- a/chambers/browse_queries.go
+++ b/chambers/browse_queries.go
@@ -32,6 +32,36 @@ func isLinked(status *string) bool {
 	return status != nil && strings.HasPrefix(*status, "linked_")
 }
 
+// momlVolumeLink rewrites a stored Gale productlink to the given host and
+// inserts the institutional user param (e.g. "u=viva_gmu&"), yielding a MOML
+// volume URL routed through that institution's proxy. Returns "" when there is
+// no productlink.
+func momlVolumeLink(productLink *string, host, userParam string) string {
+	if productLink == nil {
+		return ""
+	}
+	u := *productLink
+	u = strings.Replace(u, "http://link.galegroup.com", host, 1)
+	u = strings.Replace(u, "?sid=dhxml", "?"+userParam+"sid=dhxml", 1)
+	return u
+}
+
+// momlPageLink appends the page (pg) parameter to a Gale MOML volume URL. The pg
+// value is the pageid with its trailing and leading zeros stripped (e.g.
+// "06870" -> 687). Returns "" when base is empty.
+func momlPageLink(base, pageID string) string {
+	if base == "" {
+		return ""
+	}
+	if pageID != "" {
+		pg := strings.TrimLeft(strings.TrimRight(pageID, "0"), "0")
+		if pg != "" {
+			base += "&pg=" + pg
+		}
+	}
+	return base
+}
+
 // chipClass maps a link status to the colour class for a citation chip:
 // linked (green), no_match (red), skipped_junk (gray — OCR noise, not a real
 // citation), and everything else not attempted (amber — reporter not
@@ -344,13 +374,24 @@ func getTreatiseDetail(ctx context.Context, db *pgxpool.Pool, biblioID string) (
 // TreatisePageView is one treatise page with its OCR text and the citations
 // detected on it.
 type TreatisePageView struct {
-	PSMID      string
-	PageID     string
-	BiblioID   *string
-	Title      *string
-	SourcePage string
-	OCRText    string
-	Citations  []PageCitation
+	PSMID       string
+	PageID      string
+	BiblioID    *string
+	Title       *string
+	SourcePage  string
+	ProductLink *string
+	OCRText     string
+	Citations   []PageCitation
+}
+
+// MomlPageURLGMU links to this page on Gale MOML through GMU's library proxy.
+func (v *TreatisePageView) MomlPageURLGMU() string {
+	return momlPageLink(momlVolumeLink(v.ProductLink, "https://link.gale.com", "u=viva_gmu&"), v.PageID)
+}
+
+// MomlPageURLColumbia links to this page on Gale MOML through Columbia's proxy.
+func (v *TreatisePageView) MomlPageURLColumbia() string {
+	return momlPageLink(momlVolumeLink(v.ProductLink, "https://link.gale.com", "u=columbiau&"), v.PageID)
 }
 
 // HighlightedOCR returns the page's OCR text with each detected citation's raw
@@ -437,23 +478,25 @@ func getTreatisePage(ctx context.Context, db *pgxpool.Pool, psmid, pageid string
 	slog.Debug("querying treatise page", "psmid", psmid, "pageid", pageid)
 	view := &TreatisePageView{PSMID: psmid, PageID: pageid, SourcePage: pageid}
 
-	// Header: treatise title, bibliographicid, source page number.
+	// Header: treatise title, bibliographicid, productlink, source page number.
 	var title *string
 	var biblioID *string
+	var productLink *string
 	var sourcePage *string
 	err := db.QueryRow(ctx, `
-		SELECT bc.displaytitle, bi.bibliographicid,
+		SELECT bc.displaytitle, bi.bibliographicid, bi.productlink,
 		       (SELECT NULLIF(mp.sourcepage, '') FROM moml.page mp
 		         WHERE mp.psmid = $1 AND mp.pageid = $2)
 		FROM moml.book_info bi
 		LEFT JOIN moml.book_citation bc ON bc.psmid = bi.psmid
 		WHERE bi.psmid = $1
-	`, psmid, pageid).Scan(&title, &biblioID, &sourcePage)
+	`, psmid, pageid).Scan(&title, &biblioID, &productLink, &sourcePage)
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return nil, fmt.Errorf("querying page header: %w", err)
 	}
 	view.Title = title
 	view.BiblioID = biblioID
+	view.ProductLink = productLink
 	if sourcePage != nil && *sourcePage != "" {
 		view.SourcePage = *sourcePage
 	}

--- a/chambers/browse_queries.go
+++ b/chambers/browse_queries.go
@@ -52,6 +52,24 @@ func (t *TreatiseListItem) DetailURL() string {
 	return "/treatise?id=" + url.QueryEscape(t.BiblioID)
 }
 
+// LinkedPct is the share of the work's citations that are linked, as a rounded
+// percentage (0 when the work has no citations). Every citation is either
+// linked or not, so LinkedPct + NotLinkedPct == 100 whenever N > 0.
+func (t *TreatiseListItem) LinkedPct() int {
+	if t.N == 0 {
+		return 0
+	}
+	return (t.Linked*100 + t.N/2) / t.N
+}
+
+// NotLinkedPct is the share of the work's citations that are not linked.
+func (t *TreatiseListItem) NotLinkedPct() int {
+	if t.N == 0 {
+		return 0
+	}
+	return 100 - t.LinkedPct()
+}
+
 // treatiseSorts maps a sort key to its ORDER BY expression. Values are fixed
 // literals (never user input) so they are safe to interpolate.
 var treatiseSorts = map[string]string{

--- a/chambers/browse_queries.go
+++ b/chambers/browse_queries.go
@@ -32,6 +32,26 @@ func isLinked(status *string) bool {
 	return status != nil && strings.HasPrefix(*status, "linked_")
 }
 
+// chipClass maps a link status to the colour class for a citation chip:
+// linked (green), no_match (red), skipped_junk (gray — OCR noise, not a real
+// citation), and everything else not attempted (amber — reporter not
+// whitelisted, or unprocessed).
+func chipClass(status *string) string {
+	if status == nil {
+		return "cite-skip"
+	}
+	switch s := *status; {
+	case strings.HasPrefix(s, "linked_"):
+		return "cite-linked"
+	case s == "no_match":
+		return "cite-nomatch"
+	case s == "skipped_junk":
+		return "cite-junk"
+	default:
+		return "cite-skip"
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Treatises: browse list
 // ---------------------------------------------------------------------------
@@ -390,6 +410,9 @@ type PageCitation struct {
 
 // StatusClass reuses the shared linked/not-linked colour classes.
 func (c *PageCitation) StatusClass() string { return statusClass(c.Status) }
+
+// ChipClass returns the status-aware colour class for the citation chip.
+func (c *PageCitation) ChipClass() string { return chipClass(c.Status) }
 
 // IsLinked reports whether the citation resolved to a case.
 func (c *PageCitation) IsLinked() bool { return isLinked(c.Status) }
@@ -829,6 +852,9 @@ type NormalizedCite struct {
 
 // StatusClass reuses the shared linked/not-linked colour classes.
 func (c *NormalizedCite) StatusClass() string { return statusClass(c.Status) }
+
+// ChipClass returns the status-aware colour class for the citation chip.
+func (c *NormalizedCite) ChipClass() string { return chipClass(c.Status) }
 
 // IsLinked reports whether the instance resolved to a case.
 func (c *NormalizedCite) IsLinked() bool { return isLinked(c.Status) }

--- a/chambers/browse_queries.go
+++ b/chambers/browse_queries.go
@@ -1,0 +1,819 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
+)
+
+// cleanRaw collapses the embedded newlines that detected citations often carry
+// (OCR line breaks) into spaces, matching how the reporter/unmatched pages
+// display raw citation text.
+func cleanRaw(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	return s
+}
+
+// isLinked reports whether a link status counts as "linked" (resolved to a
+// case in any source). Anything else — no_match, skipped_*, or no row — is
+// "not linked".
+func isLinked(status *string) bool {
+	return status != nil && strings.HasPrefix(*status, "linked_")
+}
+
+// ---------------------------------------------------------------------------
+// Treatises: browse list
+// ---------------------------------------------------------------------------
+
+// TreatiseListItem is one U.S. treatise work (bibliographicid) on the
+// /treatises list, with its summed citation counts across all its volumes.
+type TreatiseListItem struct {
+	BiblioID  string
+	Title     string
+	Author    *string
+	Year      *int
+	Vols      int
+	N         int
+	Linked    int
+	NotLinked int
+}
+
+// DetailURL links to the work's detail page.
+func (t *TreatiseListItem) DetailURL() string {
+	return "/treatise?id=" + url.QueryEscape(t.BiblioID)
+}
+
+// treatiseSorts maps a sort key to its ORDER BY expression. Values are fixed
+// literals (never user input) so they are safe to interpolate.
+var treatiseSorts = map[string]string{
+	"cites": "COALESCE(c.n, 0) DESC, t.title",
+	"year":  "t.year NULLS LAST, t.title",
+	"title": "t.title, t.year",
+}
+
+// NormalizeTreatiseSort returns sort if known, else "cites".
+func NormalizeTreatiseSort(sort string) string {
+	if _, ok := treatiseSorts[sort]; ok {
+		return sort
+	}
+	return "cites"
+}
+
+// getUSTreatises returns a page of U.S. treatise works, optionally filtered by a
+// title substring, sorted by sort ("cites"|"year"|"title"). Citation totals are
+// summed from the treatise_citation_counts materialized view over each work's
+// volumes; the view is empty until refreshed, in which case counts read zero.
+func getUSTreatises(ctx context.Context, db *pgxpool.Pool, q, sort string, limit, offset int) ([]TreatiseListItem, error) {
+	order := treatiseSorts[NormalizeTreatiseSort(sort)]
+	slog.Debug("querying US treatises", "q", q, "sort", sort, "limit", limit, "offset", offset)
+	query := `
+	WITH t AS (
+		SELECT bibliographicid, year, title, vols, psmid
+		FROM moml.us_treatises
+		WHERE ($1 = '' OR title ILIKE '%' || $1 || '%')
+	),
+	c AS (
+		SELECT t.bibliographicid AS id,
+		       sum(tcc.n)          AS n,
+		       sum(tcc.linked)     AS linked,
+		       sum(tcc.not_linked) AS not_linked
+		FROM t
+		JOIN moml_citations.treatise_citation_counts tcc
+		  ON tcc.moml_treatise = ANY(t.psmid)
+		GROUP BY t.bibliographicid
+	)
+	SELECT t.bibliographicid, t.title, t.year, t.vols,
+	       (SELECT bc.author_composed FROM moml.book_citation bc
+	         WHERE bc.psmid = t.psmid[1]) AS author,
+	       COALESCE(c.n, 0), COALESCE(c.linked, 0), COALESCE(c.not_linked, 0)
+	FROM t LEFT JOIN c ON c.id = t.bibliographicid
+	ORDER BY ` + order + `
+	LIMIT $2 OFFSET $3
+	`
+	rows, err := db.Query(ctx, query, q, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("querying US treatises: %w", err)
+	}
+	defer rows.Close()
+
+	var results []TreatiseListItem
+	for rows.Next() {
+		var t TreatiseListItem
+		if err := rows.Scan(&t.BiblioID, &t.Title, &t.Year, &t.Vols, &t.Author, &t.N, &t.Linked, &t.NotLinked); err != nil {
+			return nil, fmt.Errorf("scanning treatise: %w", err)
+		}
+		results = append(results, t)
+	}
+	slog.Debug("fetched US treatises", "count", len(results))
+	return results, rows.Err()
+}
+
+// ---------------------------------------------------------------------------
+// Treatises: work detail (volumes -> pages)
+// ---------------------------------------------------------------------------
+
+// TreatiseDetail is a treatise work with its volumes and the pages that carry
+// citations.
+type TreatiseDetail struct {
+	BiblioID string
+	Title    string
+	Author   *string
+	Year     *int
+	Subjects []string
+	Volumes  []TreatiseVolume
+}
+
+// Vols is the number of volumes in the work.
+func (t *TreatiseDetail) Vols() int { return len(t.Volumes) }
+
+// MultiVolume reports whether the work has more than one volume.
+func (t *TreatiseDetail) MultiVolume() bool { return len(t.Volumes) > 1 }
+
+// TreatiseVolume is one physical volume (psmid) of a work and its pages that
+// have detected citations.
+type TreatiseVolume struct {
+	PSMID       string
+	VolumeLabel string
+	Title       string
+	Pages       []TreatisePageRow
+}
+
+// TreatisePageRow is one page of a treatise volume with citation counts.
+type TreatisePageRow struct {
+	PSMID      string
+	PageID     string
+	SourcePage string
+	Cites      int
+	Linked     int
+	NotLinked  int
+}
+
+// URL links to the page's citation detail.
+func (p *TreatisePageRow) URL() string {
+	v := url.Values{}
+	v.Set("psmid", p.PSMID)
+	v.Set("pageid", p.PageID)
+	return "/treatise/page?" + v.Encode()
+}
+
+// getTreatiseDetail returns one work's volumes and citation-bearing pages. It
+// runs three small queries (volumes, subjects, pages) keyed off the work's
+// bibliographicid; the page query uses the citations_unlinked index on
+// moml_treatise, so it stays fast and does not depend on any materialized view.
+// Returns (nil, nil) when the bibliographicid matches no volumes.
+func getTreatiseDetail(ctx context.Context, db *pgxpool.Pool, biblioID string) (*TreatiseDetail, error) {
+	slog.Debug("querying treatise detail", "biblioid", biblioID)
+
+	// Volumes, ordered by psmid so multi-volume works read v.1, v.2, ...
+	volRows, err := db.Query(ctx, `
+		SELECT bi.psmid, bi.year, bc.currentvolume, bc.displaytitle, bc.author_composed
+		FROM moml.book_info bi
+		LEFT JOIN moml.book_citation bc ON bc.psmid = bi.psmid
+		WHERE bi.bibliographicid = $1
+		ORDER BY bi.psmid
+	`, biblioID)
+	if err != nil {
+		return nil, fmt.Errorf("querying treatise volumes: %w", err)
+	}
+	defer volRows.Close()
+
+	d := &TreatiseDetail{BiblioID: biblioID}
+	var psmids []string
+	volIndex := make(map[string]*TreatiseVolume)
+	for volRows.Next() {
+		var psmid string
+		var year *int
+		var curVol, title, author *string
+		if err := volRows.Scan(&psmid, &year, &curVol, &title, &author); err != nil {
+			return nil, fmt.Errorf("scanning treatise volume: %w", err)
+		}
+		v := TreatiseVolume{PSMID: psmid}
+		if curVol != nil {
+			v.VolumeLabel = *curVol
+		}
+		if title != nil {
+			v.Title = *title
+			if d.Title == "" {
+				d.Title = *title
+			}
+		}
+		if author != nil && *author != "" && d.Author == nil {
+			d.Author = author
+		}
+		if year != nil && (d.Year == nil || *year < *d.Year) {
+			d.Year = year
+		}
+		d.Volumes = append(d.Volumes, v)
+		volIndex[psmid] = &d.Volumes[len(d.Volumes)-1]
+		psmids = append(psmids, psmid)
+	}
+	if err := volRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating treatise volumes: %w", err)
+	}
+	if len(psmids) == 0 {
+		return nil, nil
+	}
+
+	// Subjects across the work's volumes.
+	subjRows, err := db.Query(ctx, `
+		SELECT DISTINCT subject FROM moml.book_subject
+		WHERE psmid = ANY($1::text[]) AND subject IS NOT NULL AND subject <> ''
+		ORDER BY subject
+	`, psmids)
+	if err != nil {
+		return nil, fmt.Errorf("querying treatise subjects: %w", err)
+	}
+	defer subjRows.Close()
+	for subjRows.Next() {
+		var s string
+		if err := subjRows.Scan(&s); err != nil {
+			return nil, fmt.Errorf("scanning subject: %w", err)
+		}
+		d.Subjects = append(d.Subjects, s)
+	}
+	if err := subjRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating subjects: %w", err)
+	}
+
+	// Pages that have citations, with linked/not-linked counts, grouped into
+	// their volume in Go. Index scan on citations_unlinked.moml_treatise.
+	pageRows, err := db.Query(ctx, `
+		SELECT cu.moml_treatise, cu.moml_page,
+		       COALESCE(NULLIF(mp.sourcepage, ''), cu.moml_page) AS sourcepage,
+		       count(*) AS cites,
+		       count(*) FILTER (WHERE cl.status LIKE 'linked_%') AS linked,
+		       count(*) FILTER (WHERE cl.status IS NULL OR cl.status NOT LIKE 'linked_%') AS not_linked
+		FROM moml_citations.citations_unlinked cu
+		LEFT JOIN moml_citations.citation_links cl ON cl.citation_id = cu.id
+		LEFT JOIN moml.page mp ON mp.psmid = cu.moml_treatise AND mp.pageid = cu.moml_page
+		WHERE cu.moml_treatise = ANY($1::text[])
+		GROUP BY cu.moml_treatise, cu.moml_page, sourcepage
+		ORDER BY cu.moml_treatise, cu.moml_page
+	`, psmids)
+	if err != nil {
+		return nil, fmt.Errorf("querying treatise pages: %w", err)
+	}
+	defer pageRows.Close()
+	for pageRows.Next() {
+		var p TreatisePageRow
+		if err := pageRows.Scan(&p.PSMID, &p.PageID, &p.SourcePage, &p.Cites, &p.Linked, &p.NotLinked); err != nil {
+			return nil, fmt.Errorf("scanning treatise page: %w", err)
+		}
+		if v, ok := volIndex[p.PSMID]; ok {
+			v.Pages = append(v.Pages, p)
+		}
+	}
+	if err := pageRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating treatise pages: %w", err)
+	}
+
+	slog.Debug("fetched treatise detail", "biblioid", biblioID, "volumes", len(d.Volumes))
+	return d, nil
+}
+
+// ---------------------------------------------------------------------------
+// Treatise page: the citations detected on one page
+// ---------------------------------------------------------------------------
+
+// TreatisePageView is one treatise page with the citations detected on it.
+type TreatisePageView struct {
+	PSMID      string
+	PageID     string
+	BiblioID   *string
+	Title      *string
+	SourcePage string
+	Citations  []PageCitation
+}
+
+// TreatiseURL links back to the parent work, when known.
+func (v *TreatisePageView) TreatiseURL() string {
+	if v.BiblioID == nil {
+		return ""
+	}
+	return "/treatise?id=" + url.QueryEscape(*v.BiblioID)
+}
+
+// LinkedCount returns how many of the page's citations are linked.
+func (v *TreatisePageView) LinkedCount() int {
+	n := 0
+	for i := range v.Citations {
+		if v.Citations[i].IsLinked() {
+			n++
+		}
+	}
+	return n
+}
+
+// PageCitation is one detected citation on a treatise page, with its link
+// status and, when linked, the case it resolved to.
+type PageCitation struct {
+	ID       uuid.UUID
+	Raw      string
+	Status   *string
+	Source   *string // "cap" | "er" | "code" when linked
+	CaseID   *string
+	CaseName *string
+}
+
+// StatusClass reuses the shared linked/not-linked colour classes.
+func (c *PageCitation) StatusClass() string { return statusClass(c.Status) }
+
+// IsLinked reports whether the citation resolved to a case.
+func (c *PageCitation) IsLinked() bool { return isLinked(c.Status) }
+
+// CiteURL links to the existing per-citation detail page.
+func (c *PageCitation) CiteURL() string { return "/cite?id=" + c.ID.String() }
+
+// CaseURL links to the case detail page, when linked.
+func (c *PageCitation) CaseURL() string {
+	if c.Source == nil || c.CaseID == nil {
+		return ""
+	}
+	v := url.Values{}
+	v.Set("source", *c.Source)
+	v.Set("id", *c.CaseID)
+	return "/case?" + v.Encode()
+}
+
+// getTreatisePage returns one page's header and the citations on it. Returns
+// (nil, nil) when the (psmid, pageid) has no citations and no page record.
+func getTreatisePage(ctx context.Context, db *pgxpool.Pool, psmid, pageid string) (*TreatisePageView, error) {
+	slog.Debug("querying treatise page", "psmid", psmid, "pageid", pageid)
+	view := &TreatisePageView{PSMID: psmid, PageID: pageid, SourcePage: pageid}
+
+	// Header: treatise title, bibliographicid, source page number.
+	var title *string
+	var biblioID *string
+	var sourcePage *string
+	err := db.QueryRow(ctx, `
+		SELECT bc.displaytitle, bi.bibliographicid,
+		       (SELECT NULLIF(mp.sourcepage, '') FROM moml.page mp
+		         WHERE mp.psmid = $1 AND mp.pageid = $2)
+		FROM moml.book_info bi
+		LEFT JOIN moml.book_citation bc ON bc.psmid = bi.psmid
+		WHERE bi.psmid = $1
+	`, psmid, pageid).Scan(&title, &biblioID, &sourcePage)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return nil, fmt.Errorf("querying page header: %w", err)
+	}
+	view.Title = title
+	view.BiblioID = biblioID
+	if sourcePage != nil && *sourcePage != "" {
+		view.SourcePage = *sourcePage
+	}
+
+	// Citations on the page.
+	rows, err := db.Query(ctx, `
+		SELECT cu.id, cu.raw, cl.status,
+		       CASE WHEN cl.cap_case_id IS NOT NULL THEN 'cap'
+		            WHEN cl.er_case_id IS NOT NULL THEN 'er'
+		            WHEN cl.code_reporter_id IS NOT NULL THEN 'code' END AS source,
+		       COALESCE(cl.cap_case_id::text, cl.er_case_id, cl.code_reporter_id::text) AS case_id,
+		       COALESCE(cc.name_abbreviation, er.er_name, code.name) AS case_name
+		FROM moml_citations.citations_unlinked cu
+		LEFT JOIN moml_citations.citation_links cl ON cl.citation_id = cu.id
+		LEFT JOIN cap.cases cc ON cc.id = cl.cap_case_id
+		LEFT JOIN english_reports.cases er ON er.id = cl.er_case_id
+		LEFT JOIN legalhist.code_reporter code ON code.id = cl.code_reporter_id
+		WHERE cu.moml_treatise = $1 AND cu.moml_page = $2
+		ORDER BY cl.status LIKE 'linked_%' DESC, cu.raw
+	`, psmid, pageid)
+	if err != nil {
+		return nil, fmt.Errorf("querying page citations: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var c PageCitation
+		if err := rows.Scan(&c.ID, &c.Raw, &c.Status, &c.Source, &c.CaseID, &c.CaseName); err != nil {
+			return nil, fmt.Errorf("scanning page citation: %w", err)
+		}
+		c.Raw = cleanRaw(c.Raw)
+		view.Citations = append(view.Citations, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating page citations: %w", err)
+	}
+	if len(view.Citations) == 0 && view.Title == nil {
+		return nil, nil
+	}
+	slog.Debug("fetched treatise page", "psmid", psmid, "pageid", pageid, "citations", len(view.Citations))
+	return view, nil
+}
+
+// getPageOCRText returns the OCR text for one treatise page, loaded on demand by
+// the "Load OCR text" button rather than with the page itself.
+func getPageOCRText(ctx context.Context, db *pgxpool.Pool, psmid, pageid string) (string, error) {
+	slog.Debug("querying page OCR text", "psmid", psmid, "pageid", pageid)
+	var text *string
+	err := db.QueryRow(ctx, `
+		SELECT ocrtext FROM moml.page_ocrtext WHERE psmid = $1 AND pageid = $2
+	`, psmid, pageid).Scan(&text)
+	if err != nil {
+		return "", fmt.Errorf("querying page OCR text: %w", err)
+	}
+	if text == nil {
+		return "", nil
+	}
+	return *text, nil
+}
+
+// ---------------------------------------------------------------------------
+// Cases: browse list ranked by treatise-page citations
+// ---------------------------------------------------------------------------
+
+// caseSourceLabels maps the source code stored in case_citation_counts to a
+// short human label.
+var caseSourceLabels = map[string]string{
+	"cap":  "CAP",
+	"er":   "Eng. Rep.",
+	"code": "Code rep.",
+}
+
+// CaseListItem is one cited case on the /cases ranking.
+type CaseListItem struct {
+	Source    string
+	CaseID    string
+	PageCount int
+	CiteCount int
+	Name      *string
+	Year      *int
+	Court     *string
+	URL       *string // external link (CAP frontend), when available
+}
+
+// SourceLabel returns the short human label for the case's source.
+func (c *CaseListItem) SourceLabel() string {
+	if l, ok := caseSourceLabels[c.Source]; ok {
+		return l
+	}
+	return c.Source
+}
+
+// DetailURL links to the case detail page.
+func (c *CaseListItem) DetailURL() string {
+	v := url.Values{}
+	v.Set("source", c.Source)
+	v.Set("id", c.CaseID)
+	return "/case?" + v.Encode()
+}
+
+// getTopCases returns a page of cited cases ranked by the number of distinct
+// treatise pages that cite them, joining each matview row to its source table.
+func getTopCases(ctx context.Context, db *pgxpool.Pool, limit, offset int) ([]CaseListItem, error) {
+	slog.Debug("querying top cases", "limit", limit, "offset", offset)
+	query := `
+	WITH top AS (
+		SELECT source, case_id, page_count, cite_count,
+		       CASE WHEN source IN ('cap', 'code') THEN case_id::bigint END AS num_id
+		FROM moml_citations.case_citation_counts
+		ORDER BY page_count DESC, source, case_id
+		LIMIT $1 OFFSET $2
+	)
+	SELECT t.source, t.case_id, t.page_count, t.cite_count,
+	       COALESCE(cc.name_abbreviation, er.er_name, code.name) AS name,
+	       COALESCE(cc.decision_year, er.er_year, code.decision_year) AS year,
+	       COALESCE(ct.name, er.court, code.court_name) AS court,
+	       cc.frontend_url
+	FROM top t
+	LEFT JOIN cap.cases cc ON t.source = 'cap' AND cc.id = t.num_id
+	LEFT JOIN cap.courts ct ON ct.id = cc.court
+	LEFT JOIN english_reports.cases er ON t.source = 'er' AND er.id = t.case_id
+	LEFT JOIN legalhist.code_reporter code ON t.source = 'code' AND code.id = t.num_id
+	ORDER BY t.page_count DESC, t.source, t.case_id
+	`
+	rows, err := db.Query(ctx, query, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("querying top cases: %w", err)
+	}
+	defer rows.Close()
+
+	var results []CaseListItem
+	for rows.Next() {
+		var c CaseListItem
+		if err := rows.Scan(&c.Source, &c.CaseID, &c.PageCount, &c.CiteCount, &c.Name, &c.Year, &c.Court, &c.URL); err != nil {
+			return nil, fmt.Errorf("scanning case: %w", err)
+		}
+		results = append(results, c)
+	}
+	slog.Debug("fetched top cases", "count", len(results))
+	return results, rows.Err()
+}
+
+// ---------------------------------------------------------------------------
+// Cases: case detail (the treatise pages that cite a case)
+// ---------------------------------------------------------------------------
+
+// CaseDetail is one case with the treatise pages that cite it.
+type CaseDetail struct {
+	Source    string
+	CaseID    string
+	Name      *string
+	Year      *int
+	Court     *string
+	Citation  *string
+	URL       *string // external link, when available
+	PageCount int
+	Pages     []CitingPage
+}
+
+// SourceLabel returns the short human label for the case's source.
+func (c *CaseDetail) SourceLabel() string {
+	if l, ok := caseSourceLabels[c.Source]; ok {
+		return l
+	}
+	return c.Source
+}
+
+// CitingPage is one treatise page that cites a case.
+type CitingPage struct {
+	PSMID      string
+	PageID     string
+	BiblioID   *string
+	Treatise   *string
+	SourcePage string
+	Cites      int
+}
+
+// PageURL links to the treatise page's citation detail.
+func (p *CitingPage) PageURL() string {
+	v := url.Values{}
+	v.Set("psmid", p.PSMID)
+	v.Set("pageid", p.PageID)
+	return "/treatise/page?" + v.Encode()
+}
+
+// TreatiseURL links to the parent work, when known.
+func (p *CitingPage) TreatiseURL() string {
+	if p.BiblioID == nil {
+		return ""
+	}
+	return "/treatise?id=" + url.QueryEscape(*p.BiblioID)
+}
+
+// caseLinkColumns maps a case source to the citation_links column holding its id.
+// Values are fixed literals, never user input.
+var caseLinkColumns = map[string]string{
+	"cap":  "cap_case_id",
+	"er":   "er_case_id",
+	"code": "code_reporter_id",
+}
+
+// caseLinkStatuses maps a case source to the link status that selects it.
+var caseLinkStatuses = map[string]string{
+	"cap":  "linked_cap",
+	"er":   "linked_english_reports",
+	"code": "linked_code_reporter",
+}
+
+// ValidCaseSource reports whether source is one of the three known sources.
+func ValidCaseSource(source string) bool {
+	_, ok := caseLinkColumns[source]
+	return ok
+}
+
+// caseDetailCitingLimit caps how many citing pages the case detail page renders.
+const caseDetailCitingLimit = 2000
+
+// getCaseDetail returns one case's metadata and the treatise pages that cite it.
+// source must be one of "cap", "er", "code" (validate with ValidCaseSource
+// before calling). The citing-pages query filters on the source's id column,
+// which is covered by a partial index on citation_links.
+func getCaseDetail(ctx context.Context, db *pgxpool.Pool, source, id string) (*CaseDetail, error) {
+	slog.Debug("querying case detail", "source", source, "id", id)
+	d := &CaseDetail{Source: source, CaseID: id}
+
+	if err := scanCaseMeta(ctx, db, d); err != nil {
+		return nil, err
+	}
+
+	col := caseLinkColumns[source]
+	status := caseLinkStatuses[source]
+	// The id is a bigint for cap/code and text for er; bind it as text and cast
+	// the column to text so one query serves all three sources safely.
+	query := `
+	SELECT cu.moml_treatise, cu.moml_page,
+	       bi.bibliographicid,
+	       bc.displaytitle,
+	       COALESCE(NULLIF(mp.sourcepage, ''), cu.moml_page) AS sourcepage,
+	       count(*) AS cites
+	FROM moml_citations.citation_links cl
+	JOIN moml_citations.citations_unlinked cu ON cu.id = cl.citation_id
+	LEFT JOIN moml.book_info bi ON bi.psmid = cu.moml_treatise
+	LEFT JOIN moml.book_citation bc ON bc.psmid = cu.moml_treatise
+	LEFT JOIN moml.page mp ON mp.psmid = cu.moml_treatise AND mp.pageid = cu.moml_page
+	WHERE cl.status = '` + status + `' AND cl.` + col + `::text = $1
+	GROUP BY cu.moml_treatise, cu.moml_page, bi.bibliographicid, bc.displaytitle, sourcepage
+	ORDER BY cites DESC, bc.displaytitle NULLS LAST, cu.moml_page
+	LIMIT $2
+	`
+	rows, err := db.Query(ctx, query, id, caseDetailCitingLimit)
+	if err != nil {
+		return nil, fmt.Errorf("querying citing pages: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var p CitingPage
+		if err := rows.Scan(&p.PSMID, &p.PageID, &p.BiblioID, &p.Treatise, &p.SourcePage, &p.Cites); err != nil {
+			return nil, fmt.Errorf("scanning citing page: %w", err)
+		}
+		d.Pages = append(d.Pages, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating citing pages: %w", err)
+	}
+	d.PageCount = len(d.Pages)
+	slog.Debug("fetched case detail", "source", source, "id", id, "pages", d.PageCount)
+	return d, nil
+}
+
+// scanCaseMeta fills the case's display metadata from the appropriate source
+// table. A missing row leaves the metadata fields nil (the citing pages are
+// still shown).
+func scanCaseMeta(ctx context.Context, db *pgxpool.Pool, d *CaseDetail) error {
+	switch d.Source {
+	case "cap":
+		// cap.cases.volume is a barcode, not a human volume number, so build the
+		// display citation from cap.citations, preferring the official form.
+		err := db.QueryRow(ctx, `
+			SELECT cc.name_abbreviation, cc.decision_year, ct.name,
+			       (SELECT cite FROM cap.citations
+			         WHERE "case" = cc.id ORDER BY (type = 'official') DESC LIMIT 1),
+			       cc.frontend_url
+			FROM cap.cases cc
+			LEFT JOIN cap.courts ct ON ct.id = cc.court
+			WHERE cc.id = $1::bigint
+		`, d.CaseID).Scan(&d.Name, &d.Year, &d.Court, &d.Citation, &d.URL)
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("querying CAP case meta: %w", err)
+		}
+	case "er":
+		err := db.QueryRow(ctx, `
+			SELECT er_name, er_year, court, er_cite, er_url
+			FROM english_reports.cases WHERE id = $1
+		`, d.CaseID).Scan(&d.Name, &d.Year, &d.Court, &d.Citation, &d.URL)
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("querying English Reports case meta: %w", err)
+		}
+	case "code":
+		err := db.QueryRow(ctx, `
+			SELECT name, decision_year, court_name, official_citation
+			FROM legalhist.code_reporter WHERE id = $1::bigint
+		`, d.CaseID).Scan(&d.Name, &d.Year, &d.Court, &d.Citation)
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("querying code reporter case meta: %w", err)
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Normalized citations: browse list and detail
+// ---------------------------------------------------------------------------
+
+// NormalizedListItem is one normalized citation string on the /normalized list.
+type NormalizedListItem struct {
+	Cite        string
+	CiteCount   int
+	LinkedCount int
+	PageCount   int
+}
+
+// DetailURL links to the normalized citation's detail page.
+func (n *NormalizedListItem) DetailURL() string {
+	return "/normalized/cite?c=" + url.QueryEscape(n.Cite)
+}
+
+// getTopNormalized returns a page of normalized citations ranked by occurrence
+// count, optionally filtered by an anchored prefix (uses the text_pattern_ops
+// index on the materialized view).
+func getTopNormalized(ctx context.Context, db *pgxpool.Pool, q string, limit, offset int) ([]NormalizedListItem, error) {
+	slog.Debug("querying top normalized citations", "q", q, "limit", limit, "offset", offset)
+	query := `
+	SELECT cite_normalized, cite_count, linked_count, page_count
+	FROM moml_citations.normalized_citation_counts
+	WHERE ($1 = '' OR cite_normalized LIKE $1 || '%')
+	ORDER BY cite_count DESC, cite_normalized
+	LIMIT $2 OFFSET $3
+	`
+	rows, err := db.Query(ctx, query, q, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("querying top normalized citations: %w", err)
+	}
+	defer rows.Close()
+
+	var results []NormalizedListItem
+	for rows.Next() {
+		var n NormalizedListItem
+		if err := rows.Scan(&n.Cite, &n.CiteCount, &n.LinkedCount, &n.PageCount); err != nil {
+			return nil, fmt.Errorf("scanning normalized citation: %w", err)
+		}
+		results = append(results, n)
+	}
+	slog.Debug("fetched top normalized citations", "count", len(results))
+	return results, rows.Err()
+}
+
+// NormalizedCite is one detected instance of a normalized citation, on a
+// particular treatise page.
+type NormalizedCite struct {
+	ID         uuid.UUID
+	Raw        string
+	Status     *string
+	BiblioID   *string
+	Treatise   *string
+	PSMID      string
+	PageID     string
+	SourcePage string
+}
+
+// StatusClass reuses the shared linked/not-linked colour classes.
+func (c *NormalizedCite) StatusClass() string { return statusClass(c.Status) }
+
+// IsLinked reports whether the instance resolved to a case.
+func (c *NormalizedCite) IsLinked() bool { return isLinked(c.Status) }
+
+// CiteURL links to the existing per-citation detail page.
+func (c *NormalizedCite) CiteURL() string { return "/cite?id=" + c.ID.String() }
+
+// PageURL links to the treatise page the citation was found on.
+func (c *NormalizedCite) PageURL() string {
+	v := url.Values{}
+	v.Set("psmid", c.PSMID)
+	v.Set("pageid", c.PageID)
+	return "/treatise/page?" + v.Encode()
+}
+
+// TreatiseURL links to the parent work, when known.
+func (c *NormalizedCite) TreatiseURL() string {
+	if c.BiblioID == nil {
+		return ""
+	}
+	return "/treatise?id=" + url.QueryEscape(*c.BiblioID)
+}
+
+// normalizedCitesLimit caps how many instances the normalized detail page
+// renders; larger groups are truncated for display and the true total reported
+// separately, matching the unmatched-cites page.
+const normalizedCitesLimit = 5000
+
+// getNormalizedCites returns the detected instances of one normalized citation
+// string, on the treatise pages where they appear, capped at
+// normalizedCitesLimit, plus the true total. Relies on the index on
+// citation_links.cite_normalized.
+func getNormalizedCites(ctx context.Context, db *pgxpool.Pool, cite string) ([]NormalizedCite, int, error) {
+	slog.Debug("querying instances of normalized citation", "cite", cite)
+	query := `
+	SELECT cu.id, cu.raw, cl.status,
+	       bi.bibliographicid, bc.displaytitle,
+	       cu.moml_treatise, cu.moml_page,
+	       COALESCE(NULLIF(mp.sourcepage, ''), cu.moml_page) AS sourcepage,
+	       count(*) OVER() AS total
+	FROM moml_citations.citation_links cl
+	JOIN moml_citations.citations_unlinked cu ON cu.id = cl.citation_id
+	LEFT JOIN moml.book_info bi ON bi.psmid = cu.moml_treatise
+	LEFT JOIN moml.book_citation bc ON bc.psmid = cu.moml_treatise
+	LEFT JOIN moml.page mp ON mp.psmid = cu.moml_treatise AND mp.pageid = cu.moml_page
+	WHERE cl.cite_normalized = $1
+	ORDER BY bc.displaytitle NULLS LAST, cu.moml_treatise, cu.moml_page
+	LIMIT $2
+	`
+	rows, err := db.Query(ctx, query, cite, normalizedCitesLimit)
+	if err != nil {
+		return nil, 0, fmt.Errorf("querying instances of normalized citation: %w", err)
+	}
+	defer rows.Close()
+
+	var results []NormalizedCite
+	var total int
+	for rows.Next() {
+		var c NormalizedCite
+		if err := rows.Scan(&c.ID, &c.Raw, &c.Status, &c.BiblioID, &c.Treatise, &c.PSMID, &c.PageID, &c.SourcePage, &total); err != nil {
+			return nil, 0, fmt.Errorf("scanning normalized instance: %w", err)
+		}
+		c.Raw = cleanRaw(c.Raw)
+		results = append(results, c)
+	}
+	slog.Debug("fetched instances of normalized citation", "cite", cite, "shown", len(results), "total", total)
+	return results, total, rows.Err()
+}
+
+// parsePageParam reads a 1-based ?page= value, defaulting to 1.
+func parsePageParam(s string) int {
+	if s == "" {
+		return 1
+	}
+	p, err := strconv.Atoi(s)
+	if err != nil || p < 1 {
+		return 1
+	}
+	return p
+}

--- a/chambers/browse_queries.go
+++ b/chambers/browse_queries.go
@@ -646,17 +646,19 @@ func getTopCases(ctx context.Context, db *pgxpool.Pool, limit, offset int) ([]Ca
 // Cases: case detail (the treatise pages that cite a case)
 // ---------------------------------------------------------------------------
 
-// CaseDetail is one case with the treatise pages that cite it.
+// CaseDetail is one case with the treatises that cite it, each carrying its own
+// citing pages.
 type CaseDetail struct {
-	Source    string
-	CaseID    string
-	Name      *string
-	Year      *int
-	Court     *string
-	Citation  *string
-	URL       *string // external link, when available
-	PageCount int
-	Pages     []CitingPage
+	Source        string
+	CaseID        string
+	Name          *string
+	Year          *int
+	Court         *string
+	Citation      *string
+	URL           *string // external link, when available
+	PageCount     int     // total distinct citing pages across all treatises
+	TreatiseCount int
+	Treatises     []CitingTreatise
 }
 
 // SourceLabel returns the short human label for the case's source.
@@ -670,30 +672,41 @@ func (c *CaseDetail) SourceLabel() string {
 // SourceBadgeClass returns the badge colour class for the case's source.
 func (c *CaseDetail) SourceBadgeClass() string { return sourceBadgeClass(c.Source) }
 
-// CitingPage is one treatise page that cites a case.
-type CitingPage struct {
+// CitingTreatise is one treatise (work) that cites a case, with all of its
+// citing pages grouped onto a single row.
+type CitingTreatise struct {
+	BiblioID *string
+	Treatise *string
+	Pages    []CitingPageRef
+
+	total int // total citations of the case in this treatise, for ordering
+}
+
+// TreatiseURL links to the parent work, when known.
+func (t *CitingTreatise) TreatiseURL() string {
+	if t.BiblioID == nil {
+		return ""
+	}
+	return "/treatise?id=" + url.QueryEscape(*t.BiblioID)
+}
+
+// PageCount is the number of distinct citing pages in this treatise.
+func (t *CitingTreatise) PageCount() int { return len(t.Pages) }
+
+// CitingPageRef is one citing page within a treatise.
+type CitingPageRef struct {
 	PSMID      string
 	PageID     string
-	BiblioID   *string
-	Treatise   *string
 	SourcePage string
 	Cites      int
 }
 
-// PageURL links to the treatise page's citation detail.
-func (p *CitingPage) PageURL() string {
+// URL links to the treatise page's citation detail.
+func (p *CitingPageRef) URL() string {
 	v := url.Values{}
 	v.Set("psmid", p.PSMID)
 	v.Set("pageid", p.PageID)
 	return "/treatise/page?" + v.Encode()
-}
-
-// TreatiseURL links to the parent work, when known.
-func (p *CitingPage) TreatiseURL() string {
-	if p.BiblioID == nil {
-		return ""
-	}
-	return "/treatise?id=" + url.QueryEscape(*p.BiblioID)
 }
 
 // caseLinkColumns maps a case source to the citation_links column holding its id.
@@ -735,7 +748,9 @@ func getCaseDetail(ctx context.Context, db *pgxpool.Pool, source, id string) (*C
 	col := caseLinkColumns[source]
 	status := caseLinkStatuses[source]
 	// The id is a bigint for cap/code and text for er; bind it as text and cast
-	// the column to text so one query serves all three sources safely.
+	// the column to text so one query serves all three sources safely. Rows come
+	// ordered so each treatise's (and volume's) pages are contiguous and in page
+	// order; they are grouped into one row per treatise below.
 	query := `
 	SELECT cu.moml_treatise, cu.moml_page,
 	       bi.bibliographicid,
@@ -749,7 +764,7 @@ func getCaseDetail(ctx context.Context, db *pgxpool.Pool, source, id string) (*C
 	LEFT JOIN moml.page mp ON mp.psmid = cu.moml_treatise AND mp.pageid = cu.moml_page
 	WHERE cl.status = '` + status + `' AND cl.` + col + `::text = $1
 	GROUP BY cu.moml_treatise, cu.moml_page, bi.bibliographicid, bc.displaytitle, sourcepage
-	ORDER BY cites DESC, bc.displaytitle NULLS LAST, cu.moml_page
+	ORDER BY COALESCE(bi.bibliographicid, cu.moml_treatise), cu.moml_treatise, cu.moml_page
 	LIMIT $2
 	`
 	rows, err := db.Query(ctx, query, id, caseDetailCitingLimit)
@@ -757,18 +772,40 @@ func getCaseDetail(ctx context.Context, db *pgxpool.Pool, source, id string) (*C
 		return nil, fmt.Errorf("querying citing pages: %w", err)
 	}
 	defer rows.Close()
+	index := make(map[string]int) // group key -> position in d.Treatises
+	pageRows := 0
 	for rows.Next() {
-		var p CitingPage
-		if err := rows.Scan(&p.PSMID, &p.PageID, &p.BiblioID, &p.Treatise, &p.SourcePage, &p.Cites); err != nil {
+		var psmid, pageid, sourcepage string
+		var biblioID, treatise *string
+		var cites int
+		if err := rows.Scan(&psmid, &pageid, &biblioID, &treatise, &sourcepage, &cites); err != nil {
 			return nil, fmt.Errorf("scanning citing page: %w", err)
 		}
-		d.Pages = append(d.Pages, p)
+		pageRows++
+		// Group by work (bibliographicid) so a multi-volume treatise is one row;
+		// fall back to the volume id when the work is unknown.
+		key := psmid
+		if biblioID != nil {
+			key = "b:" + *biblioID
+		}
+		pos, ok := index[key]
+		if !ok {
+			d.Treatises = append(d.Treatises, CitingTreatise{BiblioID: biblioID, Treatise: treatise})
+			pos = len(d.Treatises) - 1
+			index[key] = pos
+		}
+		t := &d.Treatises[pos]
+		t.Pages = append(t.Pages, CitingPageRef{PSMID: psmid, PageID: pageid, SourcePage: sourcepage, Cites: cites})
+		t.total += cites
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterating citing pages: %w", err)
 	}
-	d.PageCount = len(d.Pages)
-	slog.Debug("fetched case detail", "source", source, "id", id, "pages", d.PageCount)
+	// Most-citing treatise first; pages within each stay in page order.
+	sort.SliceStable(d.Treatises, func(i, j int) bool { return d.Treatises[i].total > d.Treatises[j].total })
+	d.PageCount = pageRows
+	d.TreatiseCount = len(d.Treatises)
+	slog.Debug("fetched case detail", "source", source, "id", id, "pages", d.PageCount, "treatises", d.TreatiseCount)
 	return d, nil
 }
 

--- a/chambers/browse_queries.go
+++ b/chambers/browse_queries.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"html/template"
 	"log/slog"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -319,14 +321,38 @@ func getTreatiseDetail(ctx context.Context, db *pgxpool.Pool, biblioID string) (
 // Treatise page: the citations detected on one page
 // ---------------------------------------------------------------------------
 
-// TreatisePageView is one treatise page with the citations detected on it.
+// TreatisePageView is one treatise page with its OCR text and the citations
+// detected on it.
 type TreatisePageView struct {
 	PSMID      string
 	PageID     string
 	BiblioID   *string
 	Title      *string
 	SourcePage string
+	OCRText    string
 	Citations  []PageCitation
+}
+
+// HighlightedOCR returns the page's OCR text with each detected citation's raw
+// span wrapped in <mark>, HTML-escaped. Longer raw strings are marked first so a
+// full citation is highlighted before any partial sub-citation it contains.
+func (v *TreatisePageView) HighlightedOCR() template.HTML {
+	text := template.HTMLEscapeString(v.OCRText)
+	seen := make(map[string]bool, len(v.Citations))
+	raws := make([]string, 0, len(v.Citations))
+	for i := range v.Citations {
+		raw := v.Citations[i].orig
+		if raw != "" && !seen[raw] {
+			seen[raw] = true
+			raws = append(raws, raw)
+		}
+	}
+	sort.SliceStable(raws, func(i, j int) bool { return len(raws[i]) > len(raws[j]) })
+	for _, raw := range raws {
+		esc := template.HTMLEscapeString(raw)
+		text = strings.ReplaceAll(text, esc, "<mark>"+esc+"</mark>")
+	}
+	return template.HTML(text)
 }
 
 // TreatiseURL links back to the parent work, when known.
@@ -357,6 +383,9 @@ type PageCitation struct {
 	Source   *string // "cap" | "er" | "code" when linked
 	CaseID   *string
 	CaseName *string
+
+	orig string // raw before newline cleanup, for locating it in the OCR text
+	pos  int    // byte offset of orig in the OCR text, for page-order sorting
 }
 
 // StatusClass reuses the shared linked/not-linked colour classes.
@@ -406,7 +435,16 @@ func getTreatisePage(ctx context.Context, db *pgxpool.Pool, psmid, pageid string
 		view.SourcePage = *sourcePage
 	}
 
-	// Citations on the page.
+	// OCR text for the page, loaded with the page so the text and citations can
+	// be shown side by side.
+	ocr, err := getPageOCRText(ctx, db, psmid, pageid)
+	if err != nil {
+		return nil, err
+	}
+	view.OCRText = ocr
+
+	// Citations on the page, fetched in detection order (created_at) as a stable
+	// base ordering before sorting by position in the page text below.
 	rows, err := db.Query(ctx, `
 		SELECT cu.id, cu.raw, cl.status,
 		       CASE WHEN cl.cap_case_id IS NOT NULL THEN 'cap'
@@ -420,7 +458,7 @@ func getTreatisePage(ctx context.Context, db *pgxpool.Pool, psmid, pageid string
 		LEFT JOIN english_reports.cases er ON er.id = cl.er_case_id
 		LEFT JOIN legalhist.code_reporter code ON code.id = cl.code_reporter_id
 		WHERE cu.moml_treatise = $1 AND cu.moml_page = $2
-		ORDER BY cl.status LIKE 'linked_%' DESC, cu.raw
+		ORDER BY cu.created_at, cu.id
 	`, psmid, pageid)
 	if err != nil {
 		return nil, fmt.Errorf("querying page citations: %w", err)
@@ -431,17 +469,36 @@ func getTreatisePage(ctx context.Context, db *pgxpool.Pool, psmid, pageid string
 		if err := rows.Scan(&c.ID, &c.Raw, &c.Status, &c.Source, &c.CaseID, &c.CaseName); err != nil {
 			return nil, fmt.Errorf("scanning page citation: %w", err)
 		}
+		c.orig = c.Raw
 		c.Raw = cleanRaw(c.Raw)
 		view.Citations = append(view.Citations, c)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterating page citations: %w", err)
 	}
-	if len(view.Citations) == 0 && view.Title == nil {
+	view.orderCitationsByPosition()
+	if len(view.Citations) == 0 && view.Title == nil && view.OCRText == "" {
 		return nil, nil
 	}
 	slog.Debug("fetched treatise page", "psmid", psmid, "pageid", pageid, "citations", len(view.Citations))
 	return view, nil
+}
+
+// orderCitationsByPosition sorts the page's citations by where their raw text
+// appears in the OCR text, approximating reading order on the page. Citations
+// whose raw text is not found verbatim (OCR drift) keep their detection-order
+// position after the located ones.
+func (v *TreatisePageView) orderCitationsByPosition() {
+	for i := range v.Citations {
+		p := strings.Index(v.OCRText, v.Citations[i].orig)
+		if p < 0 {
+			p = len(v.OCRText) + i // not found: keep detection order, after located cites
+		}
+		v.Citations[i].pos = p
+	}
+	sort.SliceStable(v.Citations, func(i, j int) bool {
+		return v.Citations[i].pos < v.Citations[j].pos
+	})
 }
 
 // getPageOCRText returns the OCR text for one treatise page, loaded on demand by

--- a/chambers/browse_queries.go
+++ b/chambers/browse_queries.go
@@ -183,6 +183,23 @@ func (p *TreatisePageRow) URL() string {
 	return "/treatise/page?" + v.Encode()
 }
 
+// LinkedPct is the share of the page's citations that are linked, as a rounded
+// percentage. LinkedPct + NotLinkedPct == 100 whenever the page has citations.
+func (p *TreatisePageRow) LinkedPct() int {
+	if p.Cites == 0 {
+		return 0
+	}
+	return (p.Linked*100 + p.Cites/2) / p.Cites
+}
+
+// NotLinkedPct is the share of the page's citations that are not linked.
+func (p *TreatisePageRow) NotLinkedPct() int {
+	if p.Cites == 0 {
+		return 0
+	}
+	return 100 - p.LinkedPct()
+}
+
 // getTreatiseDetail returns one work's volumes and citation-bearing pages. It
 // runs three small queries (volumes, subjects, pages) keyed off the work's
 // bibliographicid; the page query uses the citations_unlinked index on

--- a/chambers/browse_queries.go
+++ b/chambers/browse_queries.go
@@ -553,6 +553,22 @@ var caseSourceLabels = map[string]string{
 	"code": "Code rep.",
 }
 
+// caseSourceBadges maps a case source to its badge colour class (defined in the
+// cases/case templates), so each source reads as a distinct colour.
+var caseSourceBadges = map[string]string{
+	"cap":  "src-cap",
+	"er":   "src-er",
+	"code": "src-code",
+}
+
+// sourceBadgeClass returns the badge colour class for a case source.
+func sourceBadgeClass(source string) string {
+	if c, ok := caseSourceBadges[source]; ok {
+		return c
+	}
+	return "bg-secondary"
+}
+
 // CaseListItem is one cited case on the /cases ranking.
 type CaseListItem struct {
 	Source    string
@@ -572,6 +588,9 @@ func (c *CaseListItem) SourceLabel() string {
 	}
 	return c.Source
 }
+
+// SourceBadgeClass returns the badge colour class for the case's source.
+func (c *CaseListItem) SourceBadgeClass() string { return sourceBadgeClass(c.Source) }
 
 // DetailURL links to the case detail page.
 func (c *CaseListItem) DetailURL() string {
@@ -647,6 +666,9 @@ func (c *CaseDetail) SourceLabel() string {
 	}
 	return c.Source
 }
+
+// SourceBadgeClass returns the badge colour class for the case's source.
+func (c *CaseDetail) SourceBadgeClass() string { return sourceBadgeClass(c.Source) }
 
 // CitingPage is one treatise page that cites a case.
 type CitingPage struct {

--- a/chambers/main.go
+++ b/chambers/main.go
@@ -58,6 +58,16 @@ var funcMap = template.FuncMap{
 		highlighted := strings.ReplaceAll(escaped, rawEscaped, "<mark>"+rawEscaped+"</mark>")
 		return template.HTML(highlighted)
 	},
+	// Small integer helpers for computing list rank numbers in templates.
+	"add": func(nums ...int) int {
+		sum := 0
+		for _, n := range nums {
+			sum += n
+		}
+		return sum
+	},
+	"sub": func(a, b int) int { return a - b },
+	"mul": func(a, b int) int { return a * b },
 }
 
 func init() {
@@ -77,6 +87,13 @@ func parseTemplates() map[string]*template.Template {
 		"unmatched-cites.html",
 		"dashboard.html",
 		"whitelist-extender.html",
+		"treatises.html",
+		"treatise.html",
+		"treatise-page.html",
+		"cases.html",
+		"case.html",
+		"normalized.html",
+		"normalized-cite.html",
 	}
 	tmpls := make(map[string]*template.Template, len(pages))
 	for _, page := range pages {
@@ -142,6 +159,28 @@ func main() {
 		handleWhitelistExtender(w, r, tmpls["whitelist-extender.html"])
 	})
 	mux.HandleFunc("/api/whitelist-extender", handleWhitelistExtenderAPI)
+	mux.HandleFunc("/treatises", func(w http.ResponseWriter, r *http.Request) {
+		handleTreatises(w, r, tmpls["treatises.html"])
+	})
+	mux.HandleFunc("/treatise", func(w http.ResponseWriter, r *http.Request) {
+		handleTreatise(w, r, tmpls["treatise.html"])
+	})
+	mux.HandleFunc("/treatise/page", func(w http.ResponseWriter, r *http.Request) {
+		handleTreatisePage(w, r, tmpls["treatise-page.html"])
+	})
+	mux.HandleFunc("/api/page-text", handlePageText)
+	mux.HandleFunc("/cases", func(w http.ResponseWriter, r *http.Request) {
+		handleCases(w, r, tmpls["cases.html"])
+	})
+	mux.HandleFunc("/case", func(w http.ResponseWriter, r *http.Request) {
+		handleCase(w, r, tmpls["case.html"])
+	})
+	mux.HandleFunc("/normalized", func(w http.ResponseWriter, r *http.Request) {
+		handleNormalized(w, r, tmpls["normalized.html"])
+	})
+	mux.HandleFunc("/normalized/cite", func(w http.ResponseWriter, r *http.Request) {
+		handleNormalizedCite(w, r, tmpls["normalized-cite.html"])
+	})
 	staticSub, _ := fs.Sub(staticFS, "static")
 	mux.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.FS(staticSub))))
 

--- a/chambers/queries.go
+++ b/chambers/queries.go
@@ -88,13 +88,7 @@ func (c *CitationDetail) IsEnglishReports() bool {
 // parameter. host and userParam select which institution's proxy the link
 // routes through.
 func (c *CitationDetail) momlVolumeURL(host, userParam string) string {
-	if c.ProductLink == nil {
-		return ""
-	}
-	url := *c.ProductLink
-	url = strings.Replace(url, "http://link.galegroup.com", host, 1)
-	url = strings.Replace(url, "?sid=dhxml", "?"+userParam+"sid=dhxml", 1)
-	return url
+	return momlVolumeLink(c.ProductLink, host, userParam)
 }
 
 // MomlVolumeURL returns a Gale MOML URL for the volume as a whole, routed
@@ -114,18 +108,7 @@ func (c *CitationDetail) MomlVolumeURLColumbia() string {
 // The pg parameter uses MomlPage (pageid), with the trailing 0 stripped
 // and leading 0s removed. E.g., pageid "06870" becomes pg=687.
 func (c *CitationDetail) momlPageURL(base string) string {
-	if base == "" {
-		return ""
-	}
-	if c.MomlPage != "" {
-		pg := c.MomlPage
-		pg = strings.TrimRight(pg, "0")
-		pg = strings.TrimLeft(pg, "0")
-		if pg != "" {
-			base += "&pg=" + pg
-		}
-	}
-	return base
+	return momlPageLink(base, c.MomlPage)
 }
 
 // MomlPageURL constructs a Gale MOML URL linking to the specific page, routed

--- a/chambers/templates/case.html
+++ b/chambers/templates/case.html
@@ -25,23 +25,29 @@
     </div>
 
     <p class="small text-secondary">
-        Cited on <strong>{{.Case.PageCount}}</strong> treatise page(s){{if .Truncated}} (showing the first {{.Case.PageCount}}){{end}}.
-        Click a page to see all of its citations.
+        Cited on <strong>{{.Case.PageCount}}</strong> treatise page(s) across
+        <strong>{{.Case.TreatiseCount}}</strong> treatise(s){{if .Truncated}} (showing the first {{.Case.PageCount}}){{end}}.
+        Each row is one treatise; click a page to see all of its citations. A
+        <span class="text-secondary">(n)</span> after a page is how many times the case is cited there.
     </p>
 
     <table class="table table-sm table-hover align-middle">
         <thead>
-            <tr><th>Treatise</th><th>Page</th><th class="text-end">Times cited here</th></tr>
+            <tr><th>Treatise</th><th>Pages</th></tr>
         </thead>
         <tbody>
-        {{range .Case.Pages}}
+        {{range .Case.Treatises}}
             <tr>
-                <td>{{if .TreatiseURL}}<a href="{{.TreatiseURL}}">{{ptrOr .Treatise "(untitled)"}}</a>{{else}}{{ptrOr .Treatise "(untitled)"}}{{end}}</td>
-                <td><a href="{{.PageURL}}">p. {{.SourcePage}}</a></td>
-                <td class="num text-secondary">{{.Cites}}</td>
+                <td>
+                    {{if .TreatiseURL}}<a href="{{.TreatiseURL}}">{{ptrOr .Treatise "(untitled)"}}</a>{{else}}{{ptrOr .Treatise "(untitled)"}}{{end}}
+                    <span class="text-secondary small">&middot; {{.PageCount}} page{{if ne .PageCount 1}}s{{end}}</span>
+                </td>
+                <td>
+                    {{range $i, $p := .Pages}}{{if $i}}, {{end}}<a href="{{$p.URL}}" class="text-nowrap">p.&nbsp;{{$p.SourcePage}}</a>{{if gt $p.Cites 1}}<span class="text-secondary small">&nbsp;({{$p.Cites}})</span>{{end}}{{end}}
+                </td>
             </tr>
         {{else}}
-            <tr><td colspan="3" class="text-secondary">No citing pages found.</td></tr>
+            <tr><td colspan="2" class="text-secondary">No citing pages found.</td></tr>
         {{end}}
         </tbody>
     </table>

--- a/chambers/templates/case.html
+++ b/chambers/templates/case.html
@@ -3,6 +3,9 @@
 {{define "styles"}}
     td.num { text-align: right; font-variant-numeric: tabular-nums; }
     .detail-grid { display: grid; grid-template-columns: auto 1fr; gap: 0.1rem 0.8rem; margin: 0.2rem 0; }
+    .badge.src-cap { background-color: #6f42c1; }
+    .badge.src-er { background-color: #0d9488; }
+    .badge.src-code { background-color: #c2410c; }
 {{end}}
 
 {{define "nav"}}
@@ -14,7 +17,7 @@
 {{define "content"}}
     <h1 class="h5 mt-2">{{if .Case.Name}}{{.Case.Name | derefStr}}{{else}}(unknown case){{end}}</h1>
     <div class="detail-grid small mb-2">
-        <span class="text-secondary">Source</span><span><span class="badge bg-secondary">{{.Case.SourceLabel}}</span></span>
+        <span class="text-secondary">Source</span><span><span class="badge {{.Case.SourceBadgeClass}}">{{.Case.SourceLabel}}</span></span>
         {{if .Case.Citation}}<span class="text-secondary">Citation</span><span>{{.Case.Citation | derefStr}}</span>{{end}}
         {{if .Case.Year}}<span class="text-secondary">Year</span><span>{{deref .Case.Year}}</span>{{end}}
         {{if .Case.Court}}<span class="text-secondary">Court</span><span>{{.Case.Court | derefStr}}</span>{{end}}

--- a/chambers/templates/case.html
+++ b/chambers/templates/case.html
@@ -6,6 +6,7 @@
     .badge.src-cap { background-color: #6f42c1; }
     .badge.src-er { background-color: #0d9488; }
     .badge.src-code { background-color: #c2410c; }
+    .title-col { width: 18rem; max-width: 18rem; word-break: break-word; }
 {{end}}
 
 {{define "nav"}}
@@ -33,12 +34,12 @@
 
     <table class="table table-sm table-hover align-middle">
         <thead>
-            <tr><th>Treatise</th><th>Pages</th></tr>
+            <tr><th class="title-col">Treatise</th><th>Pages</th></tr>
         </thead>
         <tbody>
         {{range .Case.Treatises}}
             <tr>
-                <td>
+                <td class="title-col">
                     {{if .TreatiseURL}}<a href="{{.TreatiseURL}}">{{ptrOr .Treatise "(untitled)"}}</a>{{else}}{{ptrOr .Treatise "(untitled)"}}{{end}}
                     <span class="text-secondary small">&middot; {{.PageCount}} page{{if ne .PageCount 1}}s{{end}}</span>
                 </td>

--- a/chambers/templates/case.html
+++ b/chambers/templates/case.html
@@ -1,0 +1,43 @@
+{{define "title"}}{{if .Case.Name}}{{.Case.Name | derefStr}}{{else}}Case{{end}} &mdash; Chambers{{end}}
+
+{{define "styles"}}
+    td.num { text-align: right; font-variant-numeric: tabular-nums; }
+    .detail-grid { display: grid; grid-template-columns: auto 1fr; gap: 0.1rem 0.8rem; margin: 0.2rem 0; }
+{{end}}
+
+{{define "nav"}}
+    <a href="/cases" class="small text-decoration-none">&larr; All cases</a>
+{{end}}
+
+{{define "content"}}
+    <h1 class="h5 mt-2">{{if .Case.Name}}{{.Case.Name | derefStr}}{{else}}(unknown case){{end}}</h1>
+    <div class="detail-grid small mb-2">
+        <span class="text-secondary">Source</span><span><span class="badge bg-secondary">{{.Case.SourceLabel}}</span></span>
+        {{if .Case.Citation}}<span class="text-secondary">Citation</span><span>{{.Case.Citation | derefStr}}</span>{{end}}
+        {{if .Case.Year}}<span class="text-secondary">Year</span><span>{{deref .Case.Year}}</span>{{end}}
+        {{if .Case.Court}}<span class="text-secondary">Court</span><span>{{.Case.Court | derefStr}}</span>{{end}}
+        {{if .Case.URL}}<span class="text-secondary">Link</span><span><a href="{{.Case.URL | derefStr}}" target="_blank" rel="noopener">view source &nearr;</a></span>{{end}}
+    </div>
+
+    <p class="small text-secondary">
+        Cited on <strong>{{.Case.PageCount}}</strong> treatise page(s){{if .Truncated}} (showing the first {{.Case.PageCount}}){{end}}.
+        Click a page to see all of its citations.
+    </p>
+
+    <table class="table table-sm table-hover align-middle">
+        <thead>
+            <tr><th>Treatise</th><th>Page</th><th class="text-end">Times cited here</th></tr>
+        </thead>
+        <tbody>
+        {{range .Case.Pages}}
+            <tr>
+                <td>{{if .TreatiseURL}}<a href="{{.TreatiseURL}}">{{ptrOr .Treatise "(untitled)"}}</a>{{else}}{{ptrOr .Treatise "(untitled)"}}{{end}}</td>
+                <td><a href="{{.PageURL}}">p. {{.SourcePage}}</a></td>
+                <td class="num text-secondary">{{.Cites}}</td>
+            </tr>
+        {{else}}
+            <tr><td colspan="3" class="text-secondary">No citing pages found.</td></tr>
+        {{end}}
+        </tbody>
+    </table>
+{{end}}

--- a/chambers/templates/case.html
+++ b/chambers/templates/case.html
@@ -6,7 +6,9 @@
 {{end}}
 
 {{define "nav"}}
-    <a href="/cases" class="small text-decoration-none">&larr; All cases</a>
+    <a href="/" class="small text-decoration-none">&larr; Chambers</a>
+    <span class="text-secondary small mx-1">&middot;</span>
+    <a href="/cases" class="small text-decoration-none">All cases</a>
 {{end}}
 
 {{define "content"}}

--- a/chambers/templates/cases.html
+++ b/chambers/templates/cases.html
@@ -1,0 +1,66 @@
+{{define "title"}}Most-cited cases &mdash; Chambers{{end}}
+
+{{define "styles"}}
+    td.num { text-align: right; font-variant-numeric: tabular-nums; }
+{{end}}
+
+{{define "nav"}}
+    <a href="/" class="small text-decoration-none">&larr; Back to Chambers</a>
+{{end}}
+
+{{define "content"}}
+    <h1 class="h5 mt-2">Most-cited cases</h1>
+    <p class="small text-secondary mb-3">
+        Cases ranked by the number of distinct treatise pages that cite them (a case cited
+        several times on one page counts once). Includes all linked sources: the Caselaw
+        Access Project (<span class="badge bg-secondary">CAP</span>), English Reports
+        (<span class="badge bg-secondary">Eng.&nbsp;Rep.</span>), and code reporters
+        (<span class="badge bg-secondary">Code&nbsp;rep.</span>). From
+        <code>moml_citations.case_citation_counts</code>.
+    </p>
+
+    <table class="table table-sm table-hover align-middle">
+        <thead>
+            <tr>
+                <th>#</th>
+                <th>Case</th>
+                <th>Source</th>
+                <th class="text-end">Year</th>
+                <th>Court</th>
+                <th class="text-end">Treatise pages</th>
+                <th class="text-end">Citations</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+        {{$start := mul (sub .Nav.Page 1) 100}}
+        {{range $i, $c := .Items}}
+            <tr>
+                <td class="num text-secondary small">{{add $start $i 1}}</td>
+                <td><a href="{{$c.DetailURL}}">{{ptrOr $c.Name "(unknown case)"}}</a></td>
+                <td><span class="badge bg-secondary">{{$c.SourceLabel}}</span></td>
+                <td class="num">{{if $c.Year}}{{deref $c.Year}}{{else}}&mdash;{{end}}</td>
+                <td class="small text-secondary">{{ptrOr $c.Court "&mdash;"}}</td>
+                <td class="num">{{$c.PageCount}}</td>
+                <td class="num text-secondary">{{$c.CiteCount}}</td>
+                <td>{{if $c.URL}}<a href="{{$c.URL | derefStr}}" target="_blank" rel="noopener" class="small">source &nearr;</a>{{end}}</td>
+            </tr>
+        {{else}}
+            <tr><td colspan="8" class="text-secondary">No cases. (If empty, the
+                <code>case_citation_counts</code> view may need a <code>make db-refresh</code>.)</td></tr>
+        {{end}}
+        </tbody>
+    </table>
+
+    {{template "pagination" .Nav}}
+{{end}}
+
+{{define "pagination"}}
+    {{if or .HasPrev .HasNext}}
+    <nav class="my-3">
+        {{if .HasPrev}}<a href="{{.PrevURL}}" class="btn btn-sm btn-outline-secondary">&larr; Prev</a>{{end}}
+        <span class="small text-secondary mx-2">Page {{.Page}}</span>
+        {{if .HasNext}}<a href="{{.NextURL}}" class="btn btn-sm btn-outline-secondary">Next &rarr;</a>{{end}}
+    </nav>
+    {{end}}
+{{end}}

--- a/chambers/templates/cases.html
+++ b/chambers/templates/cases.html
@@ -2,6 +2,9 @@
 
 {{define "styles"}}
     td.num { text-align: right; font-variant-numeric: tabular-nums; }
+    .badge.src-cap { background-color: #6f42c1; }
+    .badge.src-er { background-color: #0d9488; }
+    .badge.src-code { background-color: #c2410c; }
 {{end}}
 
 {{define "nav"}}
@@ -13,9 +16,9 @@
     <p class="small text-secondary mb-3">
         Cases ranked by the number of distinct treatise pages that cite them (a case cited
         several times on one page counts once). Includes all linked sources: the Caselaw
-        Access Project (<span class="badge bg-secondary">CAP</span>), English Reports
-        (<span class="badge bg-secondary">Eng.&nbsp;Rep.</span>), and code reporters
-        (<span class="badge bg-secondary">Code&nbsp;rep.</span>). From
+        Access Project (<span class="badge src-cap">CAP</span>), English Reports
+        (<span class="badge src-er">Eng.&nbsp;Rep.</span>), and code reporters
+        (<span class="badge src-code">Code&nbsp;rep.</span>). From
         <code>moml_citations.case_citation_counts</code>.
     </p>
 
@@ -38,7 +41,7 @@
             <tr>
                 <td class="num text-secondary small">{{add $start $i 1}}</td>
                 <td><a href="{{$c.DetailURL}}">{{ptrOr $c.Name "(unknown case)"}}</a></td>
-                <td><span class="badge bg-secondary">{{$c.SourceLabel}}</span></td>
+                <td><span class="badge {{$c.SourceBadgeClass}}">{{$c.SourceLabel}}</span></td>
                 <td class="num">{{if $c.Year}}{{deref $c.Year}}{{else}}&mdash;{{end}}</td>
                 <td class="small text-secondary">{{ptrOr $c.Court "&mdash;"}}</td>
                 <td class="num">{{$c.PageCount}}</td>

--- a/chambers/templates/home.html
+++ b/chambers/templates/home.html
@@ -50,6 +50,30 @@
             </div>
         </div>
         <div class="col-md-4">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h5 class="card-title"><a href="/treatises" class="text-decoration-none">U.S. treatises</a></h5>
+                    <p class="card-text text-secondary small">Browse U.S. treatises, walk to their pages, and see the citations detected on each &mdash; green for linked, red for not yet linked.</p>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h5 class="card-title"><a href="/cases" class="text-decoration-none">Most-cited cases</a></h5>
+                    <p class="card-text text-secondary small">Cases ranked by how many treatise pages cite them, across CAP, English Reports, and code reporters.</p>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h5 class="card-title"><a href="/normalized" class="text-decoration-none">Normalized citations</a></h5>
+                    <p class="card-text text-secondary small">Citations grouped by normalized form, ranked by frequency, linking out to the treatise pages where they appear.</p>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
             <div class="card h-100 portrait-card">
                 <div class="card-body text-center">
                     <img src="/static/portrait.jpg" alt="Portrait" class="mb-2">

--- a/chambers/templates/normalized-cite.html
+++ b/chambers/templates/normalized-cite.html
@@ -15,7 +15,9 @@
 {{end}}
 
 {{define "nav"}}
-    <a href="/normalized" class="small text-decoration-none">&larr; All normalized citations</a>
+    <a href="/" class="small text-decoration-none">&larr; Chambers</a>
+    <span class="text-secondary small mx-1">&middot;</span>
+    <a href="/normalized" class="small text-decoration-none">All normalized citations</a>
 {{end}}
 
 {{define "content"}}

--- a/chambers/templates/normalized-cite.html
+++ b/chambers/templates/normalized-cite.html
@@ -6,10 +6,12 @@
     .cite .raw { font-weight: 600; font-family: monospace; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .cite .meta { display: block; font-size: 0.72rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .cite a { text-decoration: none; }
+    .cite .raw a { color: #212529; }
     .cite-linked { background: #d4edda; border-color: #b6dcc0; }
-    .cite-linked .raw a { color: #155724; }
-    .cite-unlinked { background: #f8d7da; border-color: #eeb9be; }
-    .cite-unlinked .raw a { color: #721c24; }
+    .cite-nomatch { background: #f8d7da; border-color: #eeb9be; }
+    .cite-junk { background: #e2e3e5; border-color: #cdd0d3; }
+    .cite-skip { background: #fff3cd; border-color: #ffe69c; }
+    .legend-dot { display: inline-block; width: 0.7rem; height: 0.7rem; border-radius: 2px; border: 1px solid rgba(0,0,0,.15); vertical-align: -1px; }
 {{end}}
 
 {{define "nav"}}
@@ -20,14 +22,18 @@
     <h1 class="h5 mt-2 font-monospace">{{.Cite}}</h1>
     <p class="small text-secondary mb-2">
         {{.Total}} occurrence(s) across treatise pages{{if .Truncated}}; showing the first {{.Shown}}{{end}}.
-        <span style="color:#155724;">Green</span> = linked to a case,
-        <span style="color:#721c24;">red</span> = not linked. The raw text links to the full
-        detection/linking detail; the page link opens the treatise page.
+        The raw text links to the full detection/linking detail; the page link opens the treatise page.
+    </p>
+    <p class="small mb-2">
+        <span class="legend-dot cite-linked"></span> linked &nbsp;
+        <span class="legend-dot cite-nomatch"></span> no match &nbsp;
+        <span class="legend-dot cite-skip"></span> reporter not whitelisted &nbsp;
+        <span class="legend-dot cite-junk"></span> junk (not a real citation)
     </p>
 
     <div class="cites">
     {{range .Cites}}
-        <span class="cite {{if .IsLinked}}cite-linked{{else}}cite-unlinked{{end}}">
+        <span class="cite {{.ChipClass}}">
             <span class="raw"><a href="{{.CiteURL}}" title="Inspect detection &amp; linking">{{.Raw}}</a></span>
             <span class="meta">
                 {{if .TreatiseURL}}<a href="{{.TreatiseURL}}">{{ptrOr .Treatise "(untitled)"}}</a>{{else}}{{ptrOr .Treatise "(untitled)"}}{{end}}

--- a/chambers/templates/normalized-cite.html
+++ b/chambers/templates/normalized-cite.html
@@ -1,0 +1,41 @@
+{{define "title"}}{{.Cite}} &mdash; Chambers{{end}}
+
+{{define "styles"}}
+    .cites { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-top: 0.5rem; }
+    .cite { width: 19rem; box-sizing: border-box; padding: 0.3rem 0.5rem; border-radius: 4px; font-size: 0.8rem; border: 1px solid transparent; }
+    .cite .raw { font-weight: 600; font-family: monospace; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .cite .meta { display: block; font-size: 0.72rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .cite a { text-decoration: none; }
+    .cite-linked { background: #d4edda; border-color: #b6dcc0; }
+    .cite-linked .raw a { color: #155724; }
+    .cite-unlinked { background: #f8d7da; border-color: #eeb9be; }
+    .cite-unlinked .raw a { color: #721c24; }
+{{end}}
+
+{{define "nav"}}
+    <a href="/normalized" class="small text-decoration-none">&larr; All normalized citations</a>
+{{end}}
+
+{{define "content"}}
+    <h1 class="h5 mt-2 font-monospace">{{.Cite}}</h1>
+    <p class="small text-secondary mb-2">
+        {{.Total}} occurrence(s) across treatise pages{{if .Truncated}}; showing the first {{.Shown}}{{end}}.
+        <span style="color:#155724;">Green</span> = linked to a case,
+        <span style="color:#721c24;">red</span> = not linked. The raw text links to the full
+        detection/linking detail; the page link opens the treatise page.
+    </p>
+
+    <div class="cites">
+    {{range .Cites}}
+        <span class="cite {{if .IsLinked}}cite-linked{{else}}cite-unlinked{{end}}">
+            <span class="raw"><a href="{{.CiteURL}}" title="Inspect detection &amp; linking">{{.Raw}}</a></span>
+            <span class="meta">
+                {{if .TreatiseURL}}<a href="{{.TreatiseURL}}">{{ptrOr .Treatise "(untitled)"}}</a>{{else}}{{ptrOr .Treatise "(untitled)"}}{{end}}
+                &middot; <a href="{{.PageURL}}">p. {{.SourcePage}}</a>
+            </span>
+        </span>
+    {{else}}
+        <span class="text-secondary small">No occurrences found.</span>
+    {{end}}
+    </div>
+{{end}}

--- a/chambers/templates/normalized.html
+++ b/chambers/templates/normalized.html
@@ -1,0 +1,65 @@
+{{define "title"}}Normalized citations &mdash; Chambers{{end}}
+
+{{define "styles"}}
+    td.num { text-align: right; font-variant-numeric: tabular-nums; }
+{{end}}
+
+{{define "nav"}}
+    <a href="/" class="small text-decoration-none">&larr; Back to Chambers</a>
+{{end}}
+
+{{define "content"}}
+    <h1 class="h5 mt-2">Normalized citations</h1>
+    <p class="small text-secondary mb-2">
+        Citations grouped by their normalized form (e.g. <code>2 Haw. 63</code>), ranked by how
+        often they occur. <strong>Linked</strong> counts how many occurrences resolved to a case;
+        <strong>Pages</strong> is the number of distinct treatise pages the citation appears on.
+        Click a citation to see those pages. From
+        <code>moml_citations.normalized_citation_counts</code>.
+    </p>
+
+    <form method="get" class="row g-2 align-items-center mb-3">
+        <div class="col-auto">
+            <input type="search" name="q" value="{{.Q}}" class="form-control form-control-sm"
+                   placeholder="Starts with&hellip; (e.g. 2 Haw.)" style="min-width: 18rem;">
+        </div>
+        <div class="col-auto"><button class="btn btn-sm btn-primary">Search</button></div>
+        {{if .Q}}<div class="col-auto"><a href="/normalized" class="small">clear</a></div>{{end}}
+    </form>
+
+    <table class="table table-sm table-hover align-middle" style="max-width: 48rem;">
+        <thead>
+            <tr>
+                <th>Normalized citation</th>
+                <th class="text-end">Occurrences</th>
+                <th class="text-end">Linked</th>
+                <th class="text-end">Pages</th>
+            </tr>
+        </thead>
+        <tbody>
+        {{range .Items}}
+            <tr>
+                <td><a href="{{.DetailURL}}" class="font-monospace">{{.Cite}}</a></td>
+                <td class="num">{{.CiteCount}}</td>
+                <td class="num text-secondary">{{.LinkedCount}}</td>
+                <td class="num text-secondary">{{.PageCount}}</td>
+            </tr>
+        {{else}}
+            <tr><td colspan="4" class="text-secondary">No normalized citations. (If empty, the
+                <code>normalized_citation_counts</code> view may need a <code>make db-refresh</code>.)</td></tr>
+        {{end}}
+        </tbody>
+    </table>
+
+    {{template "pagination" .Nav}}
+{{end}}
+
+{{define "pagination"}}
+    {{if or .HasPrev .HasNext}}
+    <nav class="my-3">
+        {{if .HasPrev}}<a href="{{.PrevURL}}" class="btn btn-sm btn-outline-secondary">&larr; Prev</a>{{end}}
+        <span class="small text-secondary mx-2">Page {{.Page}}</span>
+        {{if .HasNext}}<a href="{{.NextURL}}" class="btn btn-sm btn-outline-secondary">Next &rarr;</a>{{end}}
+    </nav>
+    {{end}}
+{{end}}

--- a/chambers/templates/treatise-page.html
+++ b/chambers/templates/treatise-page.html
@@ -16,7 +16,11 @@
 {{end}}
 
 {{define "nav"}}
-    {{if .Page.TreatiseURL}}<a href="{{.Page.TreatiseURL}}" class="small text-decoration-none">&larr; Back to treatise</a>{{else}}<a href="/treatises" class="small text-decoration-none">&larr; All treatises</a>{{end}}
+    <a href="/" class="small text-decoration-none">&larr; Chambers</a>
+    <span class="text-secondary small mx-1">&middot;</span>
+    <a href="/treatises" class="small text-decoration-none">All treatises</a>
+    {{if .Page.TreatiseURL}}<span class="text-secondary small mx-1">&middot;</span>
+    <a href="{{.Page.TreatiseURL}}" class="small text-decoration-none">Back to treatise</a>{{end}}
 {{end}}
 
 {{define "content"}}

--- a/chambers/templates/treatise-page.html
+++ b/chambers/templates/treatise-page.html
@@ -39,6 +39,13 @@
         <span class="legend-dot cite-skip"></span> reporter not whitelisted &nbsp;
         <span class="legend-dot cite-junk"></span> junk (not a real citation)
     </p>
+    {{if or .Page.MomlPageURLGMU .Page.MomlPageURLColumbia}}
+    <p class="small mb-2">
+        View this page on Gale MOML:
+        {{if .Page.MomlPageURLGMU}}<a href="{{.Page.MomlPageURLGMU}}" target="_blank" rel="noopener">GMU</a>{{end}}
+        {{if .Page.MomlPageURLColumbia}}&middot; <a href="{{.Page.MomlPageURLColumbia}}" target="_blank" rel="noopener">Columbia</a>{{end}}
+    </p>
+    {{end}}
 
     <div class="row g-4">
         <div class="col-md-6">

--- a/chambers/templates/treatise-page.html
+++ b/chambers/templates/treatise-page.html
@@ -1,16 +1,16 @@
 {{define "title"}}Page {{.Page.SourcePage}} &mdash; Chambers{{end}}
 
 {{define "styles"}}
-    .cites { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-top: 0.5rem; }
-    .cite { width: 18rem; box-sizing: border-box; padding: 0.3rem 0.5rem; border-radius: 4px; font-size: 0.8rem; border: 1px solid transparent; }
-    .cite .raw { font-weight: 600; font-family: monospace; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .cites { display: flex; flex-direction: column; gap: 0.4rem; margin-top: 0.5rem; }
+    .cite { box-sizing: border-box; padding: 0.3rem 0.5rem; border-radius: 4px; font-size: 0.8rem; border: 1px solid transparent; }
+    .cite .raw { font-weight: 600; font-family: monospace; }
     .cite .meta { display: block; font-size: 0.72rem; }
     .cite a { text-decoration: none; }
     .cite-linked { background: #d4edda; border-color: #b6dcc0; }
     .cite-linked .raw a { color: #155724; }
     .cite-unlinked { background: #f8d7da; border-color: #eeb9be; }
     .cite-unlinked .raw a { color: #721c24; }
-    pre.ocrtext { white-space: pre-wrap; word-wrap: break-word; max-height: 32rem; overflow-y: auto; }
+    pre.ocrtext { white-space: pre-wrap; word-wrap: break-word; position: sticky; top: 1rem; max-height: calc(100vh - 3rem); overflow-y: auto; }
 {{end}}
 
 {{define "nav"}}
@@ -26,62 +26,37 @@
         <code>{{.Page.PSMID}}</code> / <code>{{.Page.PageID}}</code> &middot;
         {{len .Page.Citations}} citation(s) detected, {{.Page.LinkedCount}} linked.
         <span style="color:#28a745;">Green</span> = linked to a case,
-        <span style="color:#dc3545;">red</span> = not yet linked.
+        <span style="color:#dc3545;">red</span> = not yet linked. Citations are ordered as they
+        appear on the page.
     </p>
 
-    <button id="load-ocr" class="btn btn-sm btn-accent"
-            data-psmid="{{.Page.PSMID}}" data-pageid="{{.Page.PageID}}">Load OCR text</button>
-    <pre id="ocr-text" class="ocrtext bg-light border rounded p-3 mt-2 small d-none"></pre>
-
-    <div class="cites">
-    {{range .Page.Citations}}
-        <span class="cite {{if .IsLinked}}cite-linked{{else}}cite-unlinked{{end}}">
-            <span class="raw"><a href="{{.CiteURL}}" title="Inspect detection &amp; linking">{{.Raw}}</a></span>
-            <span class="meta">
-                {{if .IsLinked}}
-                    {{if .CaseURL}}<a href="{{.CaseURL}}">{{ptrOr .CaseName "linked case"}}</a>{{else}}{{ptrOr .CaseName "linked case"}}{{end}}
-                {{else}}
-                    <span class="text-secondary">{{ptrOr .Status "unlinked"}}</span>
-                {{end}}
-            </span>
-        </span>
-    {{else}}
-        <span class="text-secondary small">No citations detected on this page.</span>
-    {{end}}
+    <div class="row g-4">
+        <div class="col-md-6">
+            <h2 class="h6 border-bottom pb-1">Page text</h2>
+            {{if .Page.OCRText}}
+                <pre class="ocrtext bg-light border rounded p-3 small">{{.Page.HighlightedOCR}}</pre>
+            {{else}}
+                <p class="text-secondary fst-italic small">No OCR text available for this page.</p>
+            {{end}}
+        </div>
+        <div class="col-md-6">
+            <h2 class="h6 border-bottom pb-1">Citations <span class="text-secondary fw-normal">({{len .Page.Citations}})</span></h2>
+            <div class="cites">
+            {{range .Page.Citations}}
+                <span class="cite {{if .IsLinked}}cite-linked{{else}}cite-unlinked{{end}}">
+                    <span class="raw"><a href="{{.CiteURL}}" title="Inspect detection &amp; linking">{{.Raw}}</a></span>
+                    <span class="meta">
+                        {{if .IsLinked}}
+                            {{if .CaseURL}}<a href="{{.CaseURL}}">{{ptrOr .CaseName "linked case"}}</a>{{else}}{{ptrOr .CaseName "linked case"}}{{end}}
+                        {{else}}
+                            <span class="text-secondary">{{ptrOr .Status "unlinked"}}</span>
+                        {{end}}
+                    </span>
+                </span>
+            {{else}}
+                <span class="text-secondary small">No citations detected on this page.</span>
+            {{end}}
+            </div>
+        </div>
     </div>
-
-    <script>
-    const rawCites = [{{range .Page.Citations}}{{.Raw}},{{end}}];
-    function escapeHTML(s) {
-        return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-    }
-    function highlight(text) {
-        let html = escapeHTML(text);
-        for (const raw of rawCites) {
-            if (!raw) continue;
-            const esc = escapeHTML(raw).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-            try { html = html.replace(new RegExp(esc, 'g'), m => '<mark>' + m + '</mark>'); } catch (e) {}
-        }
-        return html;
-    }
-    document.getElementById('load-ocr').addEventListener('click', async function () {
-        const btn = this;
-        const pre = document.getElementById('ocr-text');
-        btn.disabled = true;
-        btn.textContent = 'Loading…';
-        try {
-            const res = await fetch('/api/page-text?psmid=' + encodeURIComponent(btn.dataset.psmid) +
-                '&pageid=' + encodeURIComponent(btn.dataset.pageid));
-            const data = await res.json();
-            pre.innerHTML = data.text ? highlight(data.text) : '<span class="text-secondary">(no OCR text for this page)</span>';
-            pre.classList.remove('d-none');
-            btn.classList.add('d-none');
-        } catch (e) {
-            pre.textContent = 'Error loading OCR text.';
-            pre.classList.remove('d-none');
-            btn.disabled = false;
-            btn.textContent = 'Load OCR text';
-        }
-    });
-    </script>
 {{end}}

--- a/chambers/templates/treatise-page.html
+++ b/chambers/templates/treatise-page.html
@@ -1,0 +1,87 @@
+{{define "title"}}Page {{.Page.SourcePage}} &mdash; Chambers{{end}}
+
+{{define "styles"}}
+    .cites { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-top: 0.5rem; }
+    .cite { width: 18rem; box-sizing: border-box; padding: 0.3rem 0.5rem; border-radius: 4px; font-size: 0.8rem; border: 1px solid transparent; }
+    .cite .raw { font-weight: 600; font-family: monospace; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .cite .meta { display: block; font-size: 0.72rem; }
+    .cite a { text-decoration: none; }
+    .cite-linked { background: #d4edda; border-color: #b6dcc0; }
+    .cite-linked .raw a { color: #155724; }
+    .cite-unlinked { background: #f8d7da; border-color: #eeb9be; }
+    .cite-unlinked .raw a { color: #721c24; }
+    pre.ocrtext { white-space: pre-wrap; word-wrap: break-word; max-height: 32rem; overflow-y: auto; }
+{{end}}
+
+{{define "nav"}}
+    {{if .Page.TreatiseURL}}<a href="{{.Page.TreatiseURL}}" class="small text-decoration-none">&larr; Back to treatise</a>{{else}}<a href="/treatises" class="small text-decoration-none">&larr; All treatises</a>{{end}}
+{{end}}
+
+{{define "content"}}
+    <h1 class="h5 mt-2">
+        {{if .Page.Title}}{{.Page.Title | derefStr}}{{else}}Treatise page{{end}}
+        <span class="text-secondary fw-normal">&middot; p. {{.Page.SourcePage}}</span>
+    </h1>
+    <p class="small text-secondary mb-2">
+        <code>{{.Page.PSMID}}</code> / <code>{{.Page.PageID}}</code> &middot;
+        {{len .Page.Citations}} citation(s) detected, {{.Page.LinkedCount}} linked.
+        <span style="color:#28a745;">Green</span> = linked to a case,
+        <span style="color:#dc3545;">red</span> = not yet linked.
+    </p>
+
+    <button id="load-ocr" class="btn btn-sm btn-accent"
+            data-psmid="{{.Page.PSMID}}" data-pageid="{{.Page.PageID}}">Load OCR text</button>
+    <pre id="ocr-text" class="ocrtext bg-light border rounded p-3 mt-2 small d-none"></pre>
+
+    <div class="cites">
+    {{range .Page.Citations}}
+        <span class="cite {{if .IsLinked}}cite-linked{{else}}cite-unlinked{{end}}">
+            <span class="raw"><a href="{{.CiteURL}}" title="Inspect detection &amp; linking">{{.Raw}}</a></span>
+            <span class="meta">
+                {{if .IsLinked}}
+                    {{if .CaseURL}}<a href="{{.CaseURL}}">{{ptrOr .CaseName "linked case"}}</a>{{else}}{{ptrOr .CaseName "linked case"}}{{end}}
+                {{else}}
+                    <span class="text-secondary">{{ptrOr .Status "unlinked"}}</span>
+                {{end}}
+            </span>
+        </span>
+    {{else}}
+        <span class="text-secondary small">No citations detected on this page.</span>
+    {{end}}
+    </div>
+
+    <script>
+    const rawCites = [{{range .Page.Citations}}{{.Raw}},{{end}}];
+    function escapeHTML(s) {
+        return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+    function highlight(text) {
+        let html = escapeHTML(text);
+        for (const raw of rawCites) {
+            if (!raw) continue;
+            const esc = escapeHTML(raw).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            try { html = html.replace(new RegExp(esc, 'g'), m => '<mark>' + m + '</mark>'); } catch (e) {}
+        }
+        return html;
+    }
+    document.getElementById('load-ocr').addEventListener('click', async function () {
+        const btn = this;
+        const pre = document.getElementById('ocr-text');
+        btn.disabled = true;
+        btn.textContent = 'Loading…';
+        try {
+            const res = await fetch('/api/page-text?psmid=' + encodeURIComponent(btn.dataset.psmid) +
+                '&pageid=' + encodeURIComponent(btn.dataset.pageid));
+            const data = await res.json();
+            pre.innerHTML = data.text ? highlight(data.text) : '<span class="text-secondary">(no OCR text for this page)</span>';
+            pre.classList.remove('d-none');
+            btn.classList.add('d-none');
+        } catch (e) {
+            pre.textContent = 'Error loading OCR text.';
+            pre.classList.remove('d-none');
+            btn.disabled = false;
+            btn.textContent = 'Load OCR text';
+        }
+    });
+    </script>
+{{end}}

--- a/chambers/templates/treatise-page.html
+++ b/chambers/templates/treatise-page.html
@@ -6,10 +6,12 @@
     .cite .raw { font-weight: 600; font-family: monospace; }
     .cite .meta { display: block; font-size: 0.72rem; }
     .cite a { text-decoration: none; }
+    .cite .raw a { color: #212529; }
     .cite-linked { background: #d4edda; border-color: #b6dcc0; }
-    .cite-linked .raw a { color: #155724; }
-    .cite-unlinked { background: #f8d7da; border-color: #eeb9be; }
-    .cite-unlinked .raw a { color: #721c24; }
+    .cite-nomatch { background: #f8d7da; border-color: #eeb9be; }
+    .cite-junk { background: #e2e3e5; border-color: #cdd0d3; }
+    .cite-skip { background: #fff3cd; border-color: #ffe69c; }
+    .legend-dot { display: inline-block; width: 0.7rem; height: 0.7rem; border-radius: 2px; border: 1px solid rgba(0,0,0,.15); vertical-align: -1px; }
     pre.ocrtext { white-space: pre-wrap; word-wrap: break-word; position: sticky; top: 1rem; max-height: calc(100vh - 3rem); overflow-y: auto; }
 {{end}}
 
@@ -25,9 +27,13 @@
     <p class="small text-secondary mb-2">
         <code>{{.Page.PSMID}}</code> / <code>{{.Page.PageID}}</code> &middot;
         {{len .Page.Citations}} citation(s) detected, {{.Page.LinkedCount}} linked.
-        <span style="color:#28a745;">Green</span> = linked to a case,
-        <span style="color:#dc3545;">red</span> = not yet linked. Citations are ordered as they
-        appear on the page.
+        Ordered as they appear on the page.
+    </p>
+    <p class="small mb-2">
+        <span class="legend-dot cite-linked"></span> linked &nbsp;
+        <span class="legend-dot cite-nomatch"></span> no match &nbsp;
+        <span class="legend-dot cite-skip"></span> reporter not whitelisted &nbsp;
+        <span class="legend-dot cite-junk"></span> junk (not a real citation)
     </p>
 
     <div class="row g-4">
@@ -43,7 +49,7 @@
             <h2 class="h6 border-bottom pb-1">Citations <span class="text-secondary fw-normal">({{len .Page.Citations}})</span></h2>
             <div class="cites">
             {{range .Page.Citations}}
-                <span class="cite {{if .IsLinked}}cite-linked{{else}}cite-unlinked{{end}}">
+                <span class="cite {{.ChipClass}}">
                     <span class="raw"><a href="{{.CiteURL}}" title="Inspect detection &amp; linking">{{.Raw}}</a></span>
                     <span class="meta">
                         {{if .IsLinked}}

--- a/chambers/templates/treatise.html
+++ b/chambers/templates/treatise.html
@@ -8,7 +8,9 @@
 {{end}}
 
 {{define "nav"}}
-    <a href="/treatises" class="small text-decoration-none">&larr; All treatises</a>
+    <a href="/" class="small text-decoration-none">&larr; Chambers</a>
+    <span class="text-secondary small mx-1">&middot;</span>
+    <a href="/treatises" class="small text-decoration-none">All treatises</a>
 {{end}}
 
 {{define "content"}}

--- a/chambers/templates/treatise.html
+++ b/chambers/templates/treatise.html
@@ -1,0 +1,52 @@
+{{define "title"}}{{if .T.Title}}{{.T.Title}}{{else}}Treatise{{end}} &mdash; Chambers{{end}}
+
+{{define "styles"}}
+    td.num { text-align: right; font-variant-numeric: tabular-nums; }
+    .linked { color: #28a745; }
+    .unlinked { color: #dc3545; }
+    .pages-table td, .pages-table th { padding-top: 0.15rem; padding-bottom: 0.15rem; }
+{{end}}
+
+{{define "nav"}}
+    <a href="/treatises" class="small text-decoration-none">&larr; All treatises</a>
+{{end}}
+
+{{define "content"}}
+    <h1 class="h5 mt-2">{{if .T.Title}}{{.T.Title}}{{else}}(untitled treatise){{end}}</h1>
+    <div class="detail-grid small mb-2" style="display:grid; grid-template-columns:auto 1fr; gap:0.1rem 0.8rem;">
+        {{if .T.Author}}<span class="text-secondary">Author</span><span>{{.T.Author | derefStr}}</span>{{end}}
+        {{if .T.Year}}<span class="text-secondary">Year</span><span>{{deref .T.Year}}</span>{{end}}
+        <span class="text-secondary">Volumes</span><span>{{.T.Vols}}</span>
+        <span class="text-secondary">Bibliographic ID</span><span><code>{{.T.BiblioID}}</code></span>
+        {{if .T.Subjects}}<span class="text-secondary">Subjects</span><span>{{range .T.Subjects}}<span class="badge bg-secondary me-1">{{.}}</span>{{end}}</span>{{end}}
+    </div>
+    <p class="small text-secondary">
+        Pages on which citations were detected. <span class="linked">Green</span> = linked,
+        <span class="unlinked">red</span> = not yet linked. Click a page to see its citations.
+    </p>
+
+    {{range .T.Volumes}}
+        {{if $.T.MultiVolume}}
+            <h2 class="h6 border-bottom pb-1 mt-3">Volume {{if .VolumeLabel}}{{.VolumeLabel}}{{else}}&mdash;{{end}} <span class="text-secondary small fw-normal"><code>{{.PSMID}}</code></span></h2>
+        {{end}}
+        {{if .Pages}}
+        <table class="table table-sm table-hover align-middle pages-table" style="max-width: 40rem;">
+            <thead>
+                <tr><th>Page</th><th class="text-end">Citations</th><th class="text-end">Linked</th><th class="text-end">Unlinked</th></tr>
+            </thead>
+            <tbody>
+            {{range .Pages}}
+                <tr>
+                    <td><a href="{{.URL}}">p. {{.SourcePage}}</a></td>
+                    <td class="num">{{.Cites}}</td>
+                    <td class="num linked">{{.Linked}}</td>
+                    <td class="num unlinked">{{.NotLinked}}</td>
+                </tr>
+            {{end}}
+            </tbody>
+        </table>
+        {{else}}
+            <p class="small text-secondary fst-italic">No citations detected in this volume.</p>
+        {{end}}
+    {{end}}
+{{end}}

--- a/chambers/templates/treatise.html
+++ b/chambers/templates/treatise.html
@@ -39,8 +39,8 @@
                 <tr>
                     <td><a href="{{.URL}}">p. {{.SourcePage}}</a></td>
                     <td class="num">{{.Cites}}</td>
-                    <td class="num linked">{{.Linked}}</td>
-                    <td class="num unlinked">{{.NotLinked}}</td>
+                    <td class="num linked">{{.Linked}}{{if .Cites}} <span class="small text-secondary">({{.LinkedPct}}%)</span>{{end}}</td>
+                    <td class="num unlinked">{{.NotLinked}}{{if .Cites}} <span class="small text-secondary">({{.NotLinkedPct}}%)</span>{{end}}</td>
                 </tr>
             {{end}}
             </tbody>

--- a/chambers/templates/treatises.html
+++ b/chambers/templates/treatises.html
@@ -31,7 +31,7 @@
     </form>
 
     <div class="btn-group btn-group-sm mb-3" role="group" aria-label="Sort">
-        <a href="/treatises?sort=cites{{if .Q}}&q={{.Q | urlquery}}{{end}}" class="btn {{if eq .Sort "cites"}}btn-primary{{else}}btn-outline-secondary{{end}}">Most cited</a>
+        <a href="/treatises?sort=cites{{if .Q}}&q={{.Q | urlquery}}{{end}}" class="btn {{if eq .Sort "cites"}}btn-primary{{else}}btn-outline-secondary{{end}}">Most citations</a>
         <a href="/treatises?sort=year{{if .Q}}&q={{.Q | urlquery}}{{end}}" class="btn {{if eq .Sort "year"}}btn-primary{{else}}btn-outline-secondary{{end}}">Earliest</a>
         <a href="/treatises?sort=title{{if .Q}}&q={{.Q | urlquery}}{{end}}" class="btn {{if eq .Sort "title"}}btn-primary{{else}}btn-outline-secondary{{end}}">Title</a>
     </div>
@@ -56,8 +56,8 @@
                 <td class="num">{{if .Year}}{{deref .Year}}{{else}}&mdash;{{end}}</td>
                 <td class="num">{{.Vols}}</td>
                 <td class="num">{{.N}}</td>
-                <td class="num linked">{{.Linked}}</td>
-                <td class="num unlinked">{{.NotLinked}}</td>
+                <td class="num linked">{{.Linked}}{{if .N}} <span class="small text-secondary">({{.LinkedPct}}%)</span>{{end}}</td>
+                <td class="num unlinked">{{.NotLinked}}{{if .N}} <span class="small text-secondary">({{.NotLinkedPct}}%)</span>{{end}}</td>
             </tr>
         {{else}}
             <tr><td colspan="7" class="text-secondary">No treatises found. (If all counts are zero, the

--- a/chambers/templates/treatises.html
+++ b/chambers/templates/treatises.html
@@ -4,6 +4,7 @@
     td.num { text-align: right; font-variant-numeric: tabular-nums; }
     .linked { color: #28a745; }
     .unlinked { color: #dc3545; }
+    .title-col { width: 22rem; max-width: 22rem; word-break: break-word; }
 {{end}}
 
 {{define "nav"}}
@@ -39,7 +40,7 @@
     <table class="table table-sm table-hover align-middle">
         <thead>
             <tr>
-                <th>Treatise</th>
+                <th class="title-col">Treatise</th>
                 <th>Author</th>
                 <th class="text-end">Year</th>
                 <th class="text-end">Vols</th>
@@ -51,7 +52,7 @@
         <tbody>
         {{range .Items}}
             <tr>
-                <td><a href="{{.DetailURL}}">{{.Title}}</a></td>
+                <td class="title-col"><a href="{{.DetailURL}}">{{.Title}}</a></td>
                 <td class="small text-secondary">{{ptrOr .Author "&mdash;"}}</td>
                 <td class="num">{{if .Year}}{{deref .Year}}{{else}}&mdash;{{end}}</td>
                 <td class="num">{{.Vols}}</td>

--- a/chambers/templates/treatises.html
+++ b/chambers/templates/treatises.html
@@ -1,0 +1,80 @@
+{{define "title"}}U.S. treatises &mdash; Chambers{{end}}
+
+{{define "styles"}}
+    td.num { text-align: right; font-variant-numeric: tabular-nums; }
+    .linked { color: #28a745; }
+    .unlinked { color: #dc3545; }
+{{end}}
+
+{{define "nav"}}
+    <a href="/" class="small text-decoration-none">&larr; Back to Chambers</a>
+{{end}}
+
+{{define "content"}}
+    <h1 class="h5 mt-2">U.S. treatises</h1>
+    <p class="small text-secondary mb-2">
+        Every U.S. legal treatise in the <em>Making of Modern Law</em>
+        (<code>moml.us_treatises</code>), with the number of citations detected across its
+        volumes. <span class="linked">Green</span> citations are linked to a case;
+        <span class="unlinked">red</span> are not yet linked. Click a title to browse its
+        pages.
+    </p>
+
+    <form method="get" class="row g-2 align-items-center mb-2">
+        <div class="col-auto">
+            <input type="search" name="q" value="{{.Q}}" class="form-control form-control-sm"
+                   placeholder="Search title&hellip;" style="min-width: 18rem;">
+        </div>
+        <input type="hidden" name="sort" value="{{.Sort}}">
+        <div class="col-auto"><button class="btn btn-sm btn-primary">Search</button></div>
+        {{if .Q}}<div class="col-auto"><a href="/treatises?sort={{.Sort}}" class="small">clear</a></div>{{end}}
+    </form>
+
+    <div class="btn-group btn-group-sm mb-3" role="group" aria-label="Sort">
+        <a href="/treatises?sort=cites{{if .Q}}&q={{.Q | urlquery}}{{end}}" class="btn {{if eq .Sort "cites"}}btn-primary{{else}}btn-outline-secondary{{end}}">Most cited</a>
+        <a href="/treatises?sort=year{{if .Q}}&q={{.Q | urlquery}}{{end}}" class="btn {{if eq .Sort "year"}}btn-primary{{else}}btn-outline-secondary{{end}}">Earliest</a>
+        <a href="/treatises?sort=title{{if .Q}}&q={{.Q | urlquery}}{{end}}" class="btn {{if eq .Sort "title"}}btn-primary{{else}}btn-outline-secondary{{end}}">Title</a>
+    </div>
+
+    <table class="table table-sm table-hover align-middle">
+        <thead>
+            <tr>
+                <th>Treatise</th>
+                <th>Author</th>
+                <th class="text-end">Year</th>
+                <th class="text-end">Vols</th>
+                <th class="text-end">Citations</th>
+                <th class="text-end">Linked</th>
+                <th class="text-end">Unlinked</th>
+            </tr>
+        </thead>
+        <tbody>
+        {{range .Items}}
+            <tr>
+                <td><a href="{{.DetailURL}}">{{.Title}}</a></td>
+                <td class="small text-secondary">{{ptrOr .Author "&mdash;"}}</td>
+                <td class="num">{{if .Year}}{{deref .Year}}{{else}}&mdash;{{end}}</td>
+                <td class="num">{{.Vols}}</td>
+                <td class="num">{{.N}}</td>
+                <td class="num linked">{{.Linked}}</td>
+                <td class="num unlinked">{{.NotLinked}}</td>
+            </tr>
+        {{else}}
+            <tr><td colspan="7" class="text-secondary">No treatises found. (If all counts are zero, the
+                <code>treatise_citation_counts</code> view may need a <code>make db-refresh</code>.)</td></tr>
+        {{end}}
+        </tbody>
+    </table>
+
+    {{template "pagination" .Nav}}
+{{end}}
+
+{{define "pagination"}}
+    {{if or .HasPrev .HasNext}}
+    <nav class="my-3">
+        {{if .HasPrev}}<a href="{{.PrevURL}}" class="btn btn-sm btn-outline-secondary">&larr; Prev</a>{{end}}
+        <span class="small text-secondary mx-2">Page {{.Page}}</span>
+        {{if .HasNext}}<a href="{{.NextURL}}" class="btn btn-sm btn-outline-secondary">Next &rarr;</a>{{end}}
+    </nav>
+    {{end}}
+{{end}}

--- a/db/migrations/20260610140000_create_chambers_browse_matviews.sql
+++ b/db/migrations/20260610140000_create_chambers_browse_matviews.sql
@@ -1,0 +1,130 @@
+-- migrate:up
+SET ROLE = law_admin;
+
+-- Precomputed aggregates for the chambers browse pages (/treatises, /cases,
+-- /normalized). Each of these pages ranks or counts over the ~62M-row
+-- moml_citations.citations_unlinked and moml_citations.citation_links tables;
+-- aggregating them on every request takes 90+ seconds. These materialized
+-- views move that work off the request path. They are built WITH NO DATA and
+-- refreshed manually with `make db-refresh` (db/refresh-matviews.sh discovers
+-- every materialized view automatically, so no script edit is needed). See the
+-- note before migrate:down for manual REFRESH commands.
+
+-- Per-treatise citation counts. For each MOML treatise volume (psmid, stored as
+-- citations_unlinked.moml_treatise), counts total detected citations and splits
+-- them into linked (any 'linked_%' status) and not-linked (no_match, skipped_%,
+-- or no link row). The /treatises list sums these over each work's volumes; the
+-- /treatise detail reads per-volume counts directly.
+CREATE MATERIALIZED VIEW IF NOT EXISTS moml_citations.treatise_citation_counts AS
+SELECT
+  cu.moml_treatise,
+  count(*) AS n,
+  count(*) FILTER (WHERE cl.status LIKE 'linked_%') AS linked,
+  count(*) FILTER (WHERE cl.status IS NULL OR cl.status NOT LIKE 'linked_%') AS not_linked
+FROM moml_citations.citations_unlinked cu
+LEFT JOIN moml_citations.citation_links cl ON cl.citation_id = cu.id
+GROUP BY cu.moml_treatise
+WITH NO DATA;
+
+-- Unique index on the grouping key (moml_treatise is the GROUP BY key, unique
+-- by construction). Documents the invariant and keeps REFRESH ... CONCURRENTLY
+-- available; also used to look up a single volume's counts.
+CREATE UNIQUE INDEX IF NOT EXISTS treatise_citation_counts_uq
+  ON moml_citations.treatise_citation_counts (moml_treatise);
+
+-- Case citation counts across all three linked case sources, unified into one
+-- ranking. source is 'cap', 'er' (English Reports), or 'code' (code reporter);
+-- case_id is the source-table primary key cast to text so the three id types
+-- (bigint, text, bigint) share one column. page_count counts each treatise page
+-- once even if a case is cited several times on it (the user's "count one
+-- citation per treatise page"); cite_count is the raw number of linked
+-- citations. Powers /cases (ranked by page_count).
+CREATE MATERIALIZED VIEW IF NOT EXISTS moml_citations.case_citation_counts AS
+SELECT 'cap'::text AS source,
+       cl.cap_case_id::text AS case_id,
+       count(DISTINCT (cu.moml_treatise, cu.moml_page)) AS page_count,
+       count(*) AS cite_count
+FROM moml_citations.citation_links cl
+JOIN moml_citations.citations_unlinked cu ON cu.id = cl.citation_id
+WHERE cl.status = 'linked_cap'
+GROUP BY cl.cap_case_id
+UNION ALL
+SELECT 'er'::text,
+       cl.er_case_id,
+       count(DISTINCT (cu.moml_treatise, cu.moml_page)),
+       count(*)
+FROM moml_citations.citation_links cl
+JOIN moml_citations.citations_unlinked cu ON cu.id = cl.citation_id
+WHERE cl.status = 'linked_english_reports'
+GROUP BY cl.er_case_id
+UNION ALL
+SELECT 'code'::text,
+       cl.code_reporter_id::text,
+       count(DISTINCT (cu.moml_treatise, cu.moml_page)),
+       count(*)
+FROM moml_citations.citation_links cl
+JOIN moml_citations.citations_unlinked cu ON cu.id = cl.citation_id
+WHERE cl.status = 'linked_code_reporter'
+GROUP BY cl.code_reporter_id
+WITH NO DATA;
+
+-- Unique index on (source, case_id): each case id is distinct within its source
+-- by GROUP BY, and source distinguishes the three unions.
+CREATE UNIQUE INDEX IF NOT EXISTS case_citation_counts_uq
+  ON moml_citations.case_citation_counts (source, case_id);
+
+-- Supports ranked reads / pagination (ORDER BY page_count DESC).
+CREATE INDEX IF NOT EXISTS case_citation_counts_page_count_idx
+  ON moml_citations.case_citation_counts (page_count DESC);
+
+-- Normalized-citation counts. Groups every link attempt by its normalized
+-- citation string (cite_normalized, e.g. "2 Haw. 63"); a normalized string can
+-- mix linked and not-linked instances. cite_count is total occurrences,
+-- linked_count how many were linked, and page_count the number of distinct
+-- treatise pages the normalized citation appears on. Powers /normalized.
+CREATE MATERIALIZED VIEW IF NOT EXISTS moml_citations.normalized_citation_counts AS
+SELECT
+  cl.cite_normalized,
+  count(*) AS cite_count,
+  count(*) FILTER (WHERE cl.status LIKE 'linked_%') AS linked_count,
+  count(DISTINCT (cu.moml_treatise, cu.moml_page)) AS page_count
+FROM moml_citations.citation_links cl
+JOIN moml_citations.citations_unlinked cu ON cu.id = cl.citation_id
+WHERE cl.cite_normalized IS NOT NULL
+GROUP BY cl.cite_normalized
+WITH NO DATA;
+
+-- Unique index on the grouping key (cite_normalized is the GROUP BY key).
+CREATE UNIQUE INDEX IF NOT EXISTS normalized_citation_counts_uq
+  ON moml_citations.normalized_citation_counts (cite_normalized);
+
+-- Supports ranked reads / pagination (ORDER BY cite_count DESC).
+CREATE INDEX IF NOT EXISTS normalized_citation_counts_count_idx
+  ON moml_citations.normalized_citation_counts (cite_count DESC);
+
+-- Supports anchored prefix search on the normalized string (LIKE 'foo%') from
+-- the /normalized search box.
+CREATE INDEX IF NOT EXISTS normalized_citation_counts_prefix_idx
+  ON moml_citations.normalized_citation_counts (cite_normalized text_pattern_ops);
+
+-- Index on citation_links.cite_normalized so the /normalized/cite detail page
+-- can list every instance of one normalized string without scanning the whole
+-- ~62M-row table. This index build is the heavy part of this migration (it
+-- scans the full table once); it is a one-time cost at migration time.
+CREATE INDEX IF NOT EXISTS citation_links_cite_normalized_idx
+  ON moml_citations.citation_links (cite_normalized);
+
+-- After this migration the three views are empty. Populate them (and refresh the
+-- existing dashboard views) with:
+--   make db-refresh
+-- or individually:
+--   REFRESH MATERIALIZED VIEW moml_citations.treatise_citation_counts;
+--   REFRESH MATERIALIZED VIEW moml_citations.case_citation_counts;
+--   REFRESH MATERIALIZED VIEW moml_citations.normalized_citation_counts;
+
+-- migrate:down
+SET ROLE = law_admin;
+DROP INDEX IF EXISTS moml_citations.citation_links_cite_normalized_idx;
+DROP MATERIALIZED VIEW IF EXISTS moml_citations.normalized_citation_counts;
+DROP MATERIALIZED VIEW IF EXISTS moml_citations.case_citation_counts;
+DROP MATERIALIZED VIEW IF EXISTS moml_citations.treatise_citation_counts;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1330,6 +1330,40 @@ CREATE TABLE moml_citations.citation_links (
 
 
 --
+-- Name: case_citation_counts; Type: MATERIALIZED VIEW; Schema: moml_citations; Owner: -
+--
+
+CREATE MATERIALIZED VIEW moml_citations.case_citation_counts AS
+ SELECT 'cap'::text AS source,
+    (cl.cap_case_id)::text AS case_id,
+    count(DISTINCT ROW(cu.moml_treatise, cu.moml_page)) AS page_count,
+    count(*) AS cite_count
+   FROM (moml_citations.citation_links cl
+     JOIN moml_citations.citations_unlinked cu ON ((cu.id = cl.citation_id)))
+  WHERE (cl.status = 'linked_cap'::text)
+  GROUP BY cl.cap_case_id
+UNION ALL
+ SELECT 'er'::text AS source,
+    cl.er_case_id AS case_id,
+    count(DISTINCT ROW(cu.moml_treatise, cu.moml_page)) AS page_count,
+    count(*) AS cite_count
+   FROM (moml_citations.citation_links cl
+     JOIN moml_citations.citations_unlinked cu ON ((cu.id = cl.citation_id)))
+  WHERE (cl.status = 'linked_english_reports'::text)
+  GROUP BY cl.er_case_id
+UNION ALL
+ SELECT 'code'::text AS source,
+    (cl.code_reporter_id)::text AS case_id,
+    count(DISTINCT ROW(cu.moml_treatise, cu.moml_page)) AS page_count,
+    count(*) AS cite_count
+   FROM (moml_citations.citation_links cl
+     JOIN moml_citations.citations_unlinked cu ON ((cu.id = cl.citation_id)))
+  WHERE (cl.status = 'linked_code_reporter'::text)
+  GROUP BY cl.code_reporter_id
+  WITH NO DATA;
+
+
+--
 -- Name: citation_links_detail; Type: VIEW; Schema: moml_citations; Owner: -
 --
 
@@ -1414,6 +1448,37 @@ UNION ALL
     count(*) AS n
    FROM moml_citations.citation_links
   GROUP BY citation_links.status
+  WITH NO DATA;
+
+
+--
+-- Name: normalized_citation_counts; Type: MATERIALIZED VIEW; Schema: moml_citations; Owner: -
+--
+
+CREATE MATERIALIZED VIEW moml_citations.normalized_citation_counts AS
+ SELECT cl.cite_normalized,
+    count(*) AS cite_count,
+    count(*) FILTER (WHERE (cl.status ~~ 'linked_%'::text)) AS linked_count,
+    count(DISTINCT ROW(cu.moml_treatise, cu.moml_page)) AS page_count
+   FROM (moml_citations.citation_links cl
+     JOIN moml_citations.citations_unlinked cu ON ((cu.id = cl.citation_id)))
+  WHERE (cl.cite_normalized IS NOT NULL)
+  GROUP BY cl.cite_normalized
+  WITH NO DATA;
+
+
+--
+-- Name: treatise_citation_counts; Type: MATERIALIZED VIEW; Schema: moml_citations; Owner: -
+--
+
+CREATE MATERIALIZED VIEW moml_citations.treatise_citation_counts AS
+ SELECT cu.moml_treatise,
+    count(*) AS n,
+    count(*) FILTER (WHERE (cl.status ~~ 'linked_%'::text)) AS linked,
+    count(*) FILTER (WHERE ((cl.status IS NULL) OR (cl.status !~~ 'linked_%'::text))) AS not_linked
+   FROM (moml_citations.citations_unlinked cu
+     LEFT JOIN moml_citations.citation_links cl ON ((cl.citation_id = cu.id)))
+  GROUP BY cu.moml_treatise
   WITH NO DATA;
 
 
@@ -2113,6 +2178,27 @@ CREATE INDEX page_bodytype_idx ON moml.page USING btree (type) WHERE ((type)::te
 
 
 --
+-- Name: case_citation_counts_page_count_idx; Type: INDEX; Schema: moml_citations; Owner: -
+--
+
+CREATE INDEX case_citation_counts_page_count_idx ON moml_citations.case_citation_counts USING btree (page_count DESC);
+
+
+--
+-- Name: case_citation_counts_uq; Type: INDEX; Schema: moml_citations; Owner: -
+--
+
+CREATE UNIQUE INDEX case_citation_counts_uq ON moml_citations.case_citation_counts USING btree (source, case_id);
+
+
+--
+-- Name: citation_links_cite_normalized_idx; Type: INDEX; Schema: moml_citations; Owner: -
+--
+
+CREATE INDEX citation_links_cite_normalized_idx ON moml_citations.citation_links USING btree (cite_normalized);
+
+
+--
 -- Name: citations_unlinked_reporter_abbr_idx; Type: INDEX; Schema: moml_citations; Owner: -
 --
 
@@ -2201,6 +2287,34 @@ CREATE INDEX moml_page_to_cap_case_moml_page_idx ON moml_citations.page_to_case 
 --
 
 CREATE INDEX moml_page_to_cap_case_moml_treatise_idx ON moml_citations.page_to_case USING btree (moml_treatise);
+
+
+--
+-- Name: normalized_citation_counts_count_idx; Type: INDEX; Schema: moml_citations; Owner: -
+--
+
+CREATE INDEX normalized_citation_counts_count_idx ON moml_citations.normalized_citation_counts USING btree (cite_count DESC);
+
+
+--
+-- Name: normalized_citation_counts_prefix_idx; Type: INDEX; Schema: moml_citations; Owner: -
+--
+
+CREATE INDEX normalized_citation_counts_prefix_idx ON moml_citations.normalized_citation_counts USING btree (cite_normalized text_pattern_ops);
+
+
+--
+-- Name: normalized_citation_counts_uq; Type: INDEX; Schema: moml_citations; Owner: -
+--
+
+CREATE UNIQUE INDEX normalized_citation_counts_uq ON moml_citations.normalized_citation_counts USING btree (cite_normalized);
+
+
+--
+-- Name: treatise_citation_counts_uq; Type: INDEX; Schema: moml_citations; Owner: -
+--
+
+CREATE UNIQUE INDEX treatise_citation_counts_uq ON moml_citations.treatise_citation_counts USING btree (moml_treatise);
 
 
 --
@@ -2520,4 +2634,5 @@ INSERT INTO sys_admin.migrations_dbmate (version) VALUES
     ('20260609115030'),
     ('20260609133000'),
     ('20260610120000'),
-    ('20260610130000');
+    ('20260610130000'),
+    ('20260610140000');


### PR DESCRIPTION
## What this adds

A connected set of **browse + detail pages** in Chambers so the citation corpus can be navigated the way a historian thinks about it — **treatise → page → citation** — plus two "what gets cited" rankings.

| Page | Route | What it shows |
|---|---|---|
| U.S. treatises | `/treatises` | The 10,552 US treatise works, searchable, sortable by citation count / year / title, with linked/unlinked totals and percentages |
| Treatise detail | `/treatise?id=…` | A work's volume(s) and its citation-bearing pages, each with green/red counts and percentages |
| Treatise page | `/treatise/page?psmid=…&pageid=…` | The page's OCR text (auto-loaded, left half) with detected citations highlighted, and the citations (right half) ordered as they appear on the page, color-coded by status; links to the original page on Gale MOML (GMU & Columbia) |
| Most-cited cases | `/cases` | Cases ranked by distinct treatise pages citing them, across CAP / English Reports / code reporters, with distinct source-color badges |
| Case detail | `/case?source=…&id=…` | Case metadata + the citing treatises, one row per treatise with all its pages inline |
| Normalized citations | `/normalized` | Citations grouped by normalized form, ranked by frequency, prefix-searchable |
| Normalized detail | `/normalized/cite?c=…` | The treatise-page instances of one normalized citation, color-coded by status |

Citation chips are colored by link status: green = linked, red = `no_match`, gray = `skipped_junk` (OCR noise), amber = skipped / reporter-not-whitelisted. Every detail page has a breadcrumb back to Chambers plus local nav.

## Implementation

Follows the existing Chambers conventions (global `*pgxpool.Pool`, `getX` query funcs returning local structs, `handleX` handlers, `baseof` template blocks). New code lives in `chambers/browse_queries.go` and `chambers/browse_handlers.go`; `main.go` registers the templates and routes; seven new templates plus home nav cards.

## Database

The three ranked lists read materialized views added in `db/migrations/20260610140000_create_chambers_browse_matviews.sql` — `treatise_citation_counts`, `case_citation_counts`, `normalized_citation_counts` — plus an index on `citation_links.cite_normalized`. Live aggregation over the ~62M-row citation tables takes 90+ seconds, so these move that work off the request path (matching the existing `citations_unmatched_top` / `linking_dashboard_*` pattern). The views are built `WITH NO DATA`; `db/refresh-matviews.sh` auto-discovers them, so `make db-refresh` populates them. The migration has already been applied and `db/schema.sql` regenerated and committed.

## Verification

`go build`, `go vet`, `go test ./...` pass. All pages were exercised live against the database (read-only); the per-treatise/per-page/per-case lookups are indexed and fast, and the ranked lists read the matviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)