### PR TITLE
Use FreeLaw parallel citations as a linker fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,10 +42,18 @@ Write code in Go unless instructed otherwise.
 
 Follow idiomatic Go patterns. Specific conventions used in this project:
 
-**Logging:** Use the `slog` package for structured logging. Output JSON to stderr. Control log level with the `LAW_DEBUG` environment variable. Domain objects should provide a `LogID()` method returning `[]any` key-value pairs for consistent structured log context. Example:
+**Logging:** Use the `slog` package for structured logging. Output JSON to stderr. Control log level with the `LAW_DEBUG` environment variable. Domain objects should provide a `LogID()` method returning `[]any` key-value pairs for consistent structured log context.
+
+Log levels:
+
+- **DEBUG** — intermittent, per-iteration progress (e.g. per-batch counts inside a loop). Gated behind `LAW_DEBUG` so a normal run isn't noisy.
+- **INFO** — phase starts and final results (e.g. `deleted X rows`, `loaded N entries`, `done linking citations`). For a long operation, log the outcome once when it finishes — not per chunk.
+- **WARN** — recoverable problems that don't stop the run.
+- **ERROR** — failures, typically right before exiting.
 
 ```go
-slog.Info("processed batch", batch.LogID()...)
+slog.Debug("saved batch", batch.LogID()...)        // per-iteration progress → DEBUG
+slog.Info("reset complete", "deleted", n)          // final result → INFO
 slog.Error("batch failed", batch.LogID("error", err)...)
 ```
 

--- a/cite-linker/main.go
+++ b/cite-linker/main.go
@@ -66,8 +66,8 @@ func main() {
 
 	// Handle --reset: delete unresolved links (no_match, skipped_not_whitelisted)
 	// so they are re-processed by this run. Linked rows and skipped_junk rows are
-	// preserved. Done before everything else so the dashboard refresh and linking
-	// below see the post-reset state.
+	// preserved. Done before everything else so the linking below sees the
+	// post-reset state.
 	if reset {
 		slog.Info("resetting unresolved citation links (no_match, skipped_not_whitelisted)")
 		deleted, err := store.ResetUnlinked(ctx)
@@ -76,16 +76,6 @@ func main() {
 			os.Exit(1)
 		}
 		slog.Info("reset complete", "deleted", deleted)
-	}
-
-	// Refresh the dashboard materialized views up front so they reflect the
-	// state of the data before this run begins. A failed refresh should not
-	// block linking, so log and continue.
-	slog.Info("refreshing dashboard materialized views")
-	if err := store.RefreshDashboardViews(ctx); err != nil {
-		slog.Warn("could not refresh dashboard materialized views", "error", err)
-	} else {
-		slog.Info("refreshed dashboard materialized views")
 	}
 
 	// Handle --skip-unlisted: bulk skip, then continue to linking
@@ -250,14 +240,8 @@ func main() {
 	wp.StopWait()
 	slog.Info("done linking citations")
 
-	// Refresh the dashboard materialized views again so they reflect the links
-	// produced by this run. Log and continue on failure.
-	slog.Info("refreshing dashboard materialized views")
-	if err := store.RefreshDashboardViews(ctx); err != nil {
-		slog.Warn("could not refresh dashboard materialized views", "error", err)
-	} else {
-		slog.Info("refreshed dashboard materialized views")
-	}
+	// The chambers dashboard materialized views are refreshed separately after a
+	// run (make db-refresh / db/refresh-matviews.sh), not by the linker.
 }
 
 // linkCitation processes a single citation through the linking pipeline.

--- a/cite-linker/main.go
+++ b/cite-linker/main.go
@@ -26,7 +26,7 @@ func main() {
 	var workers int
 	flag.BoolVar(&showProgress, "progress", false, "show a progress bar")
 	flag.BoolVar(&skipUnlisted, "skip-unlisted", false, "batch-mark non-whitelisted citations as skipped before linking")
-	flag.BoolVar(&reset, "reset", false, "before linking, delete unresolved links (status no_match and skipped_not_whitelisted) so they are re-processed; linked_* and skipped_junk rows are kept")
+	flag.BoolVar(&reset, "reset", false, "before linking, delete every non-linked citation_links row (status no_match, skipped_not_whitelisted, skipped_junk) so they are re-processed; only linked_* rows are kept")
 	flag.IntVar(&batchSize, "batch-size", 5000, "number of citations to fetch per batch (max 8000)")
 	flag.IntVar(&workers, "workers", runtime.NumCPU()*2, "number of concurrent workers")
 	flag.Parse()
@@ -64,12 +64,12 @@ func main() {
 
 	store := citations.NewLinkerDBStore(pool)
 
-	// Handle --reset: delete unresolved links (no_match, skipped_not_whitelisted)
-	// so they are re-processed by this run. Linked rows and skipped_junk rows are
-	// preserved. Done before everything else so the linking below sees the
-	// post-reset state.
+	// Handle --reset: delete every non-linked row (no_match,
+	// skipped_not_whitelisted, skipped_junk) so they are re-processed by this run.
+	// Only linked_* rows are preserved. Done before everything else so the linking
+	// below sees the post-reset state.
 	if reset {
-		slog.Info("resetting unresolved citation links (no_match, skipped_not_whitelisted)")
+		slog.Info("resetting unresolved citation links (no_match, skipped_not_whitelisted, skipped_junk)")
 		deleted, err := store.ResetUnlinked(ctx)
 		if err != nil {
 			slog.Error("reset failed", "deleted", deleted, "error", err)

--- a/cite-linker/main.go
+++ b/cite-linker/main.go
@@ -21,10 +21,12 @@ import (
 func main() {
 	var showProgress bool
 	var skipUnlisted bool
+	var reset bool
 	var batchSize int
 	var workers int
 	flag.BoolVar(&showProgress, "progress", false, "show a progress bar")
 	flag.BoolVar(&skipUnlisted, "skip-unlisted", false, "batch-mark non-whitelisted citations as skipped before linking")
+	flag.BoolVar(&reset, "reset", false, "before linking, delete unresolved links (status no_match and skipped_not_whitelisted) so they are re-processed; linked_* and skipped_junk rows are kept")
 	flag.IntVar(&batchSize, "batch-size", 5000, "number of citations to fetch per batch (max 8000)")
 	flag.IntVar(&workers, "workers", runtime.NumCPU()*2, "number of concurrent workers")
 	flag.Parse()
@@ -61,6 +63,20 @@ func main() {
 	slog.Info("connected to the database", "database", db.Host())
 
 	store := citations.NewLinkerDBStore(pool)
+
+	// Handle --reset: delete unresolved links (no_match, skipped_not_whitelisted)
+	// so they are re-processed by this run. Linked rows and skipped_junk rows are
+	// preserved. Done before everything else so the dashboard refresh and linking
+	// below see the post-reset state.
+	if reset {
+		slog.Info("resetting unresolved citation links (no_match, skipped_not_whitelisted)")
+		deleted, err := store.ResetUnlinked(ctx)
+		if err != nil {
+			slog.Error("reset failed", "deleted", deleted, "error", err)
+			os.Exit(1)
+		}
+		slog.Info("reset complete", "deleted", deleted)
+	}
 
 	// Refresh the dashboard materialized views up front so they reflect the
 	// state of the data before this run begins. A failed refresh should not
@@ -109,6 +125,17 @@ func main() {
 		os.Exit(1)
 	}
 	slog.Info("loaded CAP citations", "entries", len(capCites))
+
+	slog.Info("loading FreeLaw cite crosswalk")
+	freelawCites, err := store.LoadFreelawCites(ctx)
+	if err != nil {
+		slog.Error("could not load FreeLaw cite crosswalk", "error", err)
+		os.Exit(1)
+	}
+	if len(freelawCites) == 0 {
+		slog.Warn("FreeLaw cite crosswalk is empty; the FreeLaw fallback will do nothing — refresh the freelaw.cite_to_cap materialized view")
+	}
+	slog.Info("loaded FreeLaw cite crosswalk", "entries", len(freelawCites))
 
 	slog.Info("loading code reporter citations")
 	codeCites, err := store.LoadCodeReporterCitations(ctx)
@@ -193,7 +220,7 @@ func main() {
 				wg.Add(1)
 				go func(idx int) {
 					defer wg.Done()
-					results[idx] = linkCitation(&batchCopy[idx], whitelist, diffvols, capCites, codeCites, erCites)
+					results[idx] = linkCitation(&batchCopy[idx], whitelist, diffvols, capCites, freelawCites, codeCites, erCites)
 				}(i)
 			}
 			wg.Wait()
@@ -240,6 +267,7 @@ func linkCitation(
 	whitelist map[string]*citations.WhitelistEntry,
 	diffvols map[string]map[int]*citations.DiffVolEntry,
 	capCites map[string]int64,
+	freelawCites map[string]int64,
 	codeCites map[string]int64,
 	erCites map[string]string,
 ) *citations.LinkResult {
@@ -266,15 +294,18 @@ func linkCitation(
 	if entry.UK {
 		return linkEnglishReports(c, entry, erCites, result)
 	}
-	return linkCAPThenCode(c, entry, diffvols, capCites, codeCites, result)
+	return linkCAPThenCode(c, entry, diffvols, capCites, freelawCites, codeCites, result)
 }
 
-// linkCAPThenCode tries CAP first, then Code Reporter using in-memory maps.
+// linkCAPThenCode tries CAP first, then the FreeLaw parallel-citation crosswalk
+// (which also resolves to a CAP case), then the Code Reporter, all using
+// in-memory maps.
 func linkCAPThenCode(
 	c *citations.UnlinkedCitation,
 	entry *citations.WhitelistEntry,
 	diffvols map[string]map[int]*citations.DiffVolEntry,
 	capCites map[string]int64,
+	freelawCites map[string]int64,
 	codeCites map[string]int64,
 	result *citations.LinkResult,
 ) *citations.LinkResult {
@@ -286,6 +317,16 @@ func linkCAPThenCode(
 
 	// Try CAP with the normalized cite
 	if caseID, ok := capCites[citeNormalized]; ok {
+		result.Status = citations.StatusLinkedCAP
+		result.CAPCaseID = &caseID
+		result.CiteLinked = &citeNormalized
+		return result
+	}
+
+	// Fall back to the FreeLaw crosswalk: if any parallel form of this decision
+	// is in our CAP data, this reaches the CAP case from the form we detected.
+	// The result is still a CAP link (status linked_cap).
+	if caseID, ok := freelawCites[citeNormalized]; ok {
 		result.Status = citations.StatusLinkedCAP
 		result.CAPCaseID = &caseID
 		result.CiteLinked = &citeNormalized

--- a/cite-linker/main_test.go
+++ b/cite-linker/main_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/lmullen/legal-modernism/go/citations"
+	"github.com/stretchr/testify/assert"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+func TestLinkCitation(t *testing.T) {
+	usStd := "U.S."
+	qbStd := "Q.B."
+	statStd := "Stat."
+
+	tests := []struct {
+		name         string
+		cite         citations.UnlinkedCitation
+		whitelist    map[string]*citations.WhitelistEntry
+		capCites     map[string]int64
+		freelawCites map[string]int64
+		codeCites    map[string]int64
+		erCites      map[string]string
+		wantStatus   string
+		wantCAPID    *int64
+		wantCodeID   *int64
+		wantERID     *string
+		wantLinked   *string
+	}{
+		{
+			name:         "exact CAP hit wins over FreeLaw",
+			cite:         citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(5), ReporterAbbr: "U.S.", Page: 10},
+			whitelist:    map[string]*citations.WhitelistEntry{"U.S.": {ReporterStandard: &usStd}},
+			capCites:     map[string]int64{"5 U.S. 10": 111},
+			freelawCites: map[string]int64{"5 U.S. 10": 222},
+			wantStatus:   citations.StatusLinkedCAP,
+			wantCAPID:    ptr(int64(111)),
+			wantLinked:   ptr("5 U.S. 10"),
+		},
+		{
+			name:         "CAP miss, FreeLaw hit links to CAP case",
+			cite:         citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(5), ReporterAbbr: "U.S.", Page: 10},
+			whitelist:    map[string]*citations.WhitelistEntry{"U.S.": {ReporterStandard: &usStd}},
+			capCites:     map[string]int64{},
+			freelawCites: map[string]int64{"5 U.S. 10": 222},
+			wantStatus:   citations.StatusLinkedCAP,
+			wantCAPID:    ptr(int64(222)),
+			wantLinked:   ptr("5 U.S. 10"),
+		},
+		{
+			name:         "CAP miss, FreeLaw miss falls through to code reporter",
+			cite:         citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(2), ReporterAbbr: "Stat.", Page: 30},
+			whitelist:    map[string]*citations.WhitelistEntry{"Stat.": {ReporterStandard: &statStd}},
+			capCites:     map[string]int64{},
+			freelawCites: map[string]int64{},
+			codeCites:    map[string]int64{"2 Stat. 30": 999},
+			wantStatus:   citations.StatusLinkedCodeReporter,
+			wantCodeID:   ptr(int64(999)),
+			wantLinked:   ptr("2 Stat. 30"),
+		},
+		{
+			name:         "CAP miss, FreeLaw miss, code miss is no_match",
+			cite:         citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(5), ReporterAbbr: "U.S.", Page: 10},
+			whitelist:    map[string]*citations.WhitelistEntry{"U.S.": {ReporterStandard: &usStd}},
+			capCites:     map[string]int64{},
+			freelawCites: map[string]int64{},
+			codeCites:    map[string]int64{},
+			wantStatus:   citations.StatusNoMatch,
+			wantLinked:   nil,
+		},
+		{
+			name:         "FreeLaw is not consulted for UK reporters",
+			cite:         citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(1), ReporterAbbr: "Q.B.", Page: 20},
+			whitelist:    map[string]*citations.WhitelistEntry{"Q.B.": {ReporterStandard: &qbStd, UK: true}},
+			freelawCites: map[string]int64{"1 Q.B. 20": 222},
+			erCites:      map[string]string{"1 Q.B. 20": "er-1"},
+			wantStatus:   citations.StatusLinkedEnglishReports,
+			wantERID:     ptr("er-1"),
+			wantLinked:   ptr("1 Q.B. 20"),
+		},
+		{
+			name:       "not whitelisted is skipped",
+			cite:       citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(5), ReporterAbbr: "Bogus", Page: 10},
+			whitelist:  map[string]*citations.WhitelistEntry{},
+			wantStatus: citations.StatusSkippedNotWhitelisted,
+		},
+		{
+			name:       "junk reporter is skipped",
+			cite:       citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(5), ReporterAbbr: "U.S.", Page: 10},
+			whitelist:  map[string]*citations.WhitelistEntry{"U.S.": {Junk: true}},
+			wantStatus: citations.StatusSkippedJunk,
+		},
+		{
+			name:       "whitelisted but no standard reporter is no_match",
+			cite:       citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(5), ReporterAbbr: "U.S.", Page: 10},
+			whitelist:  map[string]*citations.WhitelistEntry{"U.S.": {ReporterStandard: nil}},
+			wantStatus: citations.StatusNoMatch,
+		},
+	}
+
+	diffvols := map[string]map[int]*citations.DiffVolEntry{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := linkCitation(&tt.cite, tt.whitelist, diffvols, tt.capCites, tt.freelawCites, tt.codeCites, tt.erCites)
+
+			assert.Equal(t, tt.wantStatus, got.Status)
+			assert.Equal(t, tt.cite.ID, got.CitationID)
+
+			if tt.wantCAPID == nil {
+				assert.Nil(t, got.CAPCaseID)
+			} else {
+				if assert.NotNil(t, got.CAPCaseID) {
+					assert.Equal(t, *tt.wantCAPID, *got.CAPCaseID)
+				}
+			}
+
+			if tt.wantCodeID == nil {
+				assert.Nil(t, got.CodeReporterID)
+			} else {
+				if assert.NotNil(t, got.CodeReporterID) {
+					assert.Equal(t, *tt.wantCodeID, *got.CodeReporterID)
+				}
+			}
+
+			if tt.wantERID == nil {
+				assert.Nil(t, got.ERCaseID)
+			} else {
+				if assert.NotNil(t, got.ERCaseID) {
+					assert.Equal(t, *tt.wantERID, *got.ERCaseID)
+				}
+			}
+
+			if tt.wantLinked == nil {
+				assert.Nil(t, got.CiteLinked)
+			} else {
+				if assert.NotNil(t, got.CiteLinked) {
+					assert.Equal(t, *tt.wantLinked, *got.CiteLinked)
+				}
+			}
+		})
+	}
+}

--- a/db/migrations/20260611182350_create_freelaw_cite_to_cap.sql
+++ b/db/migrations/20260611182350_create_freelaw_cite_to_cap.sql
@@ -1,0 +1,78 @@
+-- migrate:up
+SET ROLE = law_admin;
+
+-- A precomputed cite -> cap_case_id crosswalk covering every parallel citation
+-- form of each decision FreeLaw (CourtListener) knows about. The cite-linker
+-- loads this into memory and consults it as a fallback after the exact
+-- cap.citations lookup misses: if any parallel form of a decision is in our CAP
+-- data, we can reach the CAP case from every form (e.g. a treatise citing a
+-- reporter form CAP doesn't index directly). Keyed on the same
+-- "{volume} {reporter} {page}" string the linker builds (freelaw.citations.cite,
+-- a generated column), so no new matching machinery is needed.
+--
+-- Two routes resolve a cluster to a CAP case:
+--   Route A: freelaw.clusters_to_cap.cap_case_id (the direct ~99.8% path).
+--   Route B: for clusters Route A cannot resolve (NULL cap_case_id, or no
+--            clusters_to_cap row at all), recover a cap_case_id via a sibling
+--            parallel cite of the same cluster that exists in cap.citations.
+--
+-- A cite is kept only if it resolves UNAMBIGUOUSLY to a single cap_case_id.
+-- ~6% of linkable cites map to 2+ CAP cases — dominated by memorandum/table
+-- pages (e.g. "108 S. Ct. 185" lists 6 cert denials; "234 A.D. 748" lists 13
+-- memorandum decisions) where the cite cannot identify one case. Linking those
+-- to an arbitrary case would inject systematic errors, so they are dropped.
+--
+-- lexis/west/journal citation types are excluded: these are database-ID cites
+-- ("5 WL 55", "5 LEXIS 55", journal cites) that the linker never constructs from
+-- a reporter name, so they would only bloat the in-memory map.
+--
+-- This is a SOURCE crosswalk: it depends on the freelaw and cap data, not on
+-- linker output, so it is NOT refreshed by the cite-linker on each run. Build it
+-- WITH NO DATA and populate it with `make db-refresh` (which auto-discovers every
+-- materialized view) or:
+--   REFRESH MATERIALIZED VIEW freelaw.cite_to_cap;
+-- The build runs two large joins and takes several minutes.
+CREATE MATERIALIZED VIEW IF NOT EXISTS freelaw.cite_to_cap AS
+WITH relevant AS (
+  SELECT cite, cluster_id
+  FROM freelaw.citations
+  WHERE type NOT IN ('lexis', 'west', 'journal')
+),
+cluster_cap AS (
+  -- Route A: direct cluster -> CAP mapping.
+  SELECT cluster_id, cap_case_id
+  FROM freelaw.clusters_to_cap
+  WHERE cap_case_id IS NOT NULL
+  UNION
+  -- Route B: clusters Route A cannot resolve, recovered via a sibling parallel
+  -- cite present in cap.citations.
+  SELECT r.cluster_id, capc."case" AS cap_case_id
+  FROM relevant r
+  JOIN cap.citations capc ON capc.cite = r.cite
+  WHERE NOT EXISTS (
+    SELECT 1 FROM freelaw.clusters_to_cap a
+    WHERE a.cluster_id = r.cluster_id AND a.cap_case_id IS NOT NULL
+  )
+),
+cite_caps AS (
+  -- Map every parallel cite form to the cap_case_id(s) of its cluster.
+  SELECT r.cite, cc.cap_case_id
+  FROM relevant r
+  JOIN cluster_cap cc ON cc.cluster_id = r.cluster_id
+)
+SELECT cite, min(cap_case_id) AS cap_case_id
+FROM cite_caps
+GROUP BY cite
+HAVING count(DISTINCT cap_case_id) = 1
+WITH NO DATA;
+
+-- Unique index on the lookup key (cite is the GROUP BY key, unique by
+-- construction). Required for the in-memory load to be a clean cite -> id map and
+-- keeps REFRESH MATERIALIZED VIEW CONCURRENTLY available.
+CREATE UNIQUE INDEX IF NOT EXISTS freelaw_cite_to_cap_uq
+  ON freelaw.cite_to_cap (cite);
+
+-- migrate:down
+SET ROLE = law_admin;
+
+DROP MATERIALIZED VIEW IF EXISTS freelaw.cite_to_cap;

--- a/go/citations/linker_store.go
+++ b/go/citations/linker_store.go
@@ -25,6 +25,11 @@ type LinkerStore interface {
 	// LoadCAPCitations loads all CAP citations into memory as cite -> case ID.
 	LoadCAPCitations(ctx context.Context) (map[string]int64, error)
 
+	// LoadFreelawCites loads the FreeLaw parallel-citation crosswalk
+	// (freelaw.cite_to_cap) into memory as cite -> cap_case_id. The linker uses
+	// it as a fallback after the exact cap.citations lookup misses.
+	LoadFreelawCites(ctx context.Context) (map[string]int64, error)
+
 	// LoadCodeReporterCitations loads all code reporter citations into memory
 	// as official_citation -> id.
 	LoadCodeReporterCitations(ctx context.Context) (map[string]int64, error)
@@ -35,6 +40,12 @@ type LinkerStore interface {
 
 	// SaveLinkResults batch-inserts multiple link results in a single query.
 	SaveLinkResults(ctx context.Context, results []*LinkResult) error
+
+	// ResetUnlinked deletes citation_links rows that were not resolved to a case
+	// (status no_match and skipped_not_whitelisted) so the linker re-processes
+	// them, while preserving every linked_* row and skipped_junk row. Returns the
+	// number of rows deleted.
+	ResetUnlinked(ctx context.Context) (int64, error)
 
 	// BatchSkipNonWhitelisted marks all non-whitelisted citations as skipped
 	// in a single bulk operation. Returns the number of rows affected.

--- a/go/citations/linker_store.go
+++ b/go/citations/linker_store.go
@@ -41,10 +41,10 @@ type LinkerStore interface {
 	// SaveLinkResults batch-inserts multiple link results in a single query.
 	SaveLinkResults(ctx context.Context, results []*LinkResult) error
 
-	// ResetUnlinked deletes citation_links rows that were not resolved to a case
-	// (status no_match and skipped_not_whitelisted) so the linker re-processes
-	// them, while preserving every linked_* row and skipped_junk row. Returns the
-	// number of rows deleted.
+	// ResetUnlinked deletes every citation_links row that was not resolved to a
+	// case (status no_match, skipped_not_whitelisted, or skipped_junk) so the
+	// linker re-processes them, preserving only linked_* rows. Returns the number
+	// of rows deleted.
 	ResetUnlinked(ctx context.Context) (int64, error)
 
 	// BatchSkipNonWhitelisted marks all non-whitelisted citations as skipped

--- a/go/citations/linker_store.go
+++ b/go/citations/linker_store.go
@@ -50,10 +50,4 @@ type LinkerStore interface {
 	// BatchSkipNonWhitelisted marks all non-whitelisted citations as skipped
 	// in a single bulk operation. Returns the number of rows affected.
 	BatchSkipNonWhitelisted(ctx context.Context) (int64, error)
-
-	// RefreshDashboardViews refreshes the materialized views that back the
-	// chambers dashboard (citations_unmatched_top, linking_dashboard_reporters,
-	// linking_dashboard_summary) so their precomputed aggregates reflect the
-	// current state of citation_links.
-	RefreshDashboardViews(ctx context.Context) error
 }

--- a/go/citations/linker_store_db.go
+++ b/go/citations/linker_store_db.go
@@ -3,7 +3,6 @@ package citations
 import (
 	"context"
 	"fmt"
-	"log/slog"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -299,47 +298,21 @@ func (s *LinkerDBStore) BatchSkipNonWhitelisted(ctx context.Context) (int64, err
 	return tag.RowsAffected(), nil
 }
 
-// resetDeleteBatch is the number of rows ResetUnlinked deletes per statement.
-// Deleting in chunks keeps each transaction's WAL bounded and lets the run be
-// interrupted between chunks rather than rolling back one giant (~35M-row)
-// delete.
-const resetDeleteBatch = 50000
-
 // ResetUnlinked deletes citation_links rows that were not resolved to a case
 // (status no_match or skipped_not_whitelisted) so the linker re-processes them on
 // the next run. Every linked_* row and every skipped_junk row is left untouched.
-// The delete runs in batches of resetDeleteBatch rows; it returns the total
-// number of rows deleted. A cancelled context stops the loop and returns the
-// rows deleted so far along with the context error.
+// The delete runs as a single statement — one all-or-nothing transaction — and
+// returns the number of rows deleted.
 func (s *LinkerDBStore) ResetUnlinked(ctx context.Context) (int64, error) {
 	query := `
 	DELETE FROM moml_citations.citation_links
-	WHERE citation_id IN (
-		SELECT citation_id FROM moml_citations.citation_links
-		WHERE status IN ($1, $2)
-		LIMIT $3
-	)
+	WHERE status IN ($1, $2)
 	`
-	var total int64
-	for {
-		select {
-		case <-ctx.Done():
-			return total, ctx.Err()
-		default:
-		}
-
-		tag, err := s.DB.Exec(ctx, query, StatusNoMatch, StatusSkippedNotWhitelisted, resetDeleteBatch)
-		if err != nil {
-			return total, fmt.Errorf("resetting unlinked citations after %d rows: %w", total, err)
-		}
-		n := tag.RowsAffected()
-		if n == 0 {
-			break
-		}
-		total += n
-		slog.Info("reset progress", "deleted", total)
+	tag, err := s.DB.Exec(ctx, query, StatusNoMatch, StatusSkippedNotWhitelisted)
+	if err != nil {
+		return 0, fmt.Errorf("resetting unlinked citations: %w", err)
 	}
-	return total, nil
+	return tag.RowsAffected(), nil
 }
 
 // dashboardViews are the materialized views that precompute aggregates read by

--- a/go/citations/linker_store_db.go
+++ b/go/citations/linker_store_db.go
@@ -3,6 +3,7 @@ package citations
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -164,6 +165,34 @@ func (s *LinkerDBStore) LoadCAPCitations(ctx context.Context) (map[string]int64,
 	return m, nil
 }
 
+// LoadFreelawCites loads the FreeLaw parallel-citation crosswalk into an
+// in-memory map of cite -> cap_case_id. The matview is keyed on the same
+// "{volume} {reporter} {page}" cite string the linker builds, so the linker can
+// probe it exactly like the cap.citations map. The matview already enforces one
+// cap_case_id per cite, so no DISTINCT is needed here.
+func (s *LinkerDBStore) LoadFreelawCites(ctx context.Context) (map[string]int64, error) {
+	query := `SELECT cite, cap_case_id FROM freelaw.cite_to_cap`
+	rows, err := s.DB.Query(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("loading FreeLaw cites: %w", err)
+	}
+	defer rows.Close()
+
+	m := make(map[string]int64)
+	for rows.Next() {
+		var cite string
+		var caseID int64
+		if err := rows.Scan(&cite, &caseID); err != nil {
+			return nil, fmt.Errorf("scanning FreeLaw cite: %w", err)
+		}
+		m[cite] = caseID
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating FreeLaw cites: %w", err)
+	}
+	return m, nil
+}
+
 // LoadCodeReporterCitations loads code_reporter into an in-memory map of
 // official_citation -> id.
 func (s *LinkerDBStore) LoadCodeReporterCitations(ctx context.Context) (map[string]int64, error) {
@@ -268,6 +297,49 @@ func (s *LinkerDBStore) BatchSkipNonWhitelisted(ctx context.Context) (int64, err
 		return 0, fmt.Errorf("batch skipping non-whitelisted citations: %w", err)
 	}
 	return tag.RowsAffected(), nil
+}
+
+// resetDeleteBatch is the number of rows ResetUnlinked deletes per statement.
+// Deleting in chunks keeps each transaction's WAL bounded and lets the run be
+// interrupted between chunks rather than rolling back one giant (~35M-row)
+// delete.
+const resetDeleteBatch = 50000
+
+// ResetUnlinked deletes citation_links rows that were not resolved to a case
+// (status no_match or skipped_not_whitelisted) so the linker re-processes them on
+// the next run. Every linked_* row and every skipped_junk row is left untouched.
+// The delete runs in batches of resetDeleteBatch rows; it returns the total
+// number of rows deleted. A cancelled context stops the loop and returns the
+// rows deleted so far along with the context error.
+func (s *LinkerDBStore) ResetUnlinked(ctx context.Context) (int64, error) {
+	query := `
+	DELETE FROM moml_citations.citation_links
+	WHERE citation_id IN (
+		SELECT citation_id FROM moml_citations.citation_links
+		WHERE status IN ($1, $2)
+		LIMIT $3
+	)
+	`
+	var total int64
+	for {
+		select {
+		case <-ctx.Done():
+			return total, ctx.Err()
+		default:
+		}
+
+		tag, err := s.DB.Exec(ctx, query, StatusNoMatch, StatusSkippedNotWhitelisted, resetDeleteBatch)
+		if err != nil {
+			return total, fmt.Errorf("resetting unlinked citations after %d rows: %w", total, err)
+		}
+		n := tag.RowsAffected()
+		if n == 0 {
+			break
+		}
+		total += n
+		slog.Info("reset progress", "deleted", total)
+	}
+	return total, nil
 }
 
 // dashboardViews are the materialized views that precompute aggregates read by

--- a/go/citations/linker_store_db.go
+++ b/go/citations/linker_store_db.go
@@ -314,29 +314,3 @@ func (s *LinkerDBStore) ResetUnlinked(ctx context.Context) (int64, error) {
 	}
 	return tag.RowsAffected(), nil
 }
-
-// dashboardViews are the materialized views that precompute aggregates read by
-// the chambers linking dashboard and unmatched-citations pages. They are
-// refreshed together by RefreshDashboardViews.
-var dashboardViews = []string{
-	"moml_citations.citations_unmatched_top",
-	"moml_citations.linking_dashboard_reporters",
-	"moml_citations.linking_dashboard_summary",
-}
-
-// RefreshDashboardViews refreshes the materialized views that back the chambers
-// dashboard so their precomputed aggregates reflect the current state of
-// citation_links. Each refresh is blocking: the call does not return until the
-// views have been rebuilt, so the linker does no further work until it is done.
-// These are plain (non-concurrent) refreshes, which take an exclusive lock that
-// blocks readers while they run. That is acceptable here because the views are
-// not read during a linker run, and a plain refresh is faster than a
-// CONCURRENTLY refresh.
-func (s *LinkerDBStore) RefreshDashboardViews(ctx context.Context) error {
-	for _, view := range dashboardViews {
-		if _, err := s.DB.Exec(ctx, "REFRESH MATERIALIZED VIEW "+view); err != nil {
-			return fmt.Errorf("refreshing %s: %w", view, err)
-		}
-	}
-	return nil
-}

--- a/go/citations/linker_store_db.go
+++ b/go/citations/linker_store_db.go
@@ -298,17 +298,19 @@ func (s *LinkerDBStore) BatchSkipNonWhitelisted(ctx context.Context) (int64, err
 	return tag.RowsAffected(), nil
 }
 
-// ResetUnlinked deletes citation_links rows that were not resolved to a case
-// (status no_match or skipped_not_whitelisted) so the linker re-processes them on
-// the next run. Every linked_* row and every skipped_junk row is left untouched.
-// The delete runs as a single statement — one all-or-nothing transaction — and
-// returns the number of rows deleted.
+// ResetUnlinked deletes every citation_links row that was not resolved to a case
+// (status no_match, skipped_not_whitelisted, or skipped_junk) so the linker
+// re-processes them on the next run; only linked_* rows are preserved. Deleting
+// both skip statuses lets a re-run with --skip-unlisted re-derive them from the
+// current whitelist, so a reporter later corrected from junk to legit is no
+// longer stuck as skipped_junk. The delete runs as a single statement — one
+// all-or-nothing transaction — and returns the number of rows deleted.
 func (s *LinkerDBStore) ResetUnlinked(ctx context.Context) (int64, error) {
 	query := `
 	DELETE FROM moml_citations.citation_links
-	WHERE status IN ($1, $2)
+	WHERE status IN ($1, $2, $3)
 	`
-	tag, err := s.DB.Exec(ctx, query, StatusNoMatch, StatusSkippedNotWhitelisted)
+	tag, err := s.DB.Exec(ctx, query, StatusNoMatch, StatusSkippedNotWhitelisted, StatusSkippedJunk)
 	if err != nil {
 		return 0, fmt.Errorf("resetting unlinked citations: %w", err)
 	}

--- a/slurm/cite-linker.sh
+++ b/slurm/cite-linker.sh
@@ -17,4 +17,14 @@
 #SBATCH --mail-type FAIL
 
 ## Run the program
+
+# Routine run: link any not-yet-processed citations.
 ~/legal-modernism/bin/cite-linker --skip-unlisted --batch-size=8000 --workers=32
+
+# One-time reset run (FreeLaw rollout / after whitelist corrections): comment out
+# the line above and use the line below instead. --reset deletes unresolved links
+# (no_match, skipped_not_whitelisted) so they are re-linked against the FreeLaw
+# crosswalk; linked_* and skipped_junk rows are kept. Re-comment it afterward —
+# leaving --reset in would wipe and re-do those rows on every subsequent run. If
+# the job is interrupted, resume WITHOUT --reset.
+# ~/legal-modernism/bin/cite-linker --reset --skip-unlisted --batch-size=8000 --workers=32

--- a/slurm/cite-linker.sh
+++ b/slurm/cite-linker.sh
@@ -22,9 +22,9 @@
 # ~/legal-modernism/bin/cite-linker --skip-unlisted --batch-size=8000 --workers=32
 
 # One-time reset run (FreeLaw rollout / after whitelist corrections): comment out
-# the line above and use the line below instead. --reset deletes unresolved links
-# (no_match, skipped_not_whitelisted) so they are re-linked against the FreeLaw
-# crosswalk; linked_* and skipped_junk rows are kept. Re-comment it afterward —
-# leaving --reset in would wipe and re-do those rows on every subsequent run. If
-# the job is interrupted, resume WITHOUT --reset.
+# the line above and use the line below instead. --reset deletes every non-linked
+# row (no_match, skipped_not_whitelisted, skipped_junk) so they are re-linked
+# against the FreeLaw crosswalk; only linked_* rows are kept. Re-comment it
+# afterward — leaving --reset in would wipe and re-do those rows on every
+# subsequent run. If the job is interrupted, resume WITHOUT --reset.
 ~/legal-modernism/bin/cite-linker --reset --skip-unlisted --batch-size=8000 --workers=32

--- a/slurm/cite-linker.sh
+++ b/slurm/cite-linker.sh
@@ -19,7 +19,7 @@
 ## Run the program
 
 # Routine run: link any not-yet-processed citations.
-~/legal-modernism/bin/cite-linker --skip-unlisted --batch-size=8000 --workers=32
+# ~/legal-modernism/bin/cite-linker --skip-unlisted --batch-size=8000 --workers=32
 
 # One-time reset run (FreeLaw rollout / after whitelist corrections): comment out
 # the line above and use the line below instead. --reset deletes unresolved links
@@ -27,4 +27,4 @@
 # crosswalk; linked_* and skipped_junk rows are kept. Re-comment it afterward —
 # leaving --reset in would wipe and re-do those rows on every subsequent run. If
 # the job is interrupted, resume WITHOUT --reset.
-# ~/legal-modernism/bin/cite-linker --reset --skip-unlisted --batch-size=8000 --workers=32
+~/legal-modernism/bin/cite-linker --reset --skip-unlisted --batch-size=8000 --workers=32


### PR DESCRIPTION
Adds a FreeLaw (CourtListener) parallel-citation fallback to `cite-linker`, plus a `--reset` mechanism to re-process previously unresolved citations. Part of #197 (intentionally does **not** close it — the linking gains are only realized once the migration is applied, the matview is refreshed, and the linker is re-run; I'll close the issue after posting the post-run numbers).

## What's here

- **`freelaw.cite_to_cap` materialized view** (new migration). A precomputed `cite → cap_case_id` crosswalk over every parallel citation form FreeLaw knows, so the linker can reach a CAP case from *any* parallel form, not just the one `cap.citations` indexes.
  - **Route A:** cluster → `freelaw.clusters_to_cap.cap_case_id` (the ~99.8% path).
  - **Route B:** clusters Route A can't resolve, recovered via a sibling parallel cite present in `cap.citations`.
  - **Unambiguous only:** a cite is kept only if it resolves to a single `cap_case_id`. ~6% of linkable cites map to 2+ CAP cases — dominated by memorandum/table pages (e.g. `108 S. Ct. 185` = 6 cert denials) where the cite can't identify one case — so those are dropped to avoid systematically wrong links.
  - Excludes `lexis`/`west`/`journal` database-ID cites the linker can never construct. Built `WITH NO DATA`.
- **FreeLaw fallback tier** in `linkCAPThenCode`, after the exact `cap.citations` miss and before the code-reporter lookup. A hit is recorded as an ordinary `linked_cap` link — **no new status**, so chambers, the dashboards, and the browse matviews need no changes. (Trade-off: FreeLaw-derived links aren't separately auditable from direct CAP hits.)
- **`--reset` flag**: single-statement (all-or-nothing transaction) delete of every non-linked row (`no_match`, `skipped_not_whitelisted`, `skipped_junk`), preserving only `linked_*` rows, so they're re-processed. Combined with `--skip-unlisted` it re-derives skip status from the *current* whitelist, keeping the reset robust to future whitelist corrections/expansions (including a reporter later corrected from junk to legit).
- The linker no longer refreshes the chambers dashboard matviews itself; refresh them separately after a run with `make db-refresh`.
- Table-driven test for the linking pipeline (CAP-wins-over-FreeLaw, FreeLaw fallback, code fall-through, no_match, UK skip, whitelist/junk branches).

`go build`, `go vet`, `gofmt`, and `go test ./...` all pass. The matview SELECT was `EXPLAIN`-validated against the live DB.

## Deploy / run steps (require DB write + HPC access)

1. `make db-up`, then `make db-schema`, and commit the regenerated `db/schema.sql` (not included here — needs write access).
2. `REFRESH MATERIALIZED VIEW freelaw.cite_to_cap;` (or `make db-refresh`) — a several-minute one-time build.
3. `cite-linker --reset --skip-unlisted --progress` — allocate a few extra GB (the FreeLaw map adds ~1–1.5 GB). One-time; if interrupted, resume **without** `--reset`.
4. After: `make db-refresh` (surface new links in chambers/website) and `VACUUM (ANALYZE) moml_citations.citation_links` (reclaim delete bloat).

## Known limitations

- The reset re-evaluates only non-linked rows; already-`linked_*` rows are preserved untouched, so whitelist changes affecting an already-linked reporter aren't applied retroactively.
- No provenance: FreeLaw-derived links are indistinguishable from direct CAP links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)