### PR TITLE
Stream the cite-linker's unprocessed set in one pass (fixes 13h DB bottleneck)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BIN_DIR = bin
 DARWIN_TARGETS = $(foreach bin,$(BINARIES),$(BIN_DIR)/darwin-arm64/$(bin))
 LINUX_TARGETS = $(foreach bin,$(BINARIES),$(BIN_DIR)/linux-amd64/$(bin))
 
-.PHONY: binaries clean test vet sync-hopper db-up db-down db-status db-schema db-refresh chambers
+.PHONY: binaries clean test vet sync-hopper db-up db-down db-status db-schema db-maintenance chambers
 
 binaries: $(DARWIN_TARGETS) $(LINUX_TARGETS)
 
@@ -51,10 +51,11 @@ db-status:
 db-schema:
 	dbmate --env DBMATE_URL dump
 
-# Refresh all materialized views, in dependency order and in parallel within
-# each level. Uses LAW_DBSTR directly (needs write access).
-db-refresh:
-	./db/refresh-matviews.sh
+# Post-linker maintenance: vacuum/analyze the churned tables, then refresh all
+# materialized views in dependency order (parallel within each level). Uses
+# LAW_DBSTR directly (needs write access).
+db-maintenance:
+	./db/maintenance.sh
 
 chambers:
 	cd ./chambers && go run github.com/air-verse/air

--- a/cite-linker/main.go
+++ b/cite-linker/main.go
@@ -2,16 +2,16 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
-	"runtime"
 	"sync"
+	"sync/atomic"
 	"syscall"
 
-	"github.com/gammazero/workerpool"
-	"github.com/google/uuid"
+	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/lmullen/legal-modernism/go/citations"
 	"github.com/lmullen/legal-modernism/go/db"
 	"github.com/schollz/progressbar/v3"
@@ -27,12 +27,15 @@ func main() {
 	flag.BoolVar(&showProgress, "progress", false, "show a progress bar")
 	flag.BoolVar(&skipUnlisted, "skip-unlisted", false, "batch-mark non-whitelisted citations as skipped before linking")
 	flag.BoolVar(&reset, "reset", false, "before linking, delete every non-linked citation_links row (status no_match, skipped_not_whitelisted, skipped_junk) so they are re-processed; only linked_* rows are kept")
-	flag.IntVar(&batchSize, "batch-size", 5000, "number of citations to fetch per batch (max 8000)")
-	flag.IntVar(&workers, "workers", runtime.NumCPU()*2, "number of concurrent workers")
+	flag.IntVar(&batchSize, "batch-size", 5000, "number of citations per insert batch")
+	flag.IntVar(&workers, "workers", 32, "number of concurrent insert workers (each uses one DB connection)")
 	flag.Parse()
 
-	if batchSize > 8000 {
-		batchSize = 8000
+	if batchSize < 1 {
+		batchSize = 1
+	}
+	if workers < 1 {
+		workers = 1
 	}
 
 	slog.Info("starting the citation linker")
@@ -54,7 +57,13 @@ func main() {
 	}()
 
 	slog.Info("connecting to database", "database", db.Host())
-	pool, err := db.Connect(ctx)
+	// Size the pool to the insert workers plus one dedicated connection for the
+	// long-lived streaming read, with a small margin. Without this the default
+	// pool could starve either the reader or the workers and serialize inserts.
+	maxConns := int32(workers + 2)
+	pool, err := db.ConnectPool(ctx, func(c *pgxpool.Config) {
+		c.MaxConns = maxConns
+	})
 	if err != nil {
 		slog.Error("could not connect to database", "database", db.Host(), "error", err)
 		os.Exit(1)
@@ -143,102 +152,87 @@ func main() {
 	}
 	slog.Info("loaded English Reports citations", "entries", len(erCites))
 
-	// Count unprocessed for progress bar
-	total, err := store.CountUnprocessedCitations(ctx)
-	if err != nil {
-		slog.Error("could not count unprocessed citations", "error", err)
-		os.Exit(1)
-	}
-	slog.Info("unprocessed citations", "count", total)
-
-	if total == 0 {
-		slog.Info("no unprocessed citations, nothing to do")
-		return
-	}
-
 	var pb *progressbar.ProgressBar
 	if showProgress {
-		pb = progressbar.NewOptions64(total,
+		// The unprocessed total is not pre-counted (an exact count is itself a
+		// full anti-join), so the bar runs in count/rate mode without an ETA.
+		pb = progressbar.NewOptions64(-1,
 			progressbar.OptionSetWriter(os.Stdout),
 			progressbar.OptionShowCount(),
 			progressbar.OptionShowIts(),
-			progressbar.OptionSetPredictTime(true),
 		)
 	}
 
-	wp := workerpool.New(workers)
-
+	// Bounded pipeline. A single streaming reader (this goroutine, inside
+	// StreamUnprocessedCitations) feeds batches to a fixed pool of insert
+	// workers through a bounded channel. The channel capacity bounds how many
+	// batches are in flight, so the reader blocks — applying backpressure —
+	// when the workers fall behind, instead of buffering the whole 62M-row
+	// table in memory.
+	batchCh := make(chan []citations.UnlinkedCitation, workers)
+	var wg sync.WaitGroup
 	var pbMu sync.Mutex
+	var processed atomic.Int64
 
-	// Process in batches using cursor-based pagination.
-	// Fetching is sequential (cursor requires it), but each batch is
-	// handed off to a worker for in-memory linking + batch INSERT.
-	lastID := uuid.Nil
-	for {
-		select {
-		case <-ctx.Done():
-			slog.Info("context cancelled, stopping")
-			wp.StopWait()
-			return
-		default:
-		}
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for batch := range batchCh {
+				select {
+				case <-ctx.Done():
+					continue // drain the channel without doing work
+				default:
+				}
 
-		batch, err := store.GetUnprocessedCitations(ctx, lastID, batchSize)
-		if err != nil {
-			slog.Error("could not fetch batch", "after_id", lastID, "error", err)
-			break
-		}
-		if len(batch) == 0 {
-			break
-		}
-
-		lastID = batch[len(batch)-1].ID
-		slog.Debug("fetched batch", "size", len(batch), "last_id", lastID)
-
-		// Hand the batch to a worker
-		batchCopy := batch
-		wp.Submit(func() {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-			}
-
-			results := make([]*citations.LinkResult, len(batchCopy))
-			var wg sync.WaitGroup
-			for i := range batchCopy {
-				wg.Add(1)
-				go func(idx int) {
-					defer wg.Done()
-					results[idx] = linkCitation(&batchCopy[idx], whitelist, diffvols, capCites, freelawCites, codeCites, erCites)
-				}(i)
-			}
-			wg.Wait()
-
-			if err := store.SaveLinkResults(ctx, results); err != nil {
-				slog.Error("could not save batch results", "error", err)
-			} else {
+				results := make([]*citations.LinkResult, len(batch))
 				statusCounts := make(map[string]int)
-				for _, r := range results {
+				for j := range batch {
+					r := linkCitation(&batch[j], whitelist, diffvols, capCites, freelawCites, codeCites, erCites)
+					results[j] = r
 					statusCounts[r.Status]++
 				}
+
+				if err := store.SaveLinkResults(ctx, results); err != nil {
+					slog.Error("could not save batch results", "error", err)
+					continue
+				}
+
+				processed.Add(int64(len(batch)))
 				attrs := []any{"size", len(results)}
 				for status, count := range statusCounts {
 					attrs = append(attrs, status, count)
 				}
 				slog.Debug("saved batch", attrs...)
-			}
 
-			if pb != nil {
-				pbMu.Lock()
-				pb.Add(len(batchCopy))
-				pbMu.Unlock()
+				if pb != nil {
+					pbMu.Lock()
+					pb.Add(len(batch))
+					pbMu.Unlock()
+				}
 			}
-		})
+		}()
 	}
 
-	wp.StopWait()
-	slog.Info("done linking citations")
+	// Stream the whole unprocessed set in one pass, pushing batches into the
+	// bounded channel. The send blocks when the channel is full (backpressure).
+	streamErr := store.StreamUnprocessedCitations(ctx, batchSize, func(batch []citations.UnlinkedCitation) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case batchCh <- batch:
+			return nil
+		}
+	})
+	close(batchCh)
+	wg.Wait()
+
+	if streamErr != nil && !errors.Is(streamErr, context.Canceled) {
+		slog.Error("streaming unprocessed citations failed", "processed", processed.Load(), "error", streamErr)
+		os.Exit(1)
+	}
+
+	slog.Info("done linking citations", "processed", processed.Load())
 
 	// The chambers dashboard materialized views are refreshed separately after a
 	// run (make db-refresh / db/refresh-matviews.sh), not by the linker.

--- a/cite-linker/main.go
+++ b/cite-linker/main.go
@@ -234,8 +234,9 @@ func main() {
 
 	slog.Info("done linking citations", "processed", processed.Load())
 
-	// The chambers dashboard materialized views are refreshed separately after a
-	// run (make db-refresh / db/refresh-matviews.sh), not by the linker.
+	// Post-run database maintenance (vacuum/analyze the churned tables and
+	// refresh the chambers dashboard materialized views) is run separately
+	// (make db-maintenance / db/maintenance.sh), not by the linker.
 }
 
 // linkCitation processes a single citation through the linking pipeline.

--- a/db/maintenance.sh
+++ b/db/maintenance.sh
@@ -1,8 +1,18 @@
 #!/usr/bin/env bash
 #
-# Refresh every materialized view in the database.
+# Run post-linker database maintenance: vacuum/analyze the heavily-churned
+# tables, then refresh every materialized view.
 #
-# The set of materialized views and their dependencies are discovered at
+# Table maintenance runs first. The cite-linker churns the moml_citations
+# tables hard — a --reset run deletes and re-inserts tens of millions of rows in
+# moml_citations.citation_links — which leaves dead tuples, a stale visibility
+# map (forcing needless heap fetches during index-only scans), and outdated
+# planner statistics. VACUUM (ANALYZE) recovers the space, sets the visibility
+# map, and refreshes statistics. Doing it before the refresh also gives the
+# matview refreshes below fresh statistics to plan against. Add further
+# maintenance statements to MAINTENANCE_SQL as needed.
+#
+# The set of materialized views and their dependencies are then discovered at
 # runtime from the system catalogs, so this script never needs editing when a
 # view is added, removed, or renamed. Views are grouped into dependency levels:
 # a view is only refreshed once the materialized views it reads from have been
@@ -13,12 +23,12 @@
 # pgx-only pool_max_conns parameter is stripped because psql does not
 # understand it, matching how the Makefile feeds the string to dbmate.
 #
-# REFRESH MATERIALIZED VIEW takes an ACCESS EXCLUSIVE lock on each view, so
-# readers are blocked for the duration of that view's refresh. This is intended
-# as a maintenance task rather than something to run under live load.
+# Both VACUUM and REFRESH MATERIALIZED VIEW take heavy locks (REFRESH takes an
+# ACCESS EXCLUSIVE lock on each view, blocking readers for its duration). This
+# is intended as a maintenance task rather than something to run under live load.
 #
 # Usage:
-#   db/refresh-matviews.sh [connection-string]
+#   db/maintenance.sh [connection-string]
 
 set -euo pipefail
 
@@ -31,6 +41,27 @@ fi
 CONN="$(printf '%s' "$CONN" | sed 's/[&?]pool_max_conns=[0-9]\{1,3\}//')"
 
 PSQL=(psql "$CONN" -X -v ON_ERROR_STOP=1)
+
+# Table maintenance statements, run sequentially before the matview refresh.
+# VACUUM cannot run inside a transaction block, so each is sent on its own
+# connection (psql autocommits a bare -c statement).
+MAINTENANCE_SQL=(
+  "VACUUM (ANALYZE) moml_citations.citation_links;"
+  "VACUUM (ANALYZE) moml_citations.citations_unlinked;"
+)
+
+echo "Running ${#MAINTENANCE_SQL[@]} table maintenance statement(s)."
+for stmt in "${MAINTENANCE_SQL[@]}"; do
+  echo "[maintenance] $stmt"
+  maint_start=$(date +%s)
+  if "${PSQL[@]}" -q -c "$stmt"; then
+    printf '  done   %-52s %ss\n' "$stmt" "$(($(date +%s) - maint_start))"
+  else
+    echo "  FAILED $stmt" >&2
+    exit 1
+  fi
+done
+echo
 
 # Discover materialized views and the dependency level of each. Level 0 views
 # depend on no other materialized view; a view at level N depends on at least

--- a/db/migrations/20260610140000_create_chambers_browse_matviews.sql
+++ b/db/migrations/20260610140000_create_chambers_browse_matviews.sql
@@ -6,7 +6,7 @@ SET ROLE = law_admin;
 -- moml_citations.citations_unlinked and moml_citations.citation_links tables;
 -- aggregating them on every request takes 90+ seconds. These materialized
 -- views move that work off the request path. They are built WITH NO DATA and
--- refreshed manually with `make db-refresh` (db/refresh-matviews.sh discovers
+-- refreshed manually with `make db-maintenance` (db/maintenance.sh discovers
 -- every materialized view automatically, so no script edit is needed). See the
 -- note before migrate:down for manual REFRESH commands.
 

--- a/go/citations/linker_store.go
+++ b/go/citations/linker_store.go
@@ -2,8 +2,6 @@ package citations
 
 import (
 	"context"
-
-	"github.com/google/uuid"
 )
 
 // LinkerStore is an interface for the data operations needed by the cite-linker.
@@ -15,12 +13,12 @@ type LinkerStore interface {
 	// The outer key is reporter_standard, inner key is original volume number.
 	GetDiffVols(ctx context.Context) (map[string]map[int]*DiffVolEntry, error)
 
-	// CountUnprocessedCitations returns the number of citations not yet in citation_links.
-	CountUnprocessedCitations(ctx context.Context) (int64, error)
-
-	// GetUnprocessedCitations fetches a batch of citations not yet linked,
-	// starting after afterID (use uuid.Nil for the first batch).
-	GetUnprocessedCitations(ctx context.Context, afterID uuid.UUID, limit int) ([]UnlinkedCitation, error)
+	// StreamUnprocessedCitations runs a single anti-join over the whole
+	// citations_unlinked table and delivers every citation not yet in
+	// citation_links to fn in batches of at most batchSize. The full set is read
+	// in one streaming pass, so callers must apply their own backpressure inside
+	// fn (e.g. a bounded channel) to avoid buffering the entire table in memory.
+	StreamUnprocessedCitations(ctx context.Context, batchSize int, fn func([]UnlinkedCitation) error) error
 
 	// LoadCAPCitations loads all CAP citations into memory as cite -> case ID.
 	LoadCAPCitations(ctx context.Context) (map[string]int64, error)

--- a/go/citations/linker_store_db.go
+++ b/go/citations/linker_store_db.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v4/pgxpool"
 )
 
@@ -92,52 +91,59 @@ func (s *LinkerDBStore) GetDiffVols(ctx context.Context) (map[string]map[int]*Di
 	return diffvols, nil
 }
 
-func (s *LinkerDBStore) CountUnprocessedCitations(ctx context.Context) (int64, error) {
-	query := `
-	SELECT count(*)
-	FROM moml_citations.citations_unlinked cu
-	WHERE NOT EXISTS (
-		SELECT 1 FROM moml_citations.citation_links cl WHERE cl.citation_id = cu.id
-	)
-	`
-	var count int64
-	err := s.DB.QueryRow(ctx, query).Scan(&count)
-	if err != nil {
-		return 0, fmt.Errorf("counting unprocessed citations: %w", err)
-	}
-	return count, nil
-}
-
-func (s *LinkerDBStore) GetUnprocessedCitations(ctx context.Context, afterID uuid.UUID, limit int) ([]UnlinkedCitation, error) {
+// StreamUnprocessedCitations runs a single anti-join over the whole
+// citations_unlinked table, streaming every citation not yet in citation_links
+// to fn in batches of at most batchSize.
+//
+// This replaces the old cursor-paginated fetch. That approach ran one
+// LIMIT-bounded anti-join per batch; because the inner citation_links index
+// scan had no lower bound, each of the ~12,500 batches re-scanned an
+// ever-growing prefix of the 62M-row citation_links index to fast-forward to
+// the cursor. The total work was quadratic in the table size and dominated the
+// 13-hour runtime. One streaming pass scans each index once instead.
+//
+// The query holds a single connection (and a consistent snapshot) open for the
+// duration of the stream, so the set delivered is exactly the citations that
+// were unprocessed when the query began — concurrent inserts by the worker
+// connections are invisible to it. Callers MUST apply backpressure inside fn;
+// the whole table is read as fast as fn accepts batches.
+func (s *LinkerDBStore) StreamUnprocessedCitations(ctx context.Context, batchSize int, fn func([]UnlinkedCitation) error) error {
 	query := `
 	SELECT cu.id, cu.moml_treatise, cu.moml_page, cu.raw, cu.volume, cu.reporter_abbr, cu.page
 	FROM moml_citations.citations_unlinked cu
 	WHERE NOT EXISTS (
 		SELECT 1 FROM moml_citations.citation_links cl WHERE cl.citation_id = cu.id
 	)
-	AND cu.id > $1
-	ORDER BY cu.id
-	LIMIT $2
 	`
-	rows, err := s.DB.Query(ctx, query, afterID, limit)
+	rows, err := s.DB.Query(ctx, query)
 	if err != nil {
-		return nil, fmt.Errorf("fetching unprocessed citations: %w", err)
+		return fmt.Errorf("streaming unprocessed citations: %w", err)
 	}
 	defer rows.Close()
 
-	var citations []UnlinkedCitation
+	batch := make([]UnlinkedCitation, 0, batchSize)
 	for rows.Next() {
 		var c UnlinkedCitation
-		err := rows.Scan(&c.ID, &c.MomlTreatise, &c.MomlPage, &c.Raw, &c.Volume, &c.ReporterAbbr, &c.Page)
-		if err != nil {
-			return nil, fmt.Errorf("scanning unlinked citation: %w", err)
+		if err := rows.Scan(&c.ID, &c.MomlTreatise, &c.MomlPage, &c.Raw, &c.Volume, &c.ReporterAbbr, &c.Page); err != nil {
+			return fmt.Errorf("scanning unlinked citation: %w", err)
 		}
-		citations = append(citations, c)
+		batch = append(batch, c)
+		if len(batch) >= batchSize {
+			if err := fn(batch); err != nil {
+				return err
+			}
+			batch = make([]UnlinkedCitation, 0, batchSize)
+		}
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterating unlinked citations: %w", err)
+		return fmt.Errorf("iterating unlinked citations: %w", err)
 	}
-	return citations, nil
+	if len(batch) > 0 {
+		if err := fn(batch); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // LoadCAPCitations loads cap.citations into an in-memory map of cite -> case ID.
@@ -245,30 +251,48 @@ func (s *LinkerDBStore) LoadEnglishReportsCitations(ctx context.Context) (map[st
 	return m, nil
 }
 
-// SaveLinkResults batch-inserts multiple link results in a single query.
+// SaveLinkResults batch-inserts multiple link results in a single statement.
+//
+// Rather than build a VALUES list with up to batchSize*8 placeholders (which
+// runs into Postgres's 65535-parameter limit at large batch sizes and forces
+// the server to parse a huge statement on every batch), it passes one array per
+// column and expands them server-side with unnest(). That is a fixed 8-parameter
+// statement regardless of batch size, so it parses/plans cheaply and keeps the
+// wire payload compact. citation_id is sent as text[] and cast to uuid in SQL to
+// avoid relying on driver-side uuid-array encoding.
 func (s *LinkerDBStore) SaveLinkResults(ctx context.Context, results []*LinkResult) error {
 	if len(results) == 0 {
 		return nil
 	}
 
+	ids := make([]string, len(results))
+	statuses := make([]string, len(results))
+	capIDs := make([]*int64, len(results))
+	codeIDs := make([]*int64, len(results))
+	erIDs := make([]*string, len(results))
+	cleaned := make([]*string, len(results))
+	normalized := make([]*string, len(results))
+	linked := make([]*string, len(results))
+	for i, r := range results {
+		ids[i] = r.CitationID.String()
+		statuses[i] = r.Status
+		capIDs[i] = r.CAPCaseID
+		codeIDs[i] = r.CodeReporterID
+		erIDs[i] = r.ERCaseID
+		cleaned[i] = r.CiteCleaned
+		normalized[i] = r.CiteNormalized
+		linked[i] = r.CiteLinked
+	}
+
 	query := `
 	INSERT INTO moml_citations.citation_links
 		(citation_id, status, cap_case_id, code_reporter_id, er_case_id, cite_cleaned, cite_normalized, cite_linked)
-	VALUES `
+	SELECT u.citation_id::uuid, u.status, u.cap_case_id, u.code_reporter_id, u.er_case_id, u.cite_cleaned, u.cite_normalized, u.cite_linked
+	FROM unnest($1::text[], $2::text[], $3::bigint[], $4::bigint[], $5::text[], $6::text[], $7::text[], $8::text[])
+		AS u(citation_id, status, cap_case_id, code_reporter_id, er_case_id, cite_cleaned, cite_normalized, cite_linked)
+	ON CONFLICT (citation_id) DO NOTHING`
 
-	args := make([]interface{}, 0, len(results)*8)
-	for i, r := range results {
-		if i > 0 {
-			query += ", "
-		}
-		base := i * 8
-		query += fmt.Sprintf("($%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d)",
-			base+1, base+2, base+3, base+4, base+5, base+6, base+7, base+8)
-		args = append(args, r.CitationID, r.Status, r.CAPCaseID, r.CodeReporterID, r.ERCaseID, r.CiteCleaned, r.CiteNormalized, r.CiteLinked)
-	}
-	query += " ON CONFLICT (citation_id) DO NOTHING"
-
-	_, err := s.DB.Exec(ctx, query, args...)
+	_, err := s.DB.Exec(ctx, query, ids, statuses, capIDs, codeIDs, erIDs, cleaned, normalized, linked)
 	if err != nil {
 		return fmt.Errorf("batch saving %d link results: %w", len(results), err)
 	}

--- a/go/citations/linker_store_db_integration_test.go
+++ b/go/citations/linker_store_db_integration_test.go
@@ -1,0 +1,224 @@
+package citations
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests exercise the real SQL in LinkerDBStore against a live Postgres.
+// They are skipped unless LAW_TEST_DBSTR points at a throwaway database the test
+// is free to create/drop tables in (NOT a production DSN). CI has no database, so
+// these are a no-op there; run them locally against a disposable container, e.g.:
+//
+//	docker run -d --name lm-linker-test -e POSTGRES_PASSWORD=test \
+//	    -e POSTGRES_DB=lawtest -p 55432:5432 postgres:17
+//	LAW_TEST_DBSTR='postgres://postgres:test@localhost:55432/lawtest' go test ./go/citations/ -run Integration -v
+func newTestStore(t *testing.T) *LinkerDBStore {
+	t.Helper()
+	dsn := os.Getenv("LAW_TEST_DBSTR")
+	if dsn == "" {
+		t.Skip("LAW_TEST_DBSTR not set; skipping DB integration test")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.Connect(ctx, dsn)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+
+	// Build the minimal slice of the moml_citations schema the linker touches.
+	// Drop first so each run starts clean.
+	setup := []string{
+		`DROP SCHEMA IF EXISTS moml_citations CASCADE`,
+		`CREATE SCHEMA moml_citations`,
+		`CREATE TABLE moml_citations.citations_unlinked (
+			id uuid PRIMARY KEY,
+			moml_treatise text NOT NULL,
+			moml_page text NOT NULL,
+			raw text NOT NULL,
+			volume integer,
+			reporter_abbr text NOT NULL,
+			page integer NOT NULL,
+			created_at timestamp without time zone NOT NULL DEFAULT now()
+		)`,
+		`CREATE TABLE moml_citations.citation_links (
+			citation_id uuid PRIMARY KEY,
+			status text NOT NULL,
+			cap_case_id bigint,
+			code_reporter_id bigint,
+			er_case_id text,
+			cite_cleaned text,
+			cite_normalized text,
+			cite_linked text,
+			created_at timestamp with time zone DEFAULT now() NOT NULL
+		)`,
+	}
+	for _, stmt := range setup {
+		_, err := pool.Exec(ctx, stmt)
+		require.NoError(t, err, "setup: %s", stmt)
+	}
+	return &LinkerDBStore{DB: pool}
+}
+
+func seedUnlinked(t *testing.T, s *LinkerDBStore, id uuid.UUID, vol *int) {
+	t.Helper()
+	_, err := s.DB.Exec(context.Background(),
+		`INSERT INTO moml_citations.citations_unlinked (id, moml_treatise, moml_page, raw, volume, reporter_abbr, page)
+		 VALUES ($1, 'treatise', 'p1', 'raw cite', $2, 'U.S.', 10)`, id, vol)
+	require.NoError(t, err)
+}
+
+func TestStreamUnprocessedCitationsIntegration(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	// 10 unlinked citations; mark 3 of them already processed in citation_links.
+	all := make([]uuid.UUID, 10)
+	for i := range all {
+		all[i] = uuid.New()
+		v := i
+		seedUnlinked(t, s, all[i], &v)
+	}
+	processed := map[uuid.UUID]bool{all[0]: true, all[4]: true, all[9]: true}
+	for id := range processed {
+		_, err := s.DB.Exec(ctx,
+			`INSERT INTO moml_citations.citation_links (citation_id, status) VALUES ($1, 'no_match')`, id)
+		require.NoError(t, err)
+	}
+
+	// Stream with a small batch size and collect everything delivered.
+	var got []uuid.UUID
+	var batchSizes []int
+	err := s.StreamUnprocessedCitations(ctx, 3, func(batch []UnlinkedCitation) error {
+		batchSizes = append(batchSizes, len(batch))
+		for _, c := range batch {
+			got = append(got, c.ID)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Should deliver exactly the 7 unprocessed citations, none of the processed.
+	want := make([]uuid.UUID, 0, 7)
+	for _, id := range all {
+		if !processed[id] {
+			want = append(want, id)
+		}
+	}
+	assert.Len(t, got, 7)
+	for _, id := range got {
+		assert.False(t, processed[id], "streamed an already-processed citation %s", id)
+	}
+	assert.ElementsMatch(t, want, got)
+
+	// Batching: 7 rows at batch size 3 => batches of 3, 3, 1.
+	assert.Equal(t, []int{3, 3, 1}, batchSizes)
+}
+
+func TestSaveLinkResultsIntegration(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	capID := int64(111)
+	codeID := int64(999)
+	erID := "er-7"
+	cleaned := "5 U.S. 10"
+	normalized := "5 U.S. 10"
+	linked := "5 U.S. 10"
+
+	idCAP := uuid.New()
+	idCode := uuid.New()
+	idER := uuid.New()
+	idNoMatch := uuid.New()
+	idSkipped := uuid.New()
+
+	results := []*LinkResult{
+		// A CAP link: cap_case_id set, the rest of the case IDs nil.
+		{CitationID: idCAP, Status: StatusLinkedCAP, CAPCaseID: &capID,
+			CiteCleaned: &cleaned, CiteNormalized: &normalized, CiteLinked: &linked},
+		// A code-reporter link.
+		{CitationID: idCode, Status: StatusLinkedCodeReporter, CodeReporterID: &codeID,
+			CiteCleaned: &cleaned, CiteNormalized: &normalized, CiteLinked: &linked},
+		// An English Reports link (text id).
+		{CitationID: idER, Status: StatusLinkedEnglishReports, ERCaseID: &erID,
+			CiteCleaned: &cleaned, CiteNormalized: &normalized, CiteLinked: &linked},
+		// no_match: cite_cleaned/normalized set, everything else nil.
+		{CitationID: idNoMatch, Status: StatusNoMatch,
+			CiteCleaned: &cleaned, CiteNormalized: &normalized},
+		// skipped: all nullable columns nil. Exercises NULL encoding in every array.
+		{CitationID: idSkipped, Status: StatusSkippedNotWhitelisted},
+	}
+
+	require.NoError(t, s.SaveLinkResults(ctx, results))
+
+	// Read each row back and verify the values (and the NULLs) round-tripped.
+	type row struct {
+		status                          string
+		capCaseID, codeReporterID       *int64
+		erCaseID, cleaned, norm, linked *string
+	}
+	read := func(id uuid.UUID) row {
+		var r row
+		err := s.DB.QueryRow(ctx,
+			`SELECT status, cap_case_id, code_reporter_id, er_case_id, cite_cleaned, cite_normalized, cite_linked
+			 FROM moml_citations.citation_links WHERE citation_id = $1`, id).
+			Scan(&r.status, &r.capCaseID, &r.codeReporterID, &r.erCaseID, &r.cleaned, &r.norm, &r.linked)
+		require.NoError(t, err)
+		return r
+	}
+
+	cap := read(idCAP)
+	assert.Equal(t, StatusLinkedCAP, cap.status)
+	require.NotNil(t, cap.capCaseID)
+	assert.Equal(t, capID, *cap.capCaseID)
+	assert.Nil(t, cap.codeReporterID)
+	assert.Nil(t, cap.erCaseID)
+	require.NotNil(t, cap.linked)
+	assert.Equal(t, linked, *cap.linked)
+
+	code := read(idCode)
+	assert.Equal(t, StatusLinkedCodeReporter, code.status)
+	require.NotNil(t, code.codeReporterID)
+	assert.Equal(t, codeID, *code.codeReporterID)
+	assert.Nil(t, code.capCaseID)
+
+	er := read(idER)
+	assert.Equal(t, StatusLinkedEnglishReports, er.status)
+	require.NotNil(t, er.erCaseID)
+	assert.Equal(t, erID, *er.erCaseID)
+	assert.Nil(t, er.capCaseID)
+
+	nm := read(idNoMatch)
+	assert.Equal(t, StatusNoMatch, nm.status)
+	assert.Nil(t, nm.capCaseID)
+	require.NotNil(t, nm.cleaned)
+	assert.Equal(t, cleaned, *nm.cleaned)
+	assert.Nil(t, nm.linked)
+
+	sk := read(idSkipped)
+	assert.Equal(t, StatusSkippedNotWhitelisted, sk.status)
+	assert.Nil(t, sk.capCaseID)
+	assert.Nil(t, sk.codeReporterID)
+	assert.Nil(t, sk.erCaseID)
+	assert.Nil(t, sk.cleaned)
+	assert.Nil(t, sk.norm)
+	assert.Nil(t, sk.linked)
+
+	// ON CONFLICT DO NOTHING: re-saving the same citation_id with a different
+	// status must not overwrite the existing row.
+	conflicting := []*LinkResult{{CitationID: idCAP, Status: StatusNoMatch}}
+	require.NoError(t, s.SaveLinkResults(ctx, conflicting))
+	assert.Equal(t, StatusLinkedCAP, read(idCAP).status, "ON CONFLICT should have preserved the original row")
+
+	// Empty input is a no-op, not an error.
+	require.NoError(t, s.SaveLinkResults(ctx, nil))
+
+	// Sanity: exactly the five rows we inserted exist.
+	var n int
+	require.NoError(t, s.DB.QueryRow(ctx, `SELECT count(*) FROM moml_citations.citation_links`).Scan(&n))
+	assert.Equal(t, 5, n)
+}

--- a/go/db/db.go
+++ b/go/db/db.go
@@ -16,6 +16,15 @@ import (
 // Connect returns a pool of connections to the database, which is concurrency
 // safe. Uses the pgx interface.
 func Connect(ctx context.Context) (*pgxpool.Pool, error) {
+	return ConnectPool(ctx, nil)
+}
+
+// ConnectPool is like Connect but lets the caller tune the pool configuration
+// (for example, MaxConns) before the pool is opened. The configure callback,
+// if non-nil, is invoked with the parsed *pgxpool.Config. It is used by
+// high-concurrency batch jobs (e.g. cite-linker) that need to size the pool to
+// the number of worker connections plus a dedicated streaming-read connection.
+func ConnectPool(ctx context.Context, configure func(*pgxpool.Config)) (*pgxpool.Pool, error) {
 	timeout, cancel := context.WithTimeout(ctx, 1*time.Minute)
 	defer cancel()
 
@@ -24,7 +33,15 @@ func Connect(ctx context.Context) (*pgxpool.Pool, error) {
 		return nil, err
 	}
 
-	db, err := pgxpool.Connect(timeout, connstr)
+	config, err := pgxpool.ParseConfig(connstr)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing database config: %w", err)
+	}
+	if configure != nil {
+		configure(config)
+	}
+
+	db, err := pgxpool.ConnectConfig(timeout, config)
 	if err != nil {
 		return nil, fmt.Errorf("error connecting to database: %w", err)
 	}


### PR DESCRIPTION
## Problem

The marginal re-link job (#219) took **13 hours at 1% CPU**. The cluster wasn't the bottleneck — the database was. All citation linking is in-memory map lookups (zero DB queries during linking), so the only per-batch DB work was *fetching* the next batch and *inserting* results.

## Root cause (the fetch)

`GetUnprocessedCitations` paginated with a cursor and re-ran a `LIMIT`-bounded anti-join **once per batch**:

```sql
SELECT ... FROM moml_citations.citations_unlinked cu
WHERE NOT EXISTS (SELECT 1 FROM moml_citations.citation_links cl WHERE cl.citation_id = cu.id)
AND cu.id > $1 ORDER BY cu.id LIMIT $2
```

`EXPLAIN` shows the planner runs this as a **Merge Anti Join**, but the inner `citation_links` index-only scan has **no lower bound** — so each of the ~12,500 batches re-scans an *ever-growing prefix* of the 62.8M-row `citation_links` index to fast-forward to the cursor. Total work is **quadratic** in table size (≈ N²/batchSize ≈ 4×10¹¹ index reads), which lines up almost exactly with the 13-hour runtime. Each per-batch query also JIT-compiled separately.

## Fix

Replace the cursor pagination with `StreamUnprocessedCitations`: **one** anti-join over the whole table, streamed to the workers in batches. `EXPLAIN (ANALYZE)` on the full table shows this single pass costs **~104s in the worst case** (a fully-processed table where it scans both indexes to completion and finds nothing) — versus 13h. The query's consistent snapshot delivers exactly the rows that were unprocessed when it started, so concurrent inserts are invisible to it and nothing is double-processed. A **bounded channel** applies backpressure so the fast streaming read can't outrun the inserts and buffer the 62M-row table in memory.

### Also in this PR
- **`SaveLinkResults`** now expands one array per column with `unnest()` (a fixed **8 parameters**) instead of a `VALUES` list with up to `batchSize × 8` placeholders. Same `ON CONFLICT (citation_id) DO NOTHING` semantics, much cheaper to parse/plan, far smaller on the wire. `citation_id` is sent as `text[]` and cast to `uuid` in SQL.
- **`db.ConnectPool`** lets the linker size the pool to the insert workers + the one dedicated streaming-read connection (default `--workers 32` → pool of 34, polite to the shared 100-connection server).
- Dropped the up-front `CountUnprocessedCitations` (an exact count is *itself* a full anti-join); the progress bar runs in count/rate mode.

## Testing
- `go build ./...`, `go vet ./...`, `go test ./...` all pass.
- New **gated integration tests** (`LAW_TEST_DBSTR`, skipped in CI which has no DB) cover the streaming anti-join + batching, the `unnest` insert with NULLs in every nullable column, and `ON CONFLICT`.
- **Validated end-to-end against Postgres 17** in a throwaway container with the full stub schema and 5,200 seeded citations: correct status distribution (CAP-exact and FreeLaw-fallback links, junk/unlisted skips, no_match), a clean re-run processes 0, and `--reset` deletes the non-linked rows and re-links them to an identical distribution.

A separate comment on #219 has DB-side tuning recommendations for the DBA (indexes, VACUUM, parallelism) that are outside what this code change can do.

Refs #219