### PR TITLE
Recover no_match citations via alternate FreeLaw reporter spellings (#220 Track 1)

### DIFF
--- a/cite-linker/main.go
+++ b/cite-linker/main.go
@@ -136,6 +136,14 @@ func main() {
 	}
 	slog.Info("loaded FreeLaw cite crosswalk", "entries", len(freelawCites))
 
+	slog.Info("loading reporter alternate abbreviations")
+	altAbbrs, err := store.LoadReporterAltAbbrs(ctx)
+	if err != nil {
+		slog.Error("could not load reporter alternate abbreviations", "error", err)
+		os.Exit(1)
+	}
+	slog.Info("loaded reporter alternate abbreviations", "reporters", len(altAbbrs))
+
 	slog.Info("loading code reporter citations")
 	codeCites, err := store.LoadCodeReporterCitations(ctx)
 	if err != nil {
@@ -188,7 +196,7 @@ func main() {
 				results := make([]*citations.LinkResult, len(batch))
 				statusCounts := make(map[string]int)
 				for j := range batch {
-					r := linkCitation(&batch[j], whitelist, diffvols, capCites, freelawCites, codeCites, erCites)
+					r := linkCitation(&batch[j], whitelist, diffvols, capCites, freelawCites, altAbbrs, codeCites, erCites)
 					results[j] = r
 					statusCounts[r.Status]++
 				}
@@ -247,6 +255,7 @@ func linkCitation(
 	diffvols map[string]map[int]*citations.DiffVolEntry,
 	capCites map[string]int64,
 	freelawCites map[string]int64,
+	altAbbrs map[string][]string,
 	codeCites map[string]int64,
 	erCites map[string]string,
 ) *citations.LinkResult {
@@ -273,18 +282,19 @@ func linkCitation(
 	if entry.UK {
 		return linkEnglishReports(c, entry, erCites, result)
 	}
-	return linkCAPThenCode(c, entry, diffvols, capCites, freelawCites, codeCites, result)
+	return linkCAPThenCode(c, entry, diffvols, capCites, freelawCites, altAbbrs, codeCites, result)
 }
 
 // linkCAPThenCode tries CAP first, then the FreeLaw parallel-citation crosswalk
-// (which also resolves to a CAP case), then the Code Reporter, all using
-// in-memory maps.
+// (which also resolves to a CAP case), then the FreeLaw crosswalk again under
+// alternate reporter spellings, then the Code Reporter, all using in-memory maps.
 func linkCAPThenCode(
 	c *citations.UnlinkedCitation,
 	entry *citations.WhitelistEntry,
 	diffvols map[string]map[int]*citations.DiffVolEntry,
 	capCites map[string]int64,
 	freelawCites map[string]int64,
+	altAbbrs map[string][]string,
 	codeCites map[string]int64,
 	result *citations.LinkResult,
 ) *citations.LinkResult {
@@ -310,6 +320,27 @@ func linkCAPThenCode(
 		result.CAPCaseID = &caseID
 		result.CiteLinked = &citeNormalized
 		return result
+	}
+
+	// Fall back to alternate reporter spellings: the same decision may be in the
+	// FreeLaw crosswalk under a CourtListener spelling that differs from our
+	// reporter_standard/reporter_cap. Probe each known alternate spelling for this
+	// reporter (keyed by the canonical reporter_standard, like diffvols). The
+	// first hit links to the CAP case (status linked_cap). Volume-nil is handled
+	// the same way as buildStandardCite/buildCAPCite.
+	for _, alt := range altAbbrs[*entry.ReporterStandard] {
+		var altCite string
+		if c.Volume == nil {
+			altCite = fmt.Sprintf("%s %d", alt, c.Page)
+		} else {
+			altCite = fmt.Sprintf("%d %s %d", *c.Volume, alt, c.Page)
+		}
+		if caseID, ok := freelawCites[altCite]; ok {
+			result.Status = citations.StatusLinkedCAP
+			result.CAPCaseID = &caseID
+			result.CiteLinked = &altCite
+			return result
+		}
 	}
 
 	// Try Code Reporter with the cleaned cite

--- a/cite-linker/main_test.go
+++ b/cite-linker/main_test.go
@@ -21,6 +21,7 @@ func TestLinkCitation(t *testing.T) {
 		whitelist    map[string]*citations.WhitelistEntry
 		capCites     map[string]int64
 		freelawCites map[string]int64
+		altAbbrs     map[string][]string
 		codeCites    map[string]int64
 		erCites      map[string]string
 		wantStatus   string
@@ -81,6 +82,83 @@ func TestLinkCitation(t *testing.T) {
 			wantLinked:   ptr("1 Q.B. 20"),
 		},
 		{
+			name:         "alt_abbr FreeLaw hit recovers a no_match",
+			cite:         citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(5), ReporterAbbr: "U.S.", Page: 10},
+			whitelist:    map[string]*citations.WhitelistEntry{"U.S.": {ReporterStandard: &usStd}},
+			capCites:     map[string]int64{},
+			freelawCites: map[string]int64{"5 US 10": 333}, // CourtListener spelling, no periods
+			altAbbrs:     map[string][]string{"U.S.": {"US"}},
+			wantStatus:   citations.StatusLinkedCAP,
+			wantCAPID:    ptr(int64(333)),
+			wantLinked:   ptr("5 US 10"),
+		},
+		{
+			name:         "direct CAP hit wins over alt_abbr",
+			cite:         citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(5), ReporterAbbr: "U.S.", Page: 10},
+			whitelist:    map[string]*citations.WhitelistEntry{"U.S.": {ReporterStandard: &usStd}},
+			capCites:     map[string]int64{"5 U.S. 10": 111},
+			freelawCites: map[string]int64{"5 US 10": 333},
+			altAbbrs:     map[string][]string{"U.S.": {"US"}},
+			wantStatus:   citations.StatusLinkedCAP,
+			wantCAPID:    ptr(int64(111)),
+			wantLinked:   ptr("5 U.S. 10"),
+		},
+		{
+			name:         "direct FreeLaw-normalized hit wins over alt_abbr",
+			cite:         citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(5), ReporterAbbr: "U.S.", Page: 10},
+			whitelist:    map[string]*citations.WhitelistEntry{"U.S.": {ReporterStandard: &usStd}},
+			capCites:     map[string]int64{},
+			freelawCites: map[string]int64{"5 U.S. 10": 222, "5 US 10": 333},
+			altAbbrs:     map[string][]string{"U.S.": {"US"}},
+			wantStatus:   citations.StatusLinkedCAP,
+			wantCAPID:    ptr(int64(222)),
+			wantLinked:   ptr("5 U.S. 10"),
+		},
+		{
+			name:         "alt_abbr miss falls through to code reporter",
+			cite:         citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(2), ReporterAbbr: "Stat.", Page: 30},
+			whitelist:    map[string]*citations.WhitelistEntry{"Stat.": {ReporterStandard: &statStd}},
+			capCites:     map[string]int64{},
+			freelawCites: map[string]int64{},
+			altAbbrs:     map[string][]string{"Stat.": {"Statx"}}, // present but never matches FreeLaw
+			codeCites:    map[string]int64{"2 Stat. 30": 999},
+			wantStatus:   citations.StatusLinkedCodeReporter,
+			wantCodeID:   ptr(int64(999)),
+			wantLinked:   ptr("2 Stat. 30"),
+		},
+		{
+			name:         "multiple alt_abbrs, later entry matches",
+			cite:         citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(5), ReporterAbbr: "U.S.", Page: 10},
+			whitelist:    map[string]*citations.WhitelistEntry{"U.S.": {ReporterStandard: &usStd}},
+			capCites:     map[string]int64{},
+			freelawCites: map[string]int64{"5 US 10": 333},
+			altAbbrs:     map[string][]string{"U.S.": {"USA", "US"}}, // first misses, second hits
+			wantStatus:   citations.StatusLinkedCAP,
+			wantCAPID:    ptr(int64(333)),
+			wantLinked:   ptr("5 US 10"),
+		},
+		{
+			name:         "nil-volume alt_abbr hit",
+			cite:         citations.UnlinkedCitation{ID: uuid.New(), Volume: nil, ReporterAbbr: "Stat.", Page: 30},
+			whitelist:    map[string]*citations.WhitelistEntry{"Stat.": {ReporterStandard: &statStd}},
+			capCites:     map[string]int64{},
+			freelawCites: map[string]int64{"Stat 30": 444},
+			altAbbrs:     map[string][]string{"Stat.": {"Stat"}},
+			wantStatus:   citations.StatusLinkedCAP,
+			wantCAPID:    ptr(int64(444)),
+			wantLinked:   ptr("Stat 30"),
+		},
+		{
+			name:         "alt_abbr path is not consulted for UK reporters",
+			cite:         citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(1), ReporterAbbr: "Q.B.", Page: 20},
+			whitelist:    map[string]*citations.WhitelistEntry{"Q.B.": {ReporterStandard: &qbStd, UK: true}},
+			freelawCites: map[string]int64{"1 QB 20": 222}, // would match if alt path ran
+			altAbbrs:     map[string][]string{"Q.B.": {"QB"}},
+			erCites:      map[string]string{}, // no English Reports match
+			wantStatus:   citations.StatusNoMatch,
+			wantLinked:   nil,
+		},
+		{
 			name:       "not whitelisted is skipped",
 			cite:       citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(5), ReporterAbbr: "Bogus", Page: 10},
 			whitelist:  map[string]*citations.WhitelistEntry{},
@@ -104,7 +182,7 @@ func TestLinkCitation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := linkCitation(&tt.cite, tt.whitelist, diffvols, tt.capCites, tt.freelawCites, tt.codeCites, tt.erCites)
+			got := linkCitation(&tt.cite, tt.whitelist, diffvols, tt.capCites, tt.freelawCites, tt.altAbbrs, tt.codeCites, tt.erCites)
 
 			assert.Equal(t, tt.wantStatus, got.Status)
 			assert.Equal(t, tt.cite.ID, got.CitationID)

--- a/db/migrations/20260612205502_seed-freelaw-reporter-alt-abbrs.sql
+++ b/db/migrations/20260612205502_seed-freelaw-reporter-alt-abbrs.sql
@@ -1,0 +1,53 @@
+-- migrate:up
+SET ROLE = law_admin;
+
+-- Track 1 of issue #220: record CourtListener (FreeLaw) reporter spellings as
+-- alternate abbreviations so the cite-linker can probe freelaw.cite_to_cap under
+-- the spelling FreeLaw actually uses. The crosswalk is keyed on CourtListener's
+-- reporter string, which differs from our reporter_standard/reporter_cap for
+-- these reporters, so the FreeLaw fallback could never match them before.
+-- Approved by @kfunk074 on the issue.
+--
+-- Only the four pairs that are NOT already in reporters_abbreviations are seeded
+-- here. Four other approved pairs (Martin->Mart., Porter->Port., Stewart->Stew.,
+-- Story C.C.->Story) already exist in the table and are recovered automatically
+-- once the new linker code probes them; they are intentionally not touched.
+--
+-- reporters_abbreviations has no unique constraint, so each row is inserted only
+-- when the exact (reporter_standard, alt_abbr) pair is absent. The EXISTS guard
+-- respects the FK to legalhist.reporters; the WHERE clause respects the
+-- reporter_standard <> alt_abbr CHECK. None of these four reporters are
+-- single_vol, so this does not change the single-volume detector's behavior.
+INSERT INTO legalhist.reporters_abbreviations (reporter_standard, alt_abbr)
+SELECT v.reporter_standard, v.alt_abbr
+FROM (VALUES
+    ('Serg. & Rawl.', 'Serg. & Rawle'),
+    ('Woods.',        'Woods'),
+    ('Walker',        'Walk.'),
+    ('Green',         'Greene')
+) AS v(reporter_standard, alt_abbr)
+WHERE v.reporter_standard <> v.alt_abbr
+  AND EXISTS (
+    SELECT 1 FROM legalhist.reporters r
+    WHERE r.reporter_standard = v.reporter_standard
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM legalhist.reporters_abbreviations ra
+    WHERE ra.reporter_standard = v.reporter_standard
+      AND ra.alt_abbr = v.alt_abbr
+  );
+
+-- migrate:down
+SET ROLE = law_admin;
+
+-- Remove exactly the four pairs seeded above (and only those — the pre-existing
+-- Martin/Porter/Stewart/Story rows are never listed here, so they are untouched).
+DELETE FROM legalhist.reporters_abbreviations ra
+USING (VALUES
+    ('Serg. & Rawl.', 'Serg. & Rawle'),
+    ('Woods.',        'Woods'),
+    ('Walker',        'Walk.'),
+    ('Green',         'Greene')
+) AS v(reporter_standard, alt_abbr)
+WHERE ra.reporter_standard = v.reporter_standard
+  AND ra.alt_abbr = v.alt_abbr;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -825,6 +825,43 @@ CREATE TABLE freelaw.clusters_to_cap (
 
 
 --
+-- Name: cite_to_cap; Type: MATERIALIZED VIEW; Schema: freelaw; Owner: -
+--
+
+CREATE MATERIALIZED VIEW freelaw.cite_to_cap AS
+ WITH relevant AS (
+         SELECT citations.cite,
+            citations.cluster_id
+           FROM freelaw.citations
+          WHERE (citations.type <> ALL (ARRAY['lexis'::text, 'west'::text, 'journal'::text]))
+        ), cluster_cap AS (
+         SELECT clusters_to_cap.cluster_id,
+            clusters_to_cap.cap_case_id
+           FROM freelaw.clusters_to_cap
+          WHERE (clusters_to_cap.cap_case_id IS NOT NULL)
+        UNION
+         SELECT r.cluster_id,
+            capc."case" AS cap_case_id
+           FROM (relevant r
+             JOIN cap.citations capc ON ((capc.cite = r.cite)))
+          WHERE (NOT (EXISTS ( SELECT 1
+                   FROM freelaw.clusters_to_cap a
+                  WHERE ((a.cluster_id = r.cluster_id) AND (a.cap_case_id IS NOT NULL)))))
+        ), cite_caps AS (
+         SELECT r.cite,
+            cc.cap_case_id
+           FROM (relevant r
+             JOIN cluster_cap cc ON ((cc.cluster_id = r.cluster_id)))
+        )
+ SELECT cite,
+    min(cap_case_id) AS cap_case_id
+   FROM cite_caps
+  GROUP BY cite
+ HAVING (count(DISTINCT cap_case_id) = 1)
+  WITH NO DATA;
+
+
+--
 -- Name: reporters; Type: TABLE; Schema: legalhist; Owner: -
 --
 
@@ -2038,6 +2075,13 @@ CREATE INDEX er_cases_er_year_idx ON english_reports.cases USING btree (er_year)
 
 
 --
+-- Name: freelaw_cite_to_cap_uq; Type: INDEX; Schema: freelaw; Owner: -
+--
+
+CREATE UNIQUE INDEX freelaw_cite_to_cap_uq ON freelaw.cite_to_cap USING btree (cite);
+
+
+--
 -- Name: idx_freelaw_citations_cite; Type: INDEX; Schema: freelaw; Owner: -
 --
 
@@ -2635,4 +2679,6 @@ INSERT INTO sys_admin.migrations_dbmate (version) VALUES
     ('20260609133000'),
     ('20260610120000'),
     ('20260610130000'),
-    ('20260610140000');
+    ('20260610140000'),
+    ('20260611182350'),
+    ('20260612205502');

--- a/go/citations/linker_store.go
+++ b/go/citations/linker_store.go
@@ -28,6 +28,13 @@ type LinkerStore interface {
 	// it as a fallback after the exact cap.citations lookup misses.
 	LoadFreelawCites(ctx context.Context) (map[string]int64, error)
 
+	// LoadReporterAltAbbrs loads legalhist.reporters_abbreviations into memory as
+	// reporter_standard -> list of alternate abbreviations. The linker probes the
+	// FreeLaw crosswalk with each alternate spelling after the canonical
+	// reporter_standard / reporter_cap forms miss, recovering matches where our
+	// reporter string and CourtListener's disagree.
+	LoadReporterAltAbbrs(ctx context.Context) (map[string][]string, error)
+
 	// LoadCodeReporterCitations loads all code reporter citations into memory
 	// as official_citation -> id.
 	LoadCodeReporterCitations(ctx context.Context) (map[string]int64, error)

--- a/go/citations/linker_store_db.go
+++ b/go/citations/linker_store_db.go
@@ -198,6 +198,37 @@ func (s *LinkerDBStore) LoadFreelawCites(ctx context.Context) (map[string]int64,
 	return m, nil
 }
 
+// LoadReporterAltAbbrs loads legalhist.reporters_abbreviations into an in-memory
+// map of reporter_standard -> []alt_abbr. The linker probes the FreeLaw
+// crosswalk with each alternate spelling (keyed by the canonical
+// reporter_standard, like the diffvols mapping) after the standard/reporter_cap
+// forms miss.
+func (s *LinkerDBStore) LoadReporterAltAbbrs(ctx context.Context) (map[string][]string, error) {
+	query := `
+	SELECT reporter_standard, alt_abbr
+	FROM legalhist.reporters_abbreviations
+	WHERE alt_abbr IS NOT NULL
+	`
+	rows, err := s.DB.Query(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("loading reporter alt abbreviations: %w", err)
+	}
+	defer rows.Close()
+
+	m := make(map[string][]string)
+	for rows.Next() {
+		var std, alt string
+		if err := rows.Scan(&std, &alt); err != nil {
+			return nil, fmt.Errorf("scanning reporter alt abbreviation: %w", err)
+		}
+		m[std] = append(m[std], alt)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating reporter alt abbreviations: %w", err)
+	}
+	return m, nil
+}
+
 // LoadCodeReporterCitations loads code_reporter into an in-memory map of
 // official_citation -> id.
 func (s *LinkerDBStore) LoadCodeReporterCitations(ctx context.Context) (map[string]int64, error) {

--- a/go/citations/linker_store_db_integration_test.go
+++ b/go/citations/linker_store_db_integration_test.go
@@ -222,3 +222,42 @@ func TestSaveLinkResultsIntegration(t *testing.T) {
 	require.NoError(t, s.DB.QueryRow(ctx, `SELECT count(*) FROM moml_citations.citation_links`).Scan(&n))
 	assert.Equal(t, 5, n)
 }
+
+func TestLoadReporterAltAbbrsIntegration(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	// Build the minimal legalhist slice the loader touches, mirroring the
+	// production shape (FK to reporters + the distinct CHECK). Kept inside this
+	// test rather than in newTestStore so the unrelated stream/save tests don't
+	// depend on a legalhist schema.
+	setup := []string{
+		`DROP SCHEMA IF EXISTS legalhist CASCADE`,
+		`CREATE SCHEMA legalhist`,
+		`CREATE TABLE legalhist.reporters (reporter_standard text PRIMARY KEY)`,
+		`CREATE TABLE legalhist.reporters_abbreviations (
+			reporter_standard text NOT NULL REFERENCES legalhist.reporters(reporter_standard),
+			alt_abbr text NOT NULL,
+			CONSTRAINT reporters_abbreviations_distinct_check CHECK (reporter_standard <> alt_abbr)
+		)`,
+		`INSERT INTO legalhist.reporters (reporter_standard) VALUES ('Serg. & Rawl.'), ('U.S.'), ('Mass.')`,
+		`INSERT INTO legalhist.reporters_abbreviations (reporter_standard, alt_abbr) VALUES
+			('Serg. & Rawl.', 'Serg. & Rawle'),
+			('U.S.', 'US'),
+			('U.S.', 'U. S.')`,
+		// 'Mass.' deliberately has no alt rows: it must be absent from the map.
+	}
+	for _, stmt := range setup {
+		_, err := s.DB.Exec(ctx, stmt)
+		require.NoError(t, err, "setup: %s", stmt)
+	}
+
+	got, err := s.LoadReporterAltAbbrs(ctx)
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []string{"US", "U. S."}, got["U.S."])
+	assert.Equal(t, []string{"Serg. & Rawle"}, got["Serg. & Rawl."])
+	_, hasMass := got["Mass."]
+	assert.False(t, hasMass, "a reporter with no alt rows should be absent from the map")
+	assert.Len(t, got, 2)
+}

--- a/slurm/cite-linker.sh
+++ b/slurm/cite-linker.sh
@@ -7,10 +7,10 @@
 #SBATCH --error=/scratch/%u/logs/%j-%x-%N.log
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
-#SBATCH --cpus-per-task=64
-#SBATCH --time=1-00:00:00
-#SBATCH --mem=32GB
-#SBATCH --partition bigmem
+#SBATCH --cpus-per-task=24
+#SBATCH --time=02:00:00
+#SBATCH --mem=12GB
+#SBATCH --partition=normal
 #SBATCH --mail-user lmullen@gmu.edu
 #SBATCH --mail-type BEGIN
 #SBATCH --mail-type END


### PR DESCRIPTION
## Problem

The FreeLaw crosswalk (`freelaw.cite_to_cap`) is keyed on **CourtListener's** reporter spelling, while the linker builds its probe key from **our** `reporter_standard`/`reporter_cap`. Where those disagree — e.g. our `Serg. & Rawl.` vs FreeLaw's `Serg. & Rawle` — the FreeLaw fallback can never match even when FreeLaw holds the case, leaving citations stuck at `no_match`.

## Change

**Go (Track 1):** add `LoadReporterAltAbbrs` to load `legalhist.reporters_abbreviations` as `reporter_standard -> []alt_abbr`, and probe the FreeLaw map with each alternate spelling in `linkCAPThenCode` — after the canonical CAP and FreeLaw-normalized probes miss, before the code-reporter probe. A hit still resolves to a CAP case (`linked_cap`); direct CAP/FreeLaw hits keep precedence. alt_abbrs are keyed by `reporter_standard` (like diffvols); the nil-volume form is built like `buildStandardCite`/`buildCAPCite`.

**Migration:** `20260612205502_seed-freelaw-reporter-alt-abbrs.sql` seeds the four approved pairs not already present:
`Serg. & Rawl.→Serg. & Rawle`, `Woods.→Woods`, `Walker→Walk.`, `Green→Greene`. Four other approved pairs (`Martin→Mart.`, `Porter→Port.`, `Stewart→Stew.`, `Story C.C.→Story`) already exist in the table and are picked up automatically by the new probe. Idempotent (`WHERE NOT EXISTS` + FK/CHECK guards, no unique constraint on the table); `down` removes exactly the four seeded pairs.

Mappings derived by exact-cite analysis against `freelaw.cite_to_cap` and **approved by @kfunk074** on #220. Expected recovery ≈ **75K** `no_match` citations, ~70% of it `Serg. & Rawl.`.

**Track 2** (nominative → official volume remap) is deferred — it's data-only via `reporters_diffvols` (which `buildCAPCite` already applies), the obvious nominatives are already mapped, and remaining gaps need external volume-offset reference data.

## Note on `db/schema.sql`

The regen also brings in the `freelaw.cite_to_cap` matview DDL from the already-merged `20260611182350` migration, whose `schema.sql` regeneration had not previously been committed. This PR resyncs it.

## Testing
- `go build/vet/test ./...` pass. New unit cases cover recovery, precedence (direct CAP/FreeLaw win), multi-alt first-hit, nil-volume, and UK exclusion. `TestLoadReporterAltAbbrsIntegration` (gated by `LAW_TEST_DBSTR`) validated against Postgres 17.
- Migration up/down/idempotency validated against Postgres 17 (seeds 4, leaves pre-existing rows untouched, down reverses exactly).

After merge, re-run the linker with `--reset` to recover the affected citations.

Refs #220