### PR TITLE
cite-detector: record the abbreviation detected, not the reporter

### DIFF
--- a/cite-detector-moml/main.go
+++ b/cite-detector-moml/main.go
@@ -74,9 +74,11 @@ func main() {
 	slog.Info("prepared general-purpose detector", "num_detectors", len(detectors))
 
 	// Create and load the single volume detectors. Each row is a
-	// (reporter_standard, abbreviation) pair, so the saved reporter_abbr
-	// gets normalized to the canonical reporter_standard regardless of
-	// which spelling appeared in the OCR.
+	// (reporter_standard, abbreviation) pair. The saved reporter_abbr is the
+	// spelling that actually appeared in the OCR, not the reporter_standard the
+	// detector was built from; cite-linker normalizes it through
+	// legalhist.whitelist, so a spelling that belongs to a different reporter is
+	// linked to that reporter instead of to this single volume.
 	singleVolReporters, err := citationsDB.GetSingleVolReporterAbbrs(ctx)
 	if err != nil {
 		slog.Error("could not get single volume reporters from database", "error", err)

--- a/cite-linker/main_test.go
+++ b/cite-linker/main_test.go
@@ -14,6 +14,8 @@ func TestLinkCitation(t *testing.T) {
 	usStd := "U.S."
 	qbStd := "Q.B."
 	statStd := "Stat."
+	alaStd := "Ala."
+	aleynStd := "Al"
 
 	tests := []struct {
 		name         string
@@ -147,6 +149,40 @@ func TestLinkCitation(t *testing.T) {
 			wantStatus:   citations.StatusLinkedCAP,
 			wantCAPID:    ptr(int64(444)),
 			wantLinked:   ptr("Stat 30"),
+		},
+		{
+			// Regression test for #218/#226. The single-volume detector for
+			// Aleyn's King's Bench ("Al") also fires on "Ala." in OCR'd text.
+			// Now that the detector records the spelling it actually found, the
+			// whitelist routes the citation to the Alabama reporter. Previously
+			// ReporterAbbr arrived as "Al", so the linker built candidate cites
+			// against Aleyn's single volume instead.
+			name: "detected spelling routes to its own reporter",
+			cite: citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(12), ReporterAbbr: "Ala.", Page: 672},
+			whitelist: map[string]*citations.WhitelistEntry{
+				"Ala.": {ReporterStandard: &alaStd},
+				"Al":   {ReporterStandard: &aleynStd, UK: true},
+			},
+			capCites:   map[string]int64{"12 Ala. 672": 555},
+			erCites:    map[string]string{"Al 672": "aleyn-false-positive"},
+			wantStatus: citations.StatusLinkedCAP,
+			wantCAPID:  ptr(int64(555)),
+			wantLinked: ptr("12 Ala. 672"),
+		},
+		{
+			// The same routing, but with nothing to link to. The English
+			// Reports entry keyed on "Al 672" is exactly the false positive
+			// this issue removes: it is reachable only if the citation claims
+			// to be a citation to Aleyn.
+			name: "detected spelling is not attributed to the detecting single volume",
+			cite: citations.UnlinkedCitation{ID: uuid.New(), Volume: nil, ReporterAbbr: "Ala.", Page: 672},
+			whitelist: map[string]*citations.WhitelistEntry{
+				"Ala.": {ReporterStandard: &alaStd},
+				"Al":   {ReporterStandard: &aleynStd, UK: true},
+			},
+			erCites:    map[string]string{"Al 672": "aleyn-false-positive"},
+			wantStatus: citations.StatusNoMatch,
+			wantLinked: nil,
 		},
 		{
 			name:         "alt_abbr path is not consulted for UK reporters",

--- a/go/citations/detector.go
+++ b/go/citations/detector.go
@@ -42,12 +42,14 @@ func NewSingleVolDetector(reporter string, abbreviation string) *Detector {
 		Abbreviation: abbreviation,
 		initial:      nil,
 		// \b keeps the abbreviation from matching mid-word: without it "Bur"
-		// matches inside "McBur". The abbreviation must also be followed
-		// directly by the page number, so long forms such as "Tothill" only
-		// match if they are registered as abbreviations in their own right --
-		// stemming here made "Al" swallow "Alienation" and "Ala.".
+		// matches inside "McBur".
+		// \w* allows alternate long forms (e.g. Tothill matching Toth). It
+		// deliberately over-captures -- "Al" also matches "Alienation" and
+		// "Ala." -- because the abbreviation recorded below is the word that
+		// actually matched, which the whitelist then routes to the right
+		// reporter or rejects outright.
 		// [.,]* allows optional period/comma separators before the page number.
-		regex: regexp.MustCompile(`\b` + flexAbbr + `[.,]*\s+\d{1,4}`),
+		regex: regexp.MustCompile(`\b` + flexAbbr + `\w*[.,]*\s+\d{1,4}`),
 	}
 	return detector
 }

--- a/go/citations/detector.go
+++ b/go/citations/detector.go
@@ -41,9 +41,13 @@ func NewSingleVolDetector(reporter string, abbreviation string) *Detector {
 		Reporter:     reporter,
 		Abbreviation: abbreviation,
 		initial:      nil,
-		// \w* allows alternate long forms (e.g. Tothill matching Toth).
+		// \b keeps the abbreviation from matching mid-word: without it "Bur"
+		// matches inside "McBur". The abbreviation must also be followed
+		// directly by the page number, so long forms such as "Tothill" only
+		// match if they are registered as abbreviations in their own right --
+		// stemming here made "Al" swallow "Alienation" and "Ala.".
 		// [.,]* allows optional period/comma separators before the page number.
-		regex: regexp.MustCompile(flexAbbr + `\w*[.,]*\s+\d{1,4}`),
+		regex: regexp.MustCompile(`\b` + flexAbbr + `[.,]*\s+\d{1,4}`),
 	}
 	return detector
 }
@@ -106,21 +110,22 @@ func (d *Detector) Detect(doc sources.Document) []*Citation {
 		pp := rePage.FindString(m)
 		c.Page, _ = strconv.Atoi(pp)
 
-		// Determine the reporter abbreviation.
-		if d.initial == nil {
-			// Single-volume detector: use the canonical reporter name directly,
-			// since the raw match may include separator characters (commas,
-			// trailing periods) that are not part of the abbreviation.
-			c.ReporterAbbr = d.Reporter
-		} else {
-			// Standard detector: derive the abbreviation by trimming the volume
-			// and page numbers from the raw match.
-			abbr := m
-			abbr = strings.Replace(abbr, vol, "", 1)
-			abbr = strings.Replace(abbr, pp, "", 1)
-			abbr = strings.TrimSpace(abbr)
-			c.ReporterAbbr = abbr
-		}
+		// Derive the abbreviation as it actually appeared in the text by
+		// trimming the volume and page numbers off the match. Both reVolume and
+		// rePage are anchored, so trimming the prefix and suffix leaves any
+		// digits inside the abbreviation itself alone. A trailing comma is a
+		// separator admitted by the single-volume regex rather than part of the
+		// abbreviation, so drop it; trailing periods are kept because they are
+		// usually part of the abbreviation ("Ala.", "Hob.").
+		//
+		// Recording what was detected rather than the reporter the detector was
+		// built from is what lets the whitelist normalize single-volume
+		// citations at link time, the same way it does for every other citation.
+		abbr := m
+		abbr = strings.TrimPrefix(abbr, vol)
+		abbr = strings.TrimSuffix(abbr, pp)
+		abbr = strings.TrimRight(strings.TrimSpace(abbr), " ,")
+		c.ReporterAbbr = abbr
 
 		// Save the source
 		c.Source = doc

--- a/go/citations/detector_test.go
+++ b/go/citations/detector_test.go
@@ -112,12 +112,12 @@ func TestSingleVolDetector_Detect(t *testing.T) {
 			expected:     []string{"Cheves Eq. 12"},
 		},
 		{
-			// "Tothill, 876" is deliberately absent: without stemming, the
-			// "Toth" detector no longer swallows longer words. "Tothill" is
-			// matched by its own detector instead.
+			// \w* lets the "Toth" abbreviation reach the longer form
+			// "Tothill", which is recorded as "Tothill" rather than "Toth" so
+			// that the whitelist decides where it belongs.
 			name:         "Toth",
 			abbreviation: `Toth`,
-			expected:     []string{"Toth. 234", "Toth. 125", "Toth 462"},
+			expected:     []string{"Toth. 234", "Tothill 876", "Toth. 125", "Toth 462"},
 		},
 		{
 			name:         "Tothill",
@@ -308,44 +308,45 @@ func TestSingleVolDetector_RawPreservesOCR(t *testing.T) {
 	assert.Equal(t, "Bail Eq 42", cites[0].Raw, "Raw should preserve the OCR'd alt spelling")
 }
 
-// TestSingleVolDetector_NoStemming verifies that a single-volume abbreviation
-// does not match longer words that merely begin with it. This is the fix for
-// issue #218: the abbreviation "Al" was matching "Alienation", "Alimony" and
-// "Ala.", and every one of those was then recorded as a citation to Aleyn's
-// King's Bench. A genuine long form such as "Tothill" is picked up by its own
-// detector, registered in legalhist.reporters_abbreviations.
-func TestSingleVolDetector_NoStemming(t *testing.T) {
-	notMatched := []string{
-		"the law of Alienation, 118 is settled",
-		"see Ala., 672 for the rule",
-		"compare Allen, 2 with the later cases",
-		"questions of Alimony 122 aside",
-		"discussed in Alexander, 3 at length",
-	}
-	d := NewSingleVolDetector("Al", "Al")
-	for _, text := range notMatched {
-		t.Run(text, func(t *testing.T) {
-			doc := sources.NewDoc("test-no-stem", text)
-			assert.Empty(t, d.Detect(doc),
-				"abbreviation should not match a longer word beginning with it")
-		})
-	}
-
-	matched := []struct {
+// TestSingleVolDetector_StemRecordsMatchedWord pins down what the \w* stem
+// costs and why that is now tolerable. The stem makes the abbreviation "Al"
+// reach any word beginning with it, so Aleyn's King's Bench detector fires on
+// "Alienation", "Alimony" and "Ala." alike. Under the old behavior every one of
+// those was recorded as a citation to Aleyn and linked on the page number
+// alone, which issue #218 identifies as the largest source of false positives
+// in the data.
+//
+// Recording the word that actually matched moves the decision to the
+// whitelist: "Ala." routes to the Alabama reporter, "Alienation" and "Alimony"
+// are not whitelisted and are skipped. The over-capture becomes a volume
+// problem rather than an accuracy problem.
+func TestSingleVolDetector_StemRecordsMatchedWord(t *testing.T) {
+	tests := []struct {
 		text         string
 		expectedAbbr string
+		expectedPage int
 	}{
-		{"see Al. 17 for the rule", "Al."},
-		{"see Al 17 for the rule", "Al"},
-		{"see Al, 17 for the rule", "Al"},
+		// Stemmed matches: recorded as the longer word, not as "Al".
+		{"the law of Alienation, 118 is settled", "Alienation", 118},
+		{"see Ala., 672 for the rule", "Ala.", 672},
+		{"compare Allen, 2 with the later cases", "Allen", 2},
+		{"questions of Alimony 122 aside", "Alimony", 122},
+		{"discussed in Alexander, 3 at length", "Alexander", 3},
+		// Exact matches still record the abbreviation itself.
+		{"see Al. 17 for the rule", "Al.", 17},
+		{"see Al 17 for the rule", "Al", 17},
+		{"see Al, 17 for the rule", "Al", 17},
 	}
-	for _, tt := range matched {
+
+	d := NewSingleVolDetector("Al", "Al")
+	for _, tt := range tests {
 		t.Run(tt.text, func(t *testing.T) {
-			doc := sources.NewDoc("test-no-stem", tt.text)
+			doc := sources.NewDoc("test-stem", tt.text)
 			cites := d.Detect(doc)
 			require.Len(t, cites, 1)
-			assert.Equal(t, tt.expectedAbbr, cites[0].ReporterAbbr)
-			assert.Equal(t, 17, cites[0].Page)
+			assert.Equal(t, tt.expectedAbbr, cites[0].ReporterAbbr,
+				"ReporterAbbr should be the word that matched, not the reporter")
+			assert.Equal(t, tt.expectedPage, cites[0].Page)
 		})
 	}
 }

--- a/go/citations/detector_test.go
+++ b/go/citations/detector_test.go
@@ -112,14 +112,22 @@ func TestSingleVolDetector_Detect(t *testing.T) {
 			expected:     []string{"Cheves Eq. 12"},
 		},
 		{
+			// "Tothill, 876" is deliberately absent: without stemming, the
+			// "Toth" detector no longer swallows longer words. "Tothill" is
+			// matched by its own detector instead.
 			name:         "Toth",
 			abbreviation: `Toth`,
-			expected:     []string{"Toth 234", "Toth 876", "Toth 125", "Toth 462"},
+			expected:     []string{"Toth. 234", "Toth. 125", "Toth 462"},
+		},
+		{
+			name:         "Tothill",
+			abbreviation: `Tothill`,
+			expected:     []string{"Tothill 876"},
 		},
 		{
 			name:         "M & M",
 			abbreviation: `M & M`,
-			expected:     []string{"M & M 12", "M & M 123", "M & M 234"},
+			expected:     []string{"M&M. 12", "M & M 123", "M. & M. 234"},
 		},
 	}
 
@@ -171,82 +179,101 @@ func TestSingleVolDetector_VolumeIsNil(t *testing.T) {
 	assert.Nil(t, cites[0].Volume, "single-vol detector should produce nil Volume")
 }
 
-// TestSingleVolDetector_NormalizesReporterAbbr verifies that when the canonical
-// reporter_standard differs from the abbreviation that actually matched in the
-// OCR, the resulting Citation carries the canonical form in ReporterAbbr while
-// Raw preserves the literal OCR'd substring. This is the contract that the
-// detector-creation loop in cite-detector-moml relies on for downstream
-// linking against legalhist.reporters.
-func TestSingleVolDetector_NormalizesReporterAbbr(t *testing.T) {
+// TestSingleVolDetector_RecordsDetectedAbbr verifies that the Citation records
+// the abbreviation that actually matched in the OCR, not the reporter the
+// detector was built from. cite-linker normalizes that detected form through
+// legalhist.whitelist, exactly as it does for the generic detector. Recording
+// the reporter instead would assert that every match belongs to this single
+// volume, which is how "Alienation, 118" came to be linked to Aleyn's King's
+// Bench.
+func TestSingleVolDetector_RecordsDetectedAbbr(t *testing.T) {
 	tests := []struct {
 		name         string
-		canonical    string
+		reporter     string
 		abbreviation string
 		text         string
+		expectedAbbr string
 		expectedRaw  string
 		expectedPage int
 	}{
 		{
 			name:         "alt missing internal periods",
-			canonical:    "Bail. Eq.",
+			reporter:     "Bail. Eq.",
 			abbreviation: "Bail Eq",
 			text:         "Compare Bail Eq 17 with the earlier ruling.",
+			expectedAbbr: "Bail Eq",
 			expectedRaw:  "Bail Eq 17",
 			expectedPage: 17,
 		},
 		{
-			name:         "alt matches canonical exactly",
-			canonical:    "Bail. Eq.",
+			name:         "alt matches reporter exactly",
+			reporter:     "Bail. Eq.",
 			abbreviation: "Bail. Eq.",
 			text:         "See Bail. Eq. 42 for the rule.",
+			expectedAbbr: "Bail. Eq.",
 			expectedRaw:  "Bail. Eq. 42",
 			expectedPage: 42,
 		},
 		{
 			name:         "alt missing trailing period",
-			canonical:    "Baldw.",
+			reporter:     "Baldw.",
 			abbreviation: "Baldw",
 			text:         "The federal view in Baldw 125 was different.",
+			expectedAbbr: "Baldw",
 			expectedRaw:  "Baldw 125",
 			expectedPage: 125,
 		},
 		{
-			name:         "alt is longer form than canonical",
-			canonical:    "Hob.",
+			name:         "trailing comma is a separator, not part of the abbr",
+			reporter:     "Baldw.",
+			abbreviation: "Baldw",
+			text:         "The federal view in Baldw, 125 was different.",
+			expectedAbbr: "Baldw",
+			expectedRaw:  "Baldw, 125",
+			expectedPage: 125,
+		},
+		{
+			name:         "alt is longer form than reporter",
+			reporter:     "Hob.",
 			abbreviation: "Hobart",
 			text:         "The rule in Hobart 423 was the older precedent.",
+			expectedAbbr: "Hobart",
 			expectedRaw:  "Hobart 423",
 			expectedPage: 423,
 		},
 		{
-			name:         `alt is much longer form (exercises \w*)`,
-			canonical:    "Toth",
+			name:         "alt is much longer form than reporter",
+			reporter:     "Toth",
 			abbreviation: "Tothill",
 			text:         "See Tothill 876 for the early statement.",
+			expectedAbbr: "Tothill",
 			expectedRaw:  "Tothill 876",
 			expectedPage: 876,
 		},
 		{
 			name:         "alt with parenthesized jurisdiction (SC)",
-			canonical:    "Bail. Eq.",
+			reporter:     "Bail. Eq.",
 			abbreviation: "Bail Eq (SC)",
 			text:         "See Bail Eq (SC) 42 for the ruling.",
+			expectedAbbr: "Bail Eq (SC)",
 			expectedRaw:  "Bail Eq (SC) 42",
 			expectedPage: 42,
 		},
 		{
 			name:         "alt with parenthesized jurisdiction (Eng)",
-			canonical:    "Al",
+			reporter:     "Al",
 			abbreviation: "Al (Eng)",
 			text:         "Reference Al (Eng) 17 in the early reports.",
+			expectedAbbr: "Al (Eng)",
 			expectedRaw:  "Al (Eng) 17",
 			expectedPage: 17,
 		},
 		{
 			name:         "alt with parenthesized jurisdiction (US)",
-			canonical:    "Baldw.",
+			reporter:     "Baldw.",
 			abbreviation: "Baldw (US)",
 			text:         "The federal view in Baldw (US) 125 was different.",
+			expectedAbbr: "Baldw (US)",
 			expectedRaw:  "Baldw (US) 125",
 			expectedPage: 125,
 		},
@@ -254,12 +281,12 @@ func TestSingleVolDetector_NormalizesReporterAbbr(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			doc := sources.NewDoc("test-normalize", tt.text)
-			d := NewSingleVolDetector(tt.canonical, tt.abbreviation)
+			doc := sources.NewDoc("test-detected-abbr", tt.text)
+			d := NewSingleVolDetector(tt.reporter, tt.abbreviation)
 			cites := d.Detect(doc)
 			require.Len(t, cites, 1)
-			assert.Equal(t, tt.canonical, cites[0].ReporterAbbr,
-				"ReporterAbbr should be the canonical form, not the matched alt")
+			assert.Equal(t, tt.expectedAbbr, cites[0].ReporterAbbr,
+				"ReporterAbbr should be the spelling that matched, not the reporter")
 			assert.Equal(t, tt.expectedRaw, cites[0].Raw,
 				"Raw should preserve the OCR'd alt spelling")
 			assert.Equal(t, tt.expectedPage, cites[0].Page)
@@ -277,8 +304,65 @@ func TestSingleVolDetector_RawPreservesOCR(t *testing.T) {
 	d := NewSingleVolDetector("Bail. Eq.", "Bail Eq")
 	cites := d.Detect(doc)
 	require.Len(t, cites, 1)
-	assert.Equal(t, "Bail. Eq.", cites[0].ReporterAbbr, "ReporterAbbr should be the canonical")
+	assert.Equal(t, "Bail Eq", cites[0].ReporterAbbr, "ReporterAbbr should be the detected spelling")
 	assert.Equal(t, "Bail Eq 42", cites[0].Raw, "Raw should preserve the OCR'd alt spelling")
+}
+
+// TestSingleVolDetector_NoStemming verifies that a single-volume abbreviation
+// does not match longer words that merely begin with it. This is the fix for
+// issue #218: the abbreviation "Al" was matching "Alienation", "Alimony" and
+// "Ala.", and every one of those was then recorded as a citation to Aleyn's
+// King's Bench. A genuine long form such as "Tothill" is picked up by its own
+// detector, registered in legalhist.reporters_abbreviations.
+func TestSingleVolDetector_NoStemming(t *testing.T) {
+	notMatched := []string{
+		"the law of Alienation, 118 is settled",
+		"see Ala., 672 for the rule",
+		"compare Allen, 2 with the later cases",
+		"questions of Alimony 122 aside",
+		"discussed in Alexander, 3 at length",
+	}
+	d := NewSingleVolDetector("Al", "Al")
+	for _, text := range notMatched {
+		t.Run(text, func(t *testing.T) {
+			doc := sources.NewDoc("test-no-stem", text)
+			assert.Empty(t, d.Detect(doc),
+				"abbreviation should not match a longer word beginning with it")
+		})
+	}
+
+	matched := []struct {
+		text         string
+		expectedAbbr string
+	}{
+		{"see Al. 17 for the rule", "Al."},
+		{"see Al 17 for the rule", "Al"},
+		{"see Al, 17 for the rule", "Al"},
+	}
+	for _, tt := range matched {
+		t.Run(tt.text, func(t *testing.T) {
+			doc := sources.NewDoc("test-no-stem", tt.text)
+			cites := d.Detect(doc)
+			require.Len(t, cites, 1)
+			assert.Equal(t, tt.expectedAbbr, cites[0].ReporterAbbr)
+			assert.Equal(t, 17, cites[0].Page)
+		})
+	}
+}
+
+// TestSingleVolDetector_WordBoundary verifies that an abbreviation does not
+// match in the middle of a word, which is what the leading \b in the regex
+// guards against.
+func TestSingleVolDetector_WordBoundary(t *testing.T) {
+	d := NewSingleVolDetector("Bur.", "Bur")
+
+	doc := sources.NewDoc("test-boundary", "the estate of McBur 12 was disputed")
+	assert.Empty(t, d.Detect(doc), "abbreviation should not match mid-word")
+
+	doc = sources.NewDoc("test-boundary", "the estate in Bur. 12 was disputed")
+	cites := d.Detect(doc)
+	require.Len(t, cites, 1)
+	assert.Equal(t, "Bur.", cites[0].ReporterAbbr)
 }
 
 // TestDetector_SpacingVariants documents the generic detector's behavior on
@@ -328,24 +412,28 @@ func TestDetector_SpacingVariants(t *testing.T) {
 // detector matches OCR text that omits the whitespace between abbreviation
 // tokens. NewSingleVolDetector substitutes [\s.]* for every literal space in
 // the abbreviation, so "Ga. App." compiles to `Ga\.[\s.]*App\.` and matches
-// both "Ga. App." and "Ga.App." Saved ReporterAbbr is normalized to the
-// canonical form regardless of which spelling appeared in the OCR.
+// both "Ga. App." and "Ga.App." As with the generic detector, ReporterAbbr is
+// saved exactly as it appeared, so the whitelist must carry one row per
+// spelling. See TestDetector_SpacingVariants for the same contract.
 func TestSingleVolDetector_SpacingVariants(t *testing.T) {
 	tests := []struct {
 		name         string
 		text         string
+		expectedAbbr string
 		expectedRaw  string
 		expectedPage int
 	}{
 		{
 			name:         "canonical spacing",
 			text:         "See Ga. App. 42 for the rule.",
+			expectedAbbr: "Ga. App.",
 			expectedRaw:  "Ga. App. 42",
 			expectedPage: 42,
 		},
 		{
 			name:         "no space between tokens",
 			text:         "See Ga.App. 42 for the rule.",
+			expectedAbbr: "Ga.App.",
 			expectedRaw:  "Ga.App. 42",
 			expectedPage: 42,
 		},
@@ -356,8 +444,8 @@ func TestSingleVolDetector_SpacingVariants(t *testing.T) {
 			d := NewSingleVolDetector("Ga. App.", "Ga. App.")
 			cites := d.Detect(doc)
 			require.Len(t, cites, 1)
-			assert.Equal(t, "Ga. App.", cites[0].ReporterAbbr,
-				"ReporterAbbr should be canonical regardless of OCR spacing")
+			assert.Equal(t, tt.expectedAbbr, cites[0].ReporterAbbr,
+				"ReporterAbbr should preserve the OCR's spacing")
 			assert.Equal(t, tt.expectedRaw, cites[0].Raw,
 				"Raw should preserve the OCR's spacing")
 			assert.Equal(t, tt.expectedPage, cites[0].Page)


### PR DESCRIPTION
Closes #226. Addresses the diagnosis in #218.

## The problem

`NewSingleVolDetector` built a permissive regex and then discarded what actually
matched, stamping the reporter it was built from onto the citation:

```go
if d.initial == nil {
    c.ReporterAbbr = d.Reporter
}
```

`reporter_abbr` has exactly one job downstream: it is the key for the exact-match
whitelist lookup at `cite-linker/main.go:265`, against
`legalhist.whitelist.reporter_found`. Nothing normalizes in between. So stamping the
reporter told the linker "this *is* the single volume" and bypassed the whitelist
entirely — the linker then built candidate cites against that one volume and linked
wherever the page number happened to hit.

Measured against the current data:

| reporter | rows detected | rows that *actually* read that way | currently "linked" |
|---|---|---|---|
| `Al` (Aleyn's KB) | 982,357 | **2,631** | 324,861 |
| `Calth` (Calthrop) | 529,542 | **7** | 814 |
| `Bur.` (Burnett Wis.) | 322,227 | 14,218 | 0 |

A live sample of what `Al` captures today, every one stored as `reporter_abbr = 'Al'`:
`Alienation, 118` · `Alimony 122` · `Alterations, 82` · `Altona 33` · `Ala., 672` · `Allen, 2`.

## The change

**Record what was detected.** Both detector paths now share one derivation. Since
`reVolume` (`^\d+`) and `rePage` (`\d+$`) are anchored, `TrimPrefix`/`TrimSuffix` are
exact — and safer than the previous replace-first-occurrence for the 5 abbreviations
that contain digits. Trailing commas are dropped as separators the regex admits;
trailing periods are kept because they are usually part of the abbreviation (`Ala.`,
`Hob.`). This also removes the `d.initial == nil` branch.

**The `\w*` stem is kept.** It over-captures by design, and that is now tolerable: the
recorded value is the word that actually matched, so the whitelist routes `Ala.` and
`Allen` to their own reporters and rejects `Alienation`, `Jackson` and `Burke` outright.
The over-capture becomes a volume problem rather than an accuracy problem.

**A leading `\b` is added.** This is independent of stemming and strictly reduces false
positives: it prevents an abbreviation from matching mid-word, e.g. `Bur` inside `McBur`,
which matched before.

## Expected effect on the data

Roughly 7.7M single-volume rows are detected today and every one of them carries a
reporter name it may not deserve. Row counts stay in the same range; what changes is
where they are routed:

| | before | after |
|---|---|---|
| resolve through the whitelist | n/a (bypassed) | 5,793,560 (75%) |
| whitelisted as junk → skipped | — | 367,893 |
| unwhitelisted → skipped, surfacing in whitelist-extender | — | 1,925,335 (25%) |
| carrying a `linked_*` status | 2,028,975 | far lower, and honest |

Of the 2,028,525 rows currently carrying `linked_english_reports`, about 701,552 keep the
same reporter, 571,896 route to a *different* reporter, and the remainder drop out as
unwhitelisted (586,065) or junk (169,012).

**Link counts will drop sharply, on purpose.** Per #218 these were false positives —
"probably the biggest false positive problem we have in the data right now."

Figures are derived from the existing `raw` column across the 7.7M `volume IS NULL` rows,
so they do not model the new `\b`; treat them as close approximations.

The 25% that end up unwhitelisted are the visible cost of keeping the stem. They are not
lost — they surface in the whitelist-extender (`getUnwhitelistedReporters`) for curation,
which is the intended workflow, rather than being silently attributed to a single volume.

## Reprocessing (manual, after merge)

`cite-detector-moml` has no resume logic, so stale rows must be deleted first or it will
add new rows beside them:

```sql
DELETE FROM moml_citations.citation_links
 WHERE citation_id IN (SELECT id FROM moml_citations.citations_unlinked WHERE volume IS NULL);
DELETE FROM moml_citations.citations_unlinked WHERE volume IS NULL;
```

```bash
sbatch slurm/cite-detector-moml.sh   # 64 CPU, up to 24h
sbatch slurm/cite-linker.sh
./db/maintenance.sh                  # refresh dependent matviews
```

## Relationship to #231

#231 seeds 32 long forms (`Davis`→`Dav`, `Edwards`→`Edw`, `Tothill`→`Toth`) as alternate
abbreviations. It was written when this PR removed the stem, which would have left those
192,283 citations undetected. **With the stem kept, that PR is no longer a prerequisite** —
those forms are reached from their short abbreviations as before, and are now recorded
under the spelling that matched so the whitelist links them correctly.

#231 retains an independent benefit on the linking side: `LoadReporterAltAbbrs` has no
`single_vol` filter, so registering those spellings would also make `cite-linker` probe the
FreeLaw crosswalk under them. That is worth evaluating on its own merits.

## Tests

`TestSingleVolDetector_NormalizesReporterAbbr` became `..._RecordsDetectedAbbr` with
inverted assertions. `..._StemRecordsMatchedWord` pins down the stem's over-capture and
the honest recording that makes it safe, using the actual `Al`/`Alienation`/`Ala.` strings
pulled from the database. `..._WordBoundary` covers the new `\b`. Two `cite-linker` cases
prove a detected `Ala.` routes to Alabama rather than reaching the Aleyn English Reports
entry. `go build`, `go vet`, and `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
