### PR TITLE
db: seed long-form abbreviations for single-volume reporters

### DIFF
--- a/db/migrations/20260727212625_seed-single-vol-long-form-abbrs.sql
+++ b/db/migrations/20260727212625_seed-single-vol-long-form-abbrs.sql
@@ -1,0 +1,114 @@
+-- migrate:up
+SET ROLE = law_admin;
+
+-- Issue #226 (with #218): the single-volume detector no longer stems, so an
+-- abbreviation must now be followed directly by the page number. Stemming was
+-- how "Al" came to match "Alienation" and "Ala.", but it was also the only way
+-- the long forms below were ever detected: each is a longer spelling of a
+-- single-volume reporter that is NOT registered in reporters_abbreviations, so
+-- without stemming no detector matches it at all.
+--
+-- Seeding them gives each long form its own detector, which matches the exact
+-- spelling instead of anything sharing a prefix. legalhist.whitelist already
+-- maps every one of these strings to the reporter_standard shown, so nothing
+-- downstream of detection needs to change.
+--
+-- The list was derived from the 7.7M existing volume-IS-NULL rows in
+-- moml_citations.citations_unlinked: forms that (a) stop matching once the stem
+-- is removed, (b) resolve through the whitelist to a non-junk reporter, and
+-- (c) whose reporter has single_vol = true. Together they account for 192,283
+-- detected citations. Row counts at time of writing are in the trailing comment
+-- on each pair.
+--
+-- reporters_abbreviations has no unique constraint, so each row is inserted only
+-- when the exact (reporter_standard, alt_abbr) pair is absent. The EXISTS guard
+-- respects the FK to legalhist.reporters; the WHERE clause respects the
+-- reporter_standard <> alt_abbr CHECK.
+INSERT INTO legalhist.reporters_abbreviations (reporter_standard, alt_abbr)
+SELECT v.reporter_standard, v.alt_abbr
+FROM (VALUES
+    ('Dav',        'Davis'),          -- 88174
+    ('Edw',        'Edwards'),        -- 38480
+    ('Dan',        'Daniel'),         -- 12938
+    ('Vern',       'Vernon'),         -- 10399
+    ('Dud.',       'Dudley'),         --  7730
+    ('Edw',        'Edward'),         --  6776
+    ('Comst.',     'Comstock'),       --  6554
+    ('Andr',       'Andrew'),         --  4615
+    ('Swab',       'Swabey'),         --  2213
+    ('Wilm',       'Wilmot'),         --  2055
+    ('Dan',        'Daniell'),        --  1739
+    ('Carth',      'Carthew'),        --  1706
+    ('Lush',       'Lushington'),     --  1682
+    ('Sav',        'Saville'),        --  1186
+    ('Toth',       'Tothill'),        --   914
+    ('Godb',       'Godbolt'),        --   715
+    ('Wight',      'Wightwick'),      --   674
+    ('Busb.',      'Busbee'),         --   647
+    ('Taml',       'Tamlyn'),         --   639
+    ('Tay.',       'Tayl.'),          --   511
+    ('Het',        'Hetley'),         --   447
+    ('Keil',       'Keilway'),        --   387
+    ('McMul.',     'McMull.'),        --   309
+    ('Peck',       'Peckw.'),         --   227
+    ('Calth',      'Calthrop'),       --   172
+    ('Dears',      'Dearsly'),        --   129
+    ('Comb',       'Comberbach'),     --   125
+    ('M''Cle',     'M''Cleland'),     --    51
+    ('Cas T H',    'Cas. T. Hard.'),  --    41
+    ('Gould',      'Gouldsborough'),  --    31
+    ('Hay & M',    'Hay & Marriott'), --    16
+    ('Hoff. Ch.',  'Hoff. Chan.')     --     1
+) AS v(reporter_standard, alt_abbr)
+WHERE v.reporter_standard <> v.alt_abbr
+  AND EXISTS (
+    SELECT 1 FROM legalhist.reporters r
+    WHERE r.reporter_standard = v.reporter_standard
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM legalhist.reporters_abbreviations ra
+    WHERE ra.reporter_standard = v.reporter_standard
+      AND ra.alt_abbr = v.alt_abbr
+  );
+
+-- migrate:down
+SET ROLE = law_admin;
+
+-- Remove exactly the pairs seeded above.
+DELETE FROM legalhist.reporters_abbreviations ra
+USING (VALUES
+    ('Dav',        'Davis'),
+    ('Edw',        'Edwards'),
+    ('Dan',        'Daniel'),
+    ('Vern',       'Vernon'),
+    ('Dud.',       'Dudley'),
+    ('Edw',        'Edward'),
+    ('Comst.',     'Comstock'),
+    ('Andr',       'Andrew'),
+    ('Swab',       'Swabey'),
+    ('Wilm',       'Wilmot'),
+    ('Dan',        'Daniell'),
+    ('Carth',      'Carthew'),
+    ('Lush',       'Lushington'),
+    ('Sav',        'Saville'),
+    ('Toth',       'Tothill'),
+    ('Godb',       'Godbolt'),
+    ('Wight',      'Wightwick'),
+    ('Busb.',      'Busbee'),
+    ('Taml',       'Tamlyn'),
+    ('Tay.',       'Tayl.'),
+    ('Het',        'Hetley'),
+    ('Keil',       'Keilway'),
+    ('McMul.',     'McMull.'),
+    ('Peck',       'Peckw.'),
+    ('Calth',      'Calthrop'),
+    ('Dears',      'Dearsly'),
+    ('Comb',       'Comberbach'),
+    ('M''Cle',     'M''Cleland'),
+    ('Cas T H',    'Cas. T. Hard.'),
+    ('Gould',      'Gouldsborough'),
+    ('Hay & M',    'Hay & Marriott'),
+    ('Hoff. Ch.',  'Hoff. Chan.')
+) AS v(reporter_standard, alt_abbr)
+WHERE ra.reporter_standard = v.reporter_standard
+  AND ra.alt_abbr = v.alt_abbr;


### PR DESCRIPTION
Companion to #230 (`cite-detector: record the abbreviation detected, not the reporter`).
Refs #226, #218.

## Why

#230 removes the `\w*` stem from the single-volume detector regex. That stem is what let
`Al` swallow `Alienation` and `Bur` swallow `Burke` — but it was also the only way the 32
spellings below were ever detected. Each is a longer form of a single-volume reporter that
is **not** registered in `legalhist.reporters_abbreviations`, so once the stem is gone no
detector matches it at all.

Registering them gives each its own detector, matching the exact spelling rather than
anything sharing a prefix. Together they account for **192,283 detected citations**.

Without this migration, #230 is a regression.

## What this affects

`legalhist.reporters_abbreviations` feeds two consumers, and the detection one is the point
of this change:

1. **Detection** — `GetSingleVolReporterAbbrs` (`go/citations/store_db.go:41`) builds one
   `NewSingleVolDetector` per `(reporter_standard, alt_abbr)` pair where `single_vol = true`.
   All 32 pairs qualify, so all 32 create new detectors.
2. **Linking** — `LoadReporterAltAbbrs` (`go/citations/linker_store_db.go:206`) has no
   `single_vol` filter, so it loads the whole table. `cite-linker` will additionally probe
   the FreeLaw crosswalk under these spellings on its next run. Likely beneficial, but it is
   a change, and it takes effect independently of detection.

Also feeds the `legalhist.all_abbreviations` view and the two CAP abbreviation-diff views —
reporting only, no runtime effect.

## The list

| alt_abbr | reporter_standard | citations | | alt_abbr | reporter_standard | citations |
|---|---|---|---|---|---|---|
| Davis | Dav | 88,174 | | Godbolt | Godb | 715 |
| Edwards | Edw | 38,480 | | Wightwick | Wight | 674 |
| Daniel | Dan | 12,938 | | Busbee | Busb. | 647 |
| Vernon | Vern | 10,399 | | Tamlyn | Taml | 639 |
| Dudley | Dud. | 7,730 | | Tayl. | Tay. | 511 |
| Edward | Edw | 6,776 | | Hetley | Het | 447 |
| Comstock | Comst. | 6,554 | | Keilway | Keil | 387 |
| Andrew | Andr | 4,615 | | McMull. | McMul. | 309 |
| Swabey | Swab | 2,213 | | Peckw. | Peck | 227 |
| Wilmot | Wilm | 2,055 | | Calthrop | Calth | 172 |
| Daniell | Dan | 1,739 | | Dearsly | Dears | 129 |
| Carthew | Carth | 1,706 | | Comberbach | Comb | 125 |
| Lushington | Lush | 1,682 | | M'Cleland | M'Cle | 51 |
| Saville | Sav | 1,186 | | Cas. T. Hard. | Cas T H | 41 |
| Tothill | Toth | 914 | | Gouldsborough | Gould | 31 |
| | | | | Hay & Marriott | Hay & M | 16 |
| | | | | Hoff. Chan. | Hoff. Ch. | 1 |

## How it was derived

From the 7.7M `volume IS NULL` rows in `moml_citations.citations_unlinked`: forms that
(a) stop matching once the stem is removed, (b) resolve through `legalhist.whitelist` to a
non-junk reporter, and (c) whose reporter has `single_vol = true`.

Validated read-only against the live schema before committing:

- all 32 reference existing single-volume reporters (FK guard would skip 0)
- 0 are already present in `reporters_abbreviations`
- 0 violate the `reporter_standard <> alt_abbr` CHECK
- **all 32 alt spellings are already in `legalhist.whitelist`**, so nothing downstream of
  detection needs to change

Follows the pattern of `20260612205502_seed-freelaw-reporter-alt-abbrs.sql`: idempotent
`NOT EXISTS` guard per pair (the table has no unique constraint), and a `migrate:down` that
removes exactly these pairs.

## ⚠️ Before merging

- [ ] **@kfunk074 to sign off on the list**, per the practice on #220.
- [ ] `make db-up` then `make db-schema`, and commit the regenerated `db/schema.sql` — it
      records applied migration versions and needs the `('20260727212625')` row. I have
      read-only database access, so this needs to be run by a maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)