### PR TITLE
cite-linker: match single-volume reporters under both volume forms

### DIFF
--- a/cite-linker/main.go
+++ b/cite-linker/main.go
@@ -304,51 +304,59 @@ func linkCAPThenCode(
 	result.CiteCleaned = &citeCleaned
 	result.CiteNormalized = &citeNormalized
 
-	// Try CAP with the normalized cite
-	if caseID, ok := capCites[citeNormalized]; ok {
-		result.Status = citations.StatusLinkedCAP
-		result.CAPCaseID = &caseID
-		result.CiteLinked = &citeNormalized
-		return result
-	}
+	// Run the whole cascade for the form we detected before trying the volume
+	// variant, so an existing link can never be rewired: the variant only ever
+	// turns a no_match into a link.
+	for _, f := range volumeForms(c, entry) {
+		cleaned := buildStandardCite(f, entry)
+		normalized := buildCAPCite(f, entry, diffvols)
 
-	// Fall back to the FreeLaw crosswalk: if any parallel form of this decision
-	// is in our CAP data, this reaches the CAP case from the form we detected.
-	// The result is still a CAP link (status linked_cap).
-	if caseID, ok := freelawCites[citeNormalized]; ok {
-		result.Status = citations.StatusLinkedCAP
-		result.CAPCaseID = &caseID
-		result.CiteLinked = &citeNormalized
-		return result
-	}
-
-	// Fall back to alternate reporter spellings: the same decision may be in the
-	// FreeLaw crosswalk under a CourtListener spelling that differs from our
-	// reporter_standard/reporter_cap. Probe each known alternate spelling for this
-	// reporter (keyed by the canonical reporter_standard, like diffvols). The
-	// first hit links to the CAP case (status linked_cap). Volume-nil is handled
-	// the same way as buildStandardCite/buildCAPCite.
-	for _, alt := range altAbbrs[*entry.ReporterStandard] {
-		var altCite string
-		if c.Volume == nil {
-			altCite = fmt.Sprintf("%s %d", alt, c.Page)
-		} else {
-			altCite = fmt.Sprintf("%d %s %d", *c.Volume, alt, c.Page)
-		}
-		if caseID, ok := freelawCites[altCite]; ok {
+		// Try CAP with the normalized cite
+		if caseID, ok := capCites[normalized]; ok {
 			result.Status = citations.StatusLinkedCAP
 			result.CAPCaseID = &caseID
-			result.CiteLinked = &altCite
+			result.CiteLinked = &normalized
 			return result
 		}
-	}
 
-	// Try Code Reporter with the cleaned cite
-	if codeID, ok := codeCites[citeCleaned]; ok {
-		result.Status = citations.StatusLinkedCodeReporter
-		result.CodeReporterID = &codeID
-		result.CiteLinked = &citeCleaned
-		return result
+		// Fall back to the FreeLaw crosswalk: if any parallel form of this decision
+		// is in our CAP data, this reaches the CAP case from the form we detected.
+		// The result is still a CAP link (status linked_cap).
+		if caseID, ok := freelawCites[normalized]; ok {
+			result.Status = citations.StatusLinkedCAP
+			result.CAPCaseID = &caseID
+			result.CiteLinked = &normalized
+			return result
+		}
+
+		// Fall back to alternate reporter spellings: the same decision may be in the
+		// FreeLaw crosswalk under a CourtListener spelling that differs from our
+		// reporter_standard/reporter_cap. Probe each known alternate spelling for this
+		// reporter (keyed by the canonical reporter_standard, like diffvols). The
+		// first hit links to the CAP case (status linked_cap). Volume-nil is handled
+		// the same way as buildStandardCite/buildCAPCite.
+		for _, alt := range altAbbrs[*entry.ReporterStandard] {
+			var altCite string
+			if f.Volume == nil {
+				altCite = fmt.Sprintf("%s %d", alt, f.Page)
+			} else {
+				altCite = fmt.Sprintf("%d %s %d", *f.Volume, alt, f.Page)
+			}
+			if caseID, ok := freelawCites[altCite]; ok {
+				result.Status = citations.StatusLinkedCAP
+				result.CAPCaseID = &caseID
+				result.CiteLinked = &altCite
+				return result
+			}
+		}
+
+		// Try Code Reporter with the cleaned cite
+		if codeID, ok := codeCites[cleaned]; ok {
+			result.Status = citations.StatusLinkedCodeReporter
+			result.CodeReporterID = &codeID
+			result.CiteLinked = &cleaned
+			return result
+		}
 	}
 
 	result.Status = citations.StatusNoMatch
@@ -367,15 +375,52 @@ func linkEnglishReports(
 	result.CiteCleaned = &citeCleaned
 	result.CiteNormalized = &citeCleaned
 
-	if erID, ok := erCites[citeCleaned]; ok {
-		result.Status = citations.StatusLinkedEnglishReports
-		result.ERCaseID = &erID
-		result.CiteLinked = &citeCleaned
-		return result
+	// The English Reports are inconsistent about the redundant volume on
+	// single-volume nominate reporters: most are stored bare ("Cro Eliz 1") but
+	// some carry it ("1 Vern 1"), so try both forms.
+	for _, f := range volumeForms(c, entry) {
+		cite := buildStandardCite(f, entry)
+		if erID, ok := erCites[cite]; ok {
+			result.Status = citations.StatusLinkedEnglishReports
+			result.ERCaseID = &erID
+			result.CiteLinked = &cite
+			return result
+		}
 	}
 
 	result.Status = citations.StatusNoMatch
 	return result
+}
+
+// volumeForms returns the citation forms to probe, most-faithful first. For a
+// single-volume reporter "Toth 123" and "1 Toth 123" are the same citation --
+// such reports were often cited with a redundant volume 1 even though there is
+// only one volume to cite -- so both are tried. Everything else yields just the
+// citation as detected.
+//
+// The variant is a copy of the citation with the volume flipped rather than a
+// rewritten string, so buildStandardCite and buildCAPCite handle it with their
+// existing reporter_cap and diffvols logic. That also reaches diffvols entries
+// for volume 1, which buildCAPCite skips when the volume is nil.
+func volumeForms(c *citations.UnlinkedCitation, entry *citations.WhitelistEntry) []*citations.UnlinkedCitation {
+	forms := []*citations.UnlinkedCitation{c}
+	if !entry.SingleVol {
+		return forms
+	}
+
+	variant := *c
+	switch {
+	case c.Volume == nil:
+		one := 1
+		variant.Volume = &one
+	case *c.Volume == 1:
+		variant.Volume = nil
+	default:
+		// Volume 2 or higher is a real volume number, not a redundant 1, so
+		// there is nothing equivalent to try.
+		return forms
+	}
+	return append(forms, &variant)
 }
 
 // buildStandardCite constructs "{volume} {reporter_standard} {page}".

--- a/cite-linker/main_test.go
+++ b/cite-linker/main_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/lmullen/legal-modernism/go/citations"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func ptr[T any](v T) *T { return &v }
@@ -14,6 +15,9 @@ func TestLinkCitation(t *testing.T) {
 	usStd := "U.S."
 	qbStd := "Q.B."
 	statStd := "Stat."
+	tothStd := "Toth"
+	croStd := "Cro Eliz"
+	vernStd := "Vern"
 
 	tests := []struct {
 		name         string
@@ -159,6 +163,95 @@ func TestLinkCitation(t *testing.T) {
 			wantLinked:   nil,
 		},
 		{
+			// A single-volume reporter is the same citation with or without a
+			// leading volume 1. CAP normalizes everything to a volume, so a
+			// volume-less detection needs the variant to reach it.
+			name:       "single-volume nil volume links under an explicit volume 1",
+			cite:       citations.UnlinkedCitation{ID: uuid.New(), Volume: nil, ReporterAbbr: "Toth", Page: 123},
+			whitelist:  map[string]*citations.WhitelistEntry{"Toth": {ReporterStandard: &tothStd, SingleVol: true}},
+			capCites:   map[string]int64{"1 Toth 123": 777},
+			wantStatus: citations.StatusLinkedCAP,
+			wantCAPID:  ptr(int64(777)),
+			wantLinked: ptr("1 Toth 123"),
+		},
+		{
+			// The other direction: the English Reports store most nominate
+			// reporters bare, so a citation written "1 Cro Eliz 5" has to drop
+			// the redundant volume to match.
+			name:       "single-volume explicit volume 1 links under the bare form",
+			cite:       citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(1), ReporterAbbr: "Cro Eliz", Page: 5},
+			whitelist:  map[string]*citations.WhitelistEntry{"Cro Eliz": {ReporterStandard: &croStd, UK: true, SingleVol: true}},
+			erCites:    map[string]string{"Cro Eliz 5": "er-cro-5"},
+			wantStatus: citations.StatusLinkedEnglishReports,
+			wantERID:   ptr("er-cro-5"),
+			wantLinked: ptr("Cro Eliz 5"),
+		},
+		{
+			// ...but some English Reports rows do carry the redundant volume
+			// ("1 Vern 1"), which is why the variant is needed in both
+			// directions rather than just one.
+			name:       "single-volume nil volume links to an English Reports cite stored with the redundant 1",
+			cite:       citations.UnlinkedCitation{ID: uuid.New(), Volume: nil, ReporterAbbr: "Vern", Page: 12},
+			whitelist:  map[string]*citations.WhitelistEntry{"Vern": {ReporterStandard: &vernStd, UK: true, SingleVol: true}},
+			erCites:    map[string]string{"1 Vern 12": "er-vern-12"},
+			wantStatus: citations.StatusLinkedEnglishReports,
+			wantERID:   ptr("er-vern-12"),
+			wantLinked: ptr("1 Vern 12"),
+		},
+		{
+			// The alt-spelling probe has to use the variant's volume, not the
+			// detected one, or it builds the wrong string.
+			name:         "alt spelling is probed under the variant volume too",
+			cite:         citations.UnlinkedCitation{ID: uuid.New(), Volume: nil, ReporterAbbr: "Toth", Page: 123},
+			whitelist:    map[string]*citations.WhitelistEntry{"Toth": {ReporterStandard: &tothStd, SingleVol: true}},
+			freelawCites: map[string]int64{"1 Tothill 123": 555},
+			altAbbrs:     map[string][]string{"Toth": {"Tothill"}},
+			wantStatus:   citations.StatusLinkedCAP,
+			wantCAPID:    ptr(int64(555)),
+			wantLinked:   ptr("1 Tothill 123"),
+		},
+		{
+			// The detected form is exhausted across every source before the
+			// variant is tried, so a link that exists today can never be
+			// rewired to a different source.
+			name:       "detected form wins over the volume variant",
+			cite:       citations.UnlinkedCitation{ID: uuid.New(), Volume: nil, ReporterAbbr: "Toth", Page: 123},
+			whitelist:  map[string]*citations.WhitelistEntry{"Toth": {ReporterStandard: &tothStd, SingleVol: true}},
+			capCites:   map[string]int64{"1 Toth 123": 888},
+			codeCites:  map[string]int64{"Toth 123": 999},
+			wantStatus: citations.StatusLinkedCodeReporter,
+			wantCodeID: ptr(int64(999)),
+			wantLinked: ptr("Toth 123"),
+		},
+		{
+			// Volume 2 is a real volume, not a redundant 1, so there is nothing
+			// equivalent to try even on a single-volume reporter.
+			name:       "single-volume reporter with volume 2 has no variant",
+			cite:       citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(2), ReporterAbbr: "Toth", Page: 123},
+			whitelist:  map[string]*citations.WhitelistEntry{"Toth": {ReporterStandard: &tothStd, SingleVol: true}},
+			capCites:   map[string]int64{"Toth 123": 777, "1 Toth 123": 888},
+			wantStatus: citations.StatusNoMatch,
+			wantLinked: nil,
+		},
+		{
+			// For a multi-volume reporter "1 U.S. 10" is a real volume 1 and
+			// means something different from "U.S. 10".
+			name:       "multi-volume reporter does not gain a volume 1",
+			cite:       citations.UnlinkedCitation{ID: uuid.New(), Volume: nil, ReporterAbbr: "U.S.", Page: 10},
+			whitelist:  map[string]*citations.WhitelistEntry{"U.S.": {ReporterStandard: &usStd}},
+			capCites:   map[string]int64{"1 U.S. 10": 111},
+			wantStatus: citations.StatusNoMatch,
+			wantLinked: nil,
+		},
+		{
+			name:       "multi-volume reporter does not drop its volume 1",
+			cite:       citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(1), ReporterAbbr: "U.S.", Page: 10},
+			whitelist:  map[string]*citations.WhitelistEntry{"U.S.": {ReporterStandard: &usStd}},
+			capCites:   map[string]int64{"U.S. 10": 111},
+			wantStatus: citations.StatusNoMatch,
+			wantLinked: nil,
+		},
+		{
 			name:       "not whitelisted is skipped",
 			cite:       citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(5), ReporterAbbr: "Bogus", Page: 10},
 			whitelist:  map[string]*citations.WhitelistEntry{},
@@ -219,5 +312,69 @@ func TestLinkCitation(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestVolumeForms(t *testing.T) {
+	std := "Toth"
+	single := &citations.WhitelistEntry{ReporterStandard: &std, SingleVol: true}
+	multi := &citations.WhitelistEntry{ReporterStandard: &std}
+
+	tests := []struct {
+		name    string
+		volume  *int
+		entry   *citations.WhitelistEntry
+		wantLen int
+		wantVar *int // volume of the variant, when there is one
+	}{
+		{"single-vol nil volume gains a 1", nil, single, 2, ptr(1)},
+		{"single-vol volume 1 loses it", ptr(1), single, 2, nil},
+		{"single-vol volume 2 has no variant", ptr(2), single, 1, nil},
+		{"multi-vol nil volume has no variant", nil, multi, 1, nil},
+		{"multi-vol volume 1 has no variant", ptr(1), multi, 1, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &citations.UnlinkedCitation{ID: uuid.New(), Volume: tt.volume, ReporterAbbr: "Toth", Page: 123}
+			forms := volumeForms(c, tt.entry)
+
+			require.Len(t, forms, tt.wantLen)
+			assert.Same(t, c, forms[0], "the detected citation must be probed first")
+
+			if tt.wantLen == 1 {
+				return
+			}
+			if tt.wantVar == nil {
+				assert.Nil(t, forms[1].Volume)
+			} else if assert.NotNil(t, forms[1].Volume) {
+				assert.Equal(t, *tt.wantVar, *forms[1].Volume)
+			}
+			// The variant is a copy: the original must not be mutated.
+			assert.Equal(t, tt.volume, c.Volume)
+		})
+	}
+}
+
+// TestVolumeVariantRecordsDetectedForm checks that when the variant is what
+// matched, cite_linked reports the string that actually hit while cite_cleaned
+// and cite_normalized still describe the citation as it was detected.
+func TestVolumeVariantRecordsDetectedForm(t *testing.T) {
+	std := "Toth"
+	c := &citations.UnlinkedCitation{ID: uuid.New(), Volume: nil, ReporterAbbr: "Toth", Page: 123}
+	whitelist := map[string]*citations.WhitelistEntry{"Toth": {ReporterStandard: &std, SingleVol: true}}
+
+	got := linkCitation(c, whitelist, map[string]map[int]*citations.DiffVolEntry{},
+		map[string]int64{"1 Toth 123": 777}, nil, nil, nil, nil)
+
+	assert.Equal(t, citations.StatusLinkedCAP, got.Status)
+	if assert.NotNil(t, got.CiteLinked) {
+		assert.Equal(t, "1 Toth 123", *got.CiteLinked, "cite_linked is the form that matched")
+	}
+	if assert.NotNil(t, got.CiteCleaned) {
+		assert.Equal(t, "Toth 123", *got.CiteCleaned, "cite_cleaned stays the detected form")
+	}
+	if assert.NotNil(t, got.CiteNormalized) {
+		assert.Equal(t, "Toth 123", *got.CiteNormalized, "cite_normalized stays the detected form")
 	}
 }

--- a/go/citations/linker.go
+++ b/go/citations/linker.go
@@ -10,6 +10,11 @@ type WhitelistEntry struct {
 	UK               bool
 	Junk             bool
 	CAPDifferent     bool
+	// SingleVol reports whether the reporter has only one volume, in which case
+	// a citation to it means the same thing with or without a leading volume 1.
+	// legalhist.reporters.single_vol is nullable, and an unclassified reporter
+	// is loaded as false so the volume variant stays off it.
+	SingleVol bool
 }
 
 // DiffVolEntry maps an original volume number to the corresponding CAP volume

--- a/go/citations/linker_store_db.go
+++ b/go/citations/linker_store_db.go
@@ -28,7 +28,8 @@ func (s *LinkerDBStore) GetReporterWhitelist(ctx context.Context) (map[string]*W
 		EXISTS (
 			SELECT 1 FROM legalhist.reporters_diffvols d
 			WHERE d.reporter_standard = w.reporter_standard
-		) AS cap_different
+		) AS cap_different,
+		COALESCE(r.single_vol, false) AS single_vol
 	FROM legalhist.whitelist w
 	LEFT JOIN legalhist.reporters r ON r.reporter_standard = w.reporter_standard
 	`
@@ -42,7 +43,7 @@ func (s *LinkerDBStore) GetReporterWhitelist(ctx context.Context) (map[string]*W
 	for rows.Next() {
 		var found string
 		var e WhitelistEntry
-		err := rows.Scan(&found, &e.ReporterStandard, &e.ReporterCAP, &e.Junk, &e.UK, &e.CAPDifferent)
+		err := rows.Scan(&found, &e.ReporterStandard, &e.ReporterCAP, &e.Junk, &e.UK, &e.CAPDifferent, &e.SingleVol)
 		if err != nil {
 			return nil, fmt.Errorf("scanning reporter whitelist row: %w", err)
 		}


### PR DESCRIPTION
Closes #232. Implements the final paragraph of #218.

## The problem

For a reporter with only one volume, `Toth 123` and `1 Toth 123` are the same citation —
single-volume reports were often cited with a redundant volume 1 even though there is only
one volume to cite. The linker matched only whichever form happened to be detected.

The target data is inconsistent in exactly the same way, which is what makes this worth
doing and why the fix has to be **symmetric** rather than a one-way probe:

- `english_reports.cases` stores most nominate reporters bare — `Cro Eliz 1`, `Comb 1`,
  `Carth 1` — but some carry the redundant volume: `1 Vern 1`, `1 Barn KB 1`, `1 El & Bl 1`.
- CAP goes the other way and normalizes everything to a leading volume. Of 5.7M volume-less
  citations to non-UK single-volume reporters, **450** currently link.

## The change

**The linker did not know which reporters are single-volume.** `WhitelistEntry` gains
`SingleVol`, loaded in `GetReporterWhitelist` as `COALESCE(r.single_vol, false)`. The
`COALESCE` matters: `single_vol` is nullable and 442 of 900 reporters are unclassified, so
they are left out rather than guessed at. Against the live whitelist this flags 726 of
10,191 rows (522 UK, 204 non-UK).

**`volumeForms`** returns the citation as detected, followed by its volume variant when the
reporter is single-volume — nil volume gains a 1, volume 1 loses it. Volume 2 or higher is a
real volume number, so it yields no variant.

The variant is a **copy of the citation with the volume flipped**, not a rewritten string,
so `buildStandardCite` and `buildCAPCite` handle it with their existing `reporter_cap` and
diffvols logic. That also closes a small gap: `buildCAPCite` skips diffvols entirely when
the volume is nil, so `diffvols[std][1]` was unreachable for volume-less citations.

`linkCAPThenCode` and `linkEnglishReports` then run their existing cascade over that list.

## Strictly additive

The detected form is exhausted across **every** source before the variant is tried, so this
can turn a `no_match` into a link but **can never rewire an existing one**. There is a test
pinning that: a citation matching the detected form in the Code Reporter *and* the variant
in CAP still links to the Code Reporter.

`cite_linked` records the string that actually matched; `cite_cleaned` and `cite_normalized`
keep describing the citation as detected.

## Expected effect

| path | direction | new links |
|---|---|---|
| CAP / FreeLaw / Code | nil-volume, probed as `1 X N` | **381,944** |
| English Reports | nil-volume, probed as `1 X N` | **71,047** |
| English Reports | volume 1, probed as `X N` | **19,293** |
| CAP / FreeLaw / Code | volume 1, probed as `X N` | 46 |

**≈472,000 new links.** Measured against current `reporter_abbr` values, so the population
shifts once #230 lands — the routing gets more correct, not less.

## Reprocessing

No re-detection needed. `ResetUnlinked` deletes `no_match` and `skipped_*` rows while
preserving `linked_*`, which is exactly the right granularity for an additive change:

```bash
cite-linker --reset && sbatch slurm/cite-linker.sh
./db/maintenance.sh
```

If #230 lands first, fold this into that single full re-detect rather than running the
linker twice.

## Tests

Eight new cases in `TestLinkCitation` covering both directions, the alt-spelling probe under
the variant volume (which catches using the detected volume by mistake), the precedence
guarantee, and negatives for multi-volume reporters in both directions and for volume 2.
Plus `TestVolumeForms` (including that the original citation is not mutated) and
`TestVolumeVariantRecordsDetectedForm`. All pre-existing tests pass unchanged, which is
itself the evidence that the detected-form path is untouched.

`go build`, `go vet`, and `go test ./...` all pass. The modified whitelist query was run
read-only against the live schema.

## Note

Overlaps #230 only in `cite-linker/main_test.go`; expect a small conflict if both are open.

Follow-up worth its own issue: 442 of 900 reporters have `single_vol IS NULL`, excluding
them from this probe and from the single-volume detector alike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)