### PR TITLE
Schema update following migration

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,6 +1,6 @@
 \restrict dbmate
 
--- Dumped from database version 17.9 (Debian 17.9-1.pgdg13+1)
+-- Dumped from database version 17.10 (Debian 17.10-0+deb13u1)
 -- Dumped by pg_dump version 17.10 (Homebrew)
 
 SET statement_timeout = 0;
@@ -2681,4 +2681,5 @@ INSERT INTO sys_admin.migrations_dbmate (version) VALUES
     ('20260610130000'),
     ('20260610140000'),
     ('20260611182350'),
-    ('20260612205502');
+    ('20260612205502'),
+    ('20260727212625');


### PR DESCRIPTION
Regenerated `db/schema.sql` after applying migration `20260727212625`.

- Adds `20260727212625` to the recorded `sys_admin.migrations_dbmate` versions
- Updates the `pg_dump` version comment (17.9 → 17.10)

No code changes; this is the auto-generated schema dump catching up with the applied migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)