### PR TITLE
cite-linker: drop the batch-skip pre-pass, and fix progress and shutdown reporting

### DIFF
--- a/cite-linker/main.go
+++ b/cite-linker/main.go
@@ -15,13 +15,12 @@ import (
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/lmullen/legal-modernism/go/citations"
 	"github.com/lmullen/legal-modernism/go/db"
-	"github.com/schollz/progressbar/v3"
 	flag "github.com/spf13/pflag"
 )
 
-// progressInterval is how often the linking loop logs a progress heartbeat. A
-// full run processes ~62M citations over several hours, so this is frequent
-// enough to extrapolate a finish time without making the log noisy.
+// progressInterval is how often --progress logs a heartbeat. A full run
+// processes ~62M citations over several hours, so this is frequent enough to
+// extrapolate a finish time without making the log noisy.
 const progressInterval = 5 * time.Minute
 
 func main() {
@@ -29,7 +28,7 @@ func main() {
 	var reset bool
 	var batchSize int
 	var workers int
-	flag.BoolVar(&showProgress, "progress", false, "show a progress bar")
+	flag.BoolVar(&showProgress, "progress", false, "log a progress heartbeat (count, elapsed, rows/sec) every 5 minutes")
 	flag.BoolVar(&reset, "reset", false, "before linking, delete every non-linked citation_links row (status no_match, skipped_not_whitelisted, skipped_junk) so they are re-processed; only linked_* rows are kept")
 	flag.IntVar(&batchSize, "batch-size", 5000, "number of citations per insert batch")
 	flag.IntVar(&workers, "workers", 32, "number of concurrent insert workers (each uses one DB connection)")
@@ -153,17 +152,6 @@ func main() {
 	}
 	slog.Info("loaded English Reports citations", "entries", len(erCites))
 
-	var pb *progressbar.ProgressBar
-	if showProgress {
-		// The unprocessed total is not pre-counted (an exact count is itself a
-		// full anti-join), so the bar runs in count/rate mode without an ETA.
-		pb = progressbar.NewOptions64(-1,
-			progressbar.OptionSetWriter(os.Stdout),
-			progressbar.OptionShowCount(),
-			progressbar.OptionShowIts(),
-		)
-	}
-
 	// Bounded pipeline. A single streaming reader (this goroutine, inside
 	// StreamUnprocessedCitations) feeds batches to a fixed pool of insert
 	// workers through a bounded channel. The channel capacity bounds how many
@@ -172,35 +160,18 @@ func main() {
 	// table in memory.
 	batchCh := make(chan []citations.UnlinkedCitation, workers)
 	var wg sync.WaitGroup
-	var pbMu sync.Mutex
 	var processed atomic.Int64
 
-	// Heartbeat. A full run takes hours and results are only logged per batch at
-	// DEBUG, so without this the job is silent from here until it finishes and an
-	// operator can't tell a stalled run from a slow one. Time-based, not
-	// per-batch, so a normal run stays quiet.
-	started := time.Now()
-	heartbeatDone := make(chan struct{})
-	var heartbeatWG sync.WaitGroup
-	heartbeatWG.Add(1)
-	go func() {
-		defer heartbeatWG.Done()
-		ticker := time.NewTicker(progressInterval)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-heartbeatDone:
-				return
-			case <-ticker.C:
-				n := processed.Load()
-				elapsed := time.Since(started)
+	stopHeartbeat := func() {}
+	if showProgress {
+		stopHeartbeat = startProgressHeartbeat(progressInterval, &processed,
+			func(n int64, elapsed time.Duration) {
 				slog.Info("linking progress",
 					"processed", n,
 					"elapsed", elapsed.Round(time.Second).String(),
 					"rows_per_sec", int64(float64(n)/elapsed.Seconds()))
-			}
-		}
-	}()
+			})
+	}
 
 	for i := 0; i < workers; i++ {
 		wg.Add(1)
@@ -232,12 +203,6 @@ func main() {
 					attrs = append(attrs, status, count)
 				}
 				slog.Debug("saved batch", attrs...)
-
-				if pb != nil {
-					pbMu.Lock()
-					pb.Add(len(batch))
-					pbMu.Unlock()
-				}
 			}
 		}()
 	}
@@ -254,8 +219,7 @@ func main() {
 	})
 	close(batchCh)
 	wg.Wait()
-	close(heartbeatDone)
-	heartbeatWG.Wait()
+	stopHeartbeat()
 
 	if streamErr != nil && !errors.Is(streamErr, context.Canceled) {
 		slog.Error("streaming unprocessed citations failed", "processed", processed.Load(), "error", streamErr)
@@ -267,6 +231,38 @@ func main() {
 	// Post-run database maintenance (vacuum/analyze the churned tables and
 	// refresh the chambers dashboard materialized views) is run separately
 	// (make db-maintenance / db/maintenance.sh), not by the linker.
+}
+
+// startProgressHeartbeat calls report every interval with the current count and
+// the time elapsed since the heartbeat started, until the returned stop function
+// is called. This is what --progress does: a full run takes hours and per-batch
+// results are only logged at DEBUG, so otherwise the job is silent from the
+// start of linking until it finishes and an operator can't tell a stalled run
+// from a slow one. Reporting on a timer rather than per batch keeps the output
+// readable in a Slurm log. stop blocks until the heartbeat goroutine has exited,
+// so no report can be emitted after it returns.
+func startProgressHeartbeat(interval time.Duration, processed *atomic.Int64, report func(n int64, elapsed time.Duration)) (stop func()) {
+	started := time.Now()
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				report(processed.Load(), time.Since(started))
+			}
+		}
+	}()
+	return func() {
+		close(done)
+		wg.Wait()
+	}
 }
 
 // linkCitation processes a single citation through the linking pipeline.

--- a/cite-linker/main.go
+++ b/cite-linker/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -22,6 +21,34 @@ import (
 // processes ~62M citations over several hours, so this is frequent enough to
 // extrapolate a finish time without making the log noisy.
 const progressInterval = 5 * time.Minute
+
+// signalExitBase is added to the signal number to form the exit status of a run
+// stopped by a shutdown signal, following the shell convention: 130 for SIGINT,
+// 143 for SIGTERM. An interrupted run must be distinguishable from both a
+// completed one (0) and a genuine failure (1), because it committed real work
+// and should simply be resubmitted.
+const signalExitBase = 128
+
+// stopSignal holds the number of the shutdown signal that cancelled the run, or
+// 0 if none was received. A signal cancels the context, which then surfaces as
+// an error from whichever database call was in flight; consulting this instead
+// of inspecting that error is what lets an interrupt be reported as an
+// interrupt rather than as a failure.
+var stopSignal atomic.Int64
+
+// exitStartupError ends a run that failed before linking began. A shutdown
+// signal during startup cancels the in-flight query, so without the stopSignal
+// check a routine Ctrl-C during the minutes-long lookup-table load would exit 1
+// and log an ERROR, indistinguishable from a real failure.
+func exitStartupError(msg string, err error, attrs ...any) {
+	if sig := stopSignal.Load(); sig != 0 {
+		slog.Warn("interrupted during startup; no citations were linked",
+			append([]any{"step", msg, "signal", syscall.Signal(sig).String()}, attrs...)...)
+		os.Exit(signalExitBase + int(sig))
+	}
+	slog.Error(msg, append([]any{"error", err}, attrs...)...)
+	os.Exit(1)
+}
 
 func main() {
 	var showProgress bool
@@ -52,8 +79,11 @@ func main() {
 	}()
 	go func() {
 		select {
-		case <-quit:
-			slog.Info("quitting because shutdown signal received")
+		case s := <-quit:
+			if sig, ok := s.(syscall.Signal); ok {
+				stopSignal.Store(int64(sig))
+			}
+			slog.Info("quitting because shutdown signal received", "signal", s.String())
 			cancel()
 		case <-ctx.Done():
 		}
@@ -68,8 +98,7 @@ func main() {
 		c.MaxConns = maxConns
 	})
 	if err != nil {
-		slog.Error("could not connect to database", "database", db.Host(), "error", err)
-		os.Exit(1)
+		exitStartupError("could not connect to database", err, "database", db.Host())
 	}
 	defer pool.Close()
 	slog.Info("connected to the database", "database", db.Host())
@@ -84,8 +113,7 @@ func main() {
 		slog.Info("resetting unresolved citation links (no_match, skipped_not_whitelisted, skipped_junk)")
 		deleted, err := store.ResetUnlinked(ctx)
 		if err != nil {
-			slog.Error("reset failed", "deleted", deleted, "error", err)
-			os.Exit(1)
+			exitStartupError("reset failed", err, "deleted", deleted)
 		}
 		slog.Info("reset complete", "deleted", deleted)
 	}
@@ -96,32 +124,28 @@ func main() {
 	slog.Info("loading reporter whitelist")
 	whitelist, err := store.GetReporterWhitelist(ctx)
 	if err != nil {
-		slog.Error("could not load reporter whitelist", "error", err)
-		os.Exit(1)
+		exitStartupError("could not load reporter whitelist", err)
 	}
 	slog.Info("loaded reporter whitelist", "entries", len(whitelist))
 
 	slog.Info("loading diff-vols mapping")
 	diffvols, err := store.GetDiffVols(ctx)
 	if err != nil {
-		slog.Error("could not load diff-vols mapping", "error", err)
-		os.Exit(1)
+		exitStartupError("could not load diff-vols mapping", err)
 	}
 	slog.Info("loaded diff-vols mapping", "reporters", len(diffvols))
 
 	slog.Info("loading CAP citations")
 	capCites, err := store.LoadCAPCitations(ctx)
 	if err != nil {
-		slog.Error("could not load CAP citations", "error", err)
-		os.Exit(1)
+		exitStartupError("could not load CAP citations", err)
 	}
 	slog.Info("loaded CAP citations", "entries", len(capCites))
 
 	slog.Info("loading FreeLaw cite crosswalk")
 	freelawCites, err := store.LoadFreelawCites(ctx)
 	if err != nil {
-		slog.Error("could not load FreeLaw cite crosswalk", "error", err)
-		os.Exit(1)
+		exitStartupError("could not load FreeLaw cite crosswalk", err)
 	}
 	if len(freelawCites) == 0 {
 		slog.Warn("FreeLaw cite crosswalk is empty; the FreeLaw fallback will do nothing — refresh the freelaw.cite_to_cap materialized view")
@@ -131,24 +155,21 @@ func main() {
 	slog.Info("loading reporter alternate abbreviations")
 	altAbbrs, err := store.LoadReporterAltAbbrs(ctx)
 	if err != nil {
-		slog.Error("could not load reporter alternate abbreviations", "error", err)
-		os.Exit(1)
+		exitStartupError("could not load reporter alternate abbreviations", err)
 	}
 	slog.Info("loaded reporter alternate abbreviations", "reporters", len(altAbbrs))
 
 	slog.Info("loading code reporter citations")
 	codeCites, err := store.LoadCodeReporterCitations(ctx)
 	if err != nil {
-		slog.Error("could not load code reporter citations", "error", err)
-		os.Exit(1)
+		exitStartupError("could not load code reporter citations", err)
 	}
 	slog.Info("loaded code reporter citations", "entries", len(codeCites))
 
 	slog.Info("loading English Reports citations")
 	erCites, err := store.LoadEnglishReportsCitations(ctx)
 	if err != nil {
-		slog.Error("could not load English Reports citations", "error", err)
-		os.Exit(1)
+		exitStartupError("could not load English Reports citations", err)
 	}
 	slog.Info("loaded English Reports citations", "entries", len(erCites))
 
@@ -193,6 +214,13 @@ func main() {
 				}
 
 				if err := store.SaveLinkResults(ctx, results); err != nil {
+					if ctx.Err() != nil {
+						// Shutting down. The insert was cancelled in flight, so
+						// this batch is simply not committed and will be picked
+						// up by the next run — not a failure worth an ERROR.
+						slog.Warn("batch not saved because of shutdown", "size", len(results))
+						continue
+					}
 					slog.Error("could not save batch results", "error", err)
 					continue
 				}
@@ -221,7 +249,21 @@ func main() {
 	wg.Wait()
 	stopHeartbeat()
 
-	if streamErr != nil && !errors.Is(streamErr, context.Canceled) {
+	// A shutdown signal cancels ctx, which surfaces as an error from whichever
+	// query was in flight, so this must be checked before streamErr: the run was
+	// interrupted, not broken. The count is a lower bound — a batch whose insert
+	// committed on the server but whose response was never read (because the
+	// context was cancelled first) is reported as unsaved and not counted. That
+	// only ever undercounts, and re-processing is idempotent thanks to
+	// ON CONFLICT (citation_id) DO NOTHING.
+	if sig := stopSignal.Load(); sig != 0 {
+		slog.Warn("interrupted before finishing; committed work is saved, resubmit to resume",
+			"processed_at_least", processed.Load(),
+			"signal", syscall.Signal(sig).String())
+		os.Exit(signalExitBase + int(sig))
+	}
+
+	if streamErr != nil {
 		slog.Error("streaming unprocessed citations failed", "processed", processed.Load(), "error", streamErr)
 		os.Exit(1)
 	}

--- a/cite-linker/main.go
+++ b/cite-linker/main.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"syscall"
+	"time"
 
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/lmullen/legal-modernism/go/citations"
@@ -18,14 +19,17 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
+// progressInterval is how often the linking loop logs a progress heartbeat. A
+// full run processes ~62M citations over several hours, so this is frequent
+// enough to extrapolate a finish time without making the log noisy.
+const progressInterval = 5 * time.Minute
+
 func main() {
 	var showProgress bool
-	var skipUnlisted bool
 	var reset bool
 	var batchSize int
 	var workers int
 	flag.BoolVar(&showProgress, "progress", false, "show a progress bar")
-	flag.BoolVar(&skipUnlisted, "skip-unlisted", false, "batch-mark non-whitelisted citations as skipped before linking")
 	flag.BoolVar(&reset, "reset", false, "before linking, delete every non-linked citation_links row (status no_match, skipped_not_whitelisted, skipped_junk) so they are re-processed; only linked_* rows are kept")
 	flag.IntVar(&batchSize, "batch-size", 5000, "number of citations per insert batch")
 	flag.IntVar(&workers, "workers", 32, "number of concurrent insert workers (each uses one DB connection)")
@@ -85,17 +89,6 @@ func main() {
 			os.Exit(1)
 		}
 		slog.Info("reset complete", "deleted", deleted)
-	}
-
-	// Handle --skip-unlisted: bulk skip, then continue to linking
-	if skipUnlisted {
-		slog.Info("batch-marking non-whitelisted citations as skipped")
-		affected, err := store.BatchSkipNonWhitelisted(ctx)
-		if err != nil {
-			slog.Error("batch skip failed", "error", err)
-			os.Exit(1)
-		}
-		slog.Info("batch skip complete", "rows_affected", affected)
 	}
 
 	slog.Info("processing settings", "batch_size", batchSize, "workers", workers)
@@ -182,6 +175,33 @@ func main() {
 	var pbMu sync.Mutex
 	var processed atomic.Int64
 
+	// Heartbeat. A full run takes hours and results are only logged per batch at
+	// DEBUG, so without this the job is silent from here until it finishes and an
+	// operator can't tell a stalled run from a slow one. Time-based, not
+	// per-batch, so a normal run stays quiet.
+	started := time.Now()
+	heartbeatDone := make(chan struct{})
+	var heartbeatWG sync.WaitGroup
+	heartbeatWG.Add(1)
+	go func() {
+		defer heartbeatWG.Done()
+		ticker := time.NewTicker(progressInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-heartbeatDone:
+				return
+			case <-ticker.C:
+				n := processed.Load()
+				elapsed := time.Since(started)
+				slog.Info("linking progress",
+					"processed", n,
+					"elapsed", elapsed.Round(time.Second).String(),
+					"rows_per_sec", int64(float64(n)/elapsed.Seconds()))
+			}
+		}
+	}()
+
 	for i := 0; i < workers; i++ {
 		wg.Add(1)
 		go func() {
@@ -234,6 +254,8 @@ func main() {
 	})
 	close(batchCh)
 	wg.Wait()
+	close(heartbeatDone)
+	heartbeatWG.Wait()
 
 	if streamErr != nil && !errors.Is(streamErr, context.Canceled) {
 		slog.Error("streaming unprocessed citations failed", "processed", processed.Load(), "error", streamErr)

--- a/cite-linker/main_test.go
+++ b/cite-linker/main_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/lmullen/legal-modernism/go/citations"
@@ -413,4 +416,46 @@ func TestVolumeVariantRecordsDetectedForm(t *testing.T) {
 	if assert.NotNil(t, got.CiteNormalized) {
 		assert.Equal(t, "Toth 123", *got.CiteNormalized, "cite_normalized stays the detected form")
 	}
+}
+
+func TestStartProgressHeartbeat(t *testing.T) {
+	var processed atomic.Int64
+	processed.Store(42)
+
+	var mu sync.Mutex
+	var counts []int64
+	var elapseds []time.Duration
+
+	stop := startProgressHeartbeat(5*time.Millisecond, &processed,
+		func(n int64, elapsed time.Duration) {
+			mu.Lock()
+			defer mu.Unlock()
+			counts = append(counts, n)
+			elapseds = append(elapseds, elapsed)
+		})
+
+	// It reports repeatedly on the timer, not just once.
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(counts) >= 3
+	}, 2*time.Second, time.Millisecond, "heartbeat did not report repeatedly")
+
+	stop()
+
+	mu.Lock()
+	atStop := len(counts)
+	firstCount := counts[0]
+	firstElapsed := elapseds[0]
+	mu.Unlock()
+
+	// It reports the live count and a positive elapsed time.
+	assert.Equal(t, int64(42), firstCount, "heartbeat should report the current processed count")
+	assert.Positive(t, firstElapsed, "heartbeat should report elapsed time since it started")
+
+	// stop() waits for the goroutine to exit, so nothing is reported afterward.
+	time.Sleep(50 * time.Millisecond)
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, atStop, len(counts), "heartbeat kept reporting after stop returned")
 }

--- a/db/migrations/20260728174121_citation-links-status-unprocessed.sql
+++ b/db/migrations/20260728174121_citation-links-status-unprocessed.sql
@@ -1,0 +1,35 @@
+-- migrate:up
+SET ROLE = law_admin;
+
+-- Add an "unprocessed" row to citation_links_status: citations that exist in
+-- citations_unlinked but have no citation_links row yet, i.e. the backlog the
+-- cite-linker still has to work through. Without it the view only describes
+-- citations already processed, so a run in progress looks complete.
+--
+-- The count is computed by subtraction rather than by an anti-join against
+-- citations_unlinked. The two are exactly equivalent here: citation_links has a
+-- primary key on citation_id (so it cannot count a citation twice) and a foreign
+-- key citation_links_citation_id_fkey to citations_unlinked(id) (so every row it
+-- counts is a citation that exists). Subtraction is two counts instead of an
+-- anti-join that, once citation_links is full, builds a multi-gigabyte hash and
+-- spills to disk.
+--
+-- The unprocessed row is always present, showing 0 when linking is complete.
+CREATE OR REPLACE VIEW moml_citations.citation_links_status AS
+SELECT status, count(*) AS n
+FROM moml_citations.citation_links
+GROUP BY status
+UNION ALL
+SELECT 'unprocessed'::text AS status,
+       (SELECT count(*) FROM moml_citations.citations_unlinked)
+     - (SELECT count(*) FROM moml_citations.citation_links) AS n
+ORDER BY n DESC;
+
+-- migrate:down
+SET ROLE = law_admin;
+
+CREATE OR REPLACE VIEW moml_citations.citation_links_status AS
+SELECT status, count(*) AS n
+FROM moml_citations.citation_links
+GROUP BY status
+ORDER BY n DESC;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1427,11 +1427,16 @@ CREATE VIEW moml_citations.citation_links_detail AS
 --
 
 CREATE VIEW moml_citations.citation_links_status AS
- SELECT status,
+ SELECT citation_links.status,
     count(*) AS n
    FROM moml_citations.citation_links
-  GROUP BY status
-  ORDER BY (count(*)) DESC;
+  GROUP BY citation_links.status
+UNION ALL
+ SELECT 'unprocessed'::text AS status,
+    (( SELECT count(*) AS count
+           FROM moml_citations.citations_unlinked) - ( SELECT count(*) AS count
+           FROM moml_citations.citation_links)) AS n
+  ORDER BY 2 DESC;
 
 
 --
@@ -2682,4 +2687,5 @@ INSERT INTO sys_admin.migrations_dbmate (version) VALUES
     ('20260610140000'),
     ('20260611182350'),
     ('20260612205502'),
-    ('20260727212625');
+    ('20260727212625'),
+    ('20260728174121');

--- a/go/citations/linker_store.go
+++ b/go/citations/linker_store.go
@@ -51,8 +51,4 @@ type LinkerStore interface {
 	// linker re-processes them, preserving only linked_* rows. Returns the number
 	// of rows deleted.
 	ResetUnlinked(ctx context.Context) (int64, error)
-
-	// BatchSkipNonWhitelisted marks all non-whitelisted citations as skipped
-	// in a single bulk operation. Returns the number of rows affected.
-	BatchSkipNonWhitelisted(ctx context.Context) (int64, error)
 }

--- a/go/citations/linker_store_db.go
+++ b/go/citations/linker_store_db.go
@@ -331,35 +331,12 @@ func (s *LinkerDBStore) SaveLinkResults(ctx context.Context, results []*LinkResu
 	return nil
 }
 
-func (s *LinkerDBStore) BatchSkipNonWhitelisted(ctx context.Context) (int64, error) {
-	query := `
-	INSERT INTO moml_citations.citation_links (citation_id, status)
-	SELECT cu.id,
-	       CASE
-	         WHEN wl.junk = true THEN 'skipped_junk'
-	         ELSE 'skipped_not_whitelisted'
-	       END
-	FROM moml_citations.citations_unlinked cu
-	LEFT JOIN legalhist.whitelist wl ON cu.reporter_abbr = wl.reporter_found
-	WHERE NOT EXISTS (
-		SELECT 1 FROM moml_citations.citation_links cl WHERE cl.citation_id = cu.id
-	)
-	AND (wl.reporter_found IS NULL OR wl.junk = true)
-	ON CONFLICT (citation_id) DO NOTHING
-	`
-	tag, err := s.DB.Exec(ctx, query)
-	if err != nil {
-		return 0, fmt.Errorf("batch skipping non-whitelisted citations: %w", err)
-	}
-	return tag.RowsAffected(), nil
-}
-
 // ResetUnlinked deletes every citation_links row that was not resolved to a case
 // (status no_match, skipped_not_whitelisted, or skipped_junk) so the linker
 // re-processes them on the next run; only linked_* rows are preserved. Deleting
-// both skip statuses lets a re-run with --skip-unlisted re-derive them from the
-// current whitelist, so a reporter later corrected from junk to legit is no
-// longer stuck as skipped_junk. The delete runs as a single statement — one
+// both skip statuses lets a re-run re-derive them from the current whitelist, so
+// a reporter later corrected from junk to legit is no longer stuck as
+// skipped_junk. The delete runs as a single statement — one
 // all-or-nothing transaction — and returns the number of rows deleted.
 func (s *LinkerDBStore) ResetUnlinked(ctx context.Context) (int64, error) {
 	query := `

--- a/go/citations/linker_store_db_integration_test.go
+++ b/go/citations/linker_store_db_integration_test.go
@@ -2,7 +2,9 @@ package citations
 
 import (
 	"context"
+	"errors"
 	"os"
+	"slices"
 	"testing"
 
 	"github.com/google/uuid"
@@ -117,6 +119,63 @@ func TestStreamUnprocessedCitationsIntegration(t *testing.T) {
 
 	// Batching: 7 rows at batch size 3 => batches of 3, 3, 1.
 	assert.Equal(t, []int{3, 3, 1}, batchSizes)
+}
+
+// errStopStream aborts a stream from inside the callback, standing in for a
+// killed job.
+var errStopStream = errors.New("stop stream")
+
+// TestStreamUnprocessedCitationsResumesIntegration covers the property the
+// linker depends on for resumability: because results are committed per batch,
+// a run killed partway through (a Slurm wall-time timeout) can simply be
+// resubmitted, and the anti-join delivers only the citations that were never
+// saved. This is what replaced the old batch-skip pre-pass, whose single giant
+// transaction committed nothing when killed.
+func TestStreamUnprocessedCitationsResumesIntegration(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	all := make([]uuid.UUID, 10)
+	for i := range all {
+		all[i] = uuid.New()
+		v := i
+		seedUnlinked(t, s, all[i], &v)
+	}
+
+	// First run: stream, but only save the first batch before "dying".
+	var saved []uuid.UUID
+	err := s.StreamUnprocessedCitations(ctx, 4, func(batch []UnlinkedCitation) error {
+		results := make([]*LinkResult, len(batch))
+		for i := range batch {
+			results[i] = &LinkResult{CitationID: batch[i].ID, Status: StatusSkippedNotWhitelisted}
+			saved = append(saved, batch[i].ID)
+		}
+		if err := s.SaveLinkResults(ctx, results); err != nil {
+			return err
+		}
+		return errStopStream // simulate the job being killed after one batch
+	})
+	require.ErrorIs(t, err, errStopStream)
+	require.Len(t, saved, 4, "expected exactly one batch of 4 to be committed")
+
+	// Second run: the resubmitted job sees only the 6 that were never saved.
+	var got []uuid.UUID
+	err = s.StreamUnprocessedCitations(ctx, 4, func(batch []UnlinkedCitation) error {
+		for _, c := range batch {
+			got = append(got, c.ID)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	want := make([]uuid.UUID, 0, 6)
+	for _, id := range all {
+		if !slices.Contains(saved, id) {
+			want = append(want, id)
+		}
+	}
+	assert.Len(t, got, 6)
+	assert.ElementsMatch(t, want, got, "resumed run must skip already-saved citations")
 }
 
 func TestSaveLinkResultsIntegration(t *testing.T) {

--- a/slurm/cite-linker.sh
+++ b/slurm/cite-linker.sh
@@ -8,7 +8,7 @@
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=24
-#SBATCH --time=02:00:00
+#SBATCH --time=06:00:00
 #SBATCH --mem=12GB
 #SBATCH --partition=normal
 #SBATCH --mail-user lmullen@gmu.edu
@@ -18,13 +18,16 @@
 
 ## Run the program
 
-# Routine run: link any not-yet-processed citations.
-# ~/legal-modernism/bin/cite-linker --skip-unlisted --batch-size=8000 --workers=32
+# Routine run: link any not-yet-processed citations. Safe to resubmit — results
+# are committed per batch (8,000 rows), so a job that hits the wall time can just
+# be resubmitted and it picks up exactly where it left off. Check `squeue` first;
+# two concurrent linkers are correct but double the read work.
+~/legal-modernism/bin/cite-linker --batch-size=8000 --workers=32
 
-# One-time reset run (FreeLaw rollout / after whitelist corrections): comment out
-# the line above and use the line below instead. --reset deletes every non-linked
-# row (no_match, skipped_not_whitelisted, skipped_junk) so they are re-linked
-# against the FreeLaw crosswalk; only linked_* rows are kept. Re-comment it
-# afterward — leaving --reset in would wipe and re-do those rows on every
-# subsequent run. If the job is interrupted, resume WITHOUT --reset.
-~/legal-modernism/bin/cite-linker --reset --skip-unlisted --batch-size=8000 --workers=32
+# One-time reset run (after whitelist corrections or a new linking tier): comment
+# out the line above and use the line below instead. --reset deletes every
+# non-linked row (no_match, skipped_not_whitelisted, skipped_junk) so they are
+# re-linked; only linked_* rows are kept. Re-comment it afterward — leaving
+# --reset live would wipe and re-do those rows on every subsequent run, including
+# on a resubmit after a timeout, throwing away all partial progress.
+# ~/legal-modernism/bin/cite-linker --reset --batch-size=8000 --workers=32

--- a/slurm/cite-linker.sh
+++ b/slurm/cite-linker.sh
@@ -21,8 +21,9 @@
 # Routine run: link any not-yet-processed citations. Safe to resubmit — results
 # are committed per batch (8,000 rows), so a job that hits the wall time can just
 # be resubmitted and it picks up exactly where it left off. Check `squeue` first;
-# two concurrent linkers are correct but double the read work.
-~/legal-modernism/bin/cite-linker --batch-size=8000 --workers=32
+# two concurrent linkers are correct but double the read work. --progress logs a
+# heartbeat every 5 minutes so the job's rate is visible in the .out file.
+~/legal-modernism/bin/cite-linker --progress --batch-size=8000 --workers=32
 
 # One-time reset run (after whitelist corrections or a new linking tier): comment
 # out the line above and use the line below instead. --reset deletes every
@@ -30,4 +31,4 @@
 # re-linked; only linked_* rows are kept. Re-comment it afterward — leaving
 # --reset live would wipe and re-do those rows on every subsequent run, including
 # on a resubmit after a timeout, throwing away all partial progress.
-# ~/legal-modernism/bin/cite-linker --reset --batch-size=8000 --workers=32
+# ~/legal-modernism/bin/cite-linker --reset --progress --batch-size=8000 --workers=32


### PR DESCRIPTION
Four related changes to how the citation linker does its work and reports on it. The thread connecting them: a full run takes hours over 62.4M citations, and almost everything about observing and resuming one was either misleading or missing.

Closes #237

---

## 1. Remove the batch-skip pre-pass (the issue)

`--skip-unlisted` ran one giant `INSERT ... SELECT` at the start of a run, marking every non-whitelisted or junk citation as skipped before the normal loop began. It committed nothing until it finished, so a Slurm timeout threw the whole thing away — which is what happened on the last run, leaving `citation_links` empty against 62.4M rows in `citations_unlinked`.

**Why the deletion is safe.** The per-citation path already produces the identical result: `linkCitation` does the same whitelist lookup in memory and writes only `(citation_id, status)`, leaving the same six columns NULL. `legalhist.whitelist.reporter_found` is the PK (no fan-out) and `junk` is `NOT NULL`, so the SQL had no three-valued edge case the Go path lacks.

**Why it isn't a throughput regression.** `StreamUnprocessedCitations` plans as a hash anti join over a seq scan (verified with EXPLAIN). A `TABLESAMPLE` measurement puts 31.1% of citations in the skip categories, so the pre-pass bought that reduction in streamed rows by paying for a *second* full pass over the 6.2 GB heap.

| | with `--skip-unlisted` | without |
|---|---|---|
| full passes over `citations_unlinked` | 2 | **1** |
| rows written to `citation_links` | 62.4M | 62.4M (identical) |
| rows over the wire | ~43M | ~62.4M (+~3 GB) |
| largest single transaction | ~19.4M rows | **8,000 rows** |

Net server work goes down. `--batch-size`, `--workers`, and `--mem=12GB` are unchanged; the reader was never the bottleneck.

> ⚠️ **For review:** `LinkerStore` is never used as a type anywhere in the repo — no `var _ LinkerStore = (*LinkerDBStore)(nil)` assertion — so the compiler would not catch a half-done removal. Verified by grep that `BatchSkipNonWhitelisted` has zero remaining references.

## 2. Replace the progress bar with a `--progress` heartbeat

The issue's "shows no progress" complaint was only half-fixed by the deletion: per-batch results are logged at `slog.Debug` behind `LAW_DEBUG`, so a 6h job was silent between "loaded English Reports citations" and "done linking citations".

The `progressbar` bar that `--progress` used to drive wrote `\r`-updated output to stdout, which is unusable in a Slurm `.out` file — the only place a multi-hour run is actually observed — and it took a mutex on the hot path in every worker. It's deleted. `--progress` now gates a heartbeat that logs count, elapsed, and rows/sec on a timer, and it is passed in the Slurm script, which the bar could never be.

`schollz/progressbar` stays in `go.mod`; `cite-detector-moml`, `freelaw-import`, and `scripts/sidecorpus-import` still use it.

## 3. Report an interrupted run as interrupted

Testing SIGINT and SIGTERM against a throwaway database showed the linker shuts down *safely* — no panic, no hang, drain under 50ms, committed work durable — but misreported what happened afterwards.

| Scenario | Before | After |
|---|---|---|
| SIGINT during linking | exit 0, `"done linking citations"` | exit **130**, `"interrupted before finishing"` |
| SIGTERM (Slurm wall-time expiry) | exit 0, `"done linking citations"` | exit **143**, same message |
| SIGINT during lookup-table load | exit **1** + ERROR | exit **130** + WARN |
| Uninterrupted run | exit 0 | exit 0, unchanged |
| Bad password / missing table | exit 1 + ERROR | exit 1 + ERROR, unchanged |
| ERROR lines on a clean Ctrl-C | 8 (= worker count) | **0** |

- **An interrupted run looked like a completed one.** Slurm sends SIGTERM on wall-time expiry, so a job that ran out of time logged "done linking citations" and exited 0. Now it exits `128+signum`, distinguishable from both success and failure.
- **The exit code contradicted itself depending on when the signal landed** — 0 during linking, 1 during the load phase. In production that load is minutes of CAP citations and crosswalks, so a routine Ctrl-C there produced a Slurm FAIL. The nine startup exit sites now go through one `exitStartupError` helper that separates interrupt from failure.
- **Per-worker save errors during shutdown are demoted to WARN.** They aren't failures — the batch is uncommitted and gets re-processed — but at `--workers=32` they produced 32 ERROR lines on every clean Ctrl-C.
- **The final count is reported as `processed_at_least` on an interrupted run.** A batch whose insert commits server-side but whose response is never read (context cancelled first) is counted as unsaved: measured 340,000 rows committed against 320,000 reported. It only ever undercounts, and re-processing is idempotent via `ON CONFLICT DO NOTHING`, so naming it a lower bound is the honest fix.

Checking the recorded signal rather than unwrapping the context error also removed a latent bug: the old `errors.Is(streamErr, context.Canceled)` matched only because the reader happened to be blocked on the channel send. Had it been inside `rows.Next()`, pgx's error might not have unwrapped and the run would have exited 1.

## 4. Add an unprocessed count to `citation_links_status`

The view aggregated only citations that already had a `citation_links` row, so it described work done and was silent about work remaining — mid-run it looked complete. It now emits an `unprocessed` row, always present, showing 0 when linking is finished rather than disappearing.

Computed as `count(citations_unlinked) - count(citation_links)` rather than an anti-join. The two are exactly equivalent here: `citation_links` has a PK on `citation_id` so it cannot count a citation twice, and an FK to `citations_unlinked(id)` so every row it counts is a citation that exists. Subtraction is two counts (~2.5s at current scale) instead of an anti-join that, once `citation_links` is full, builds a multi-gigabyte hash and spills.

Not used by chambers' Go code — the dashboard reads the `linking_dashboard_summary` matview — so nothing breaks from the added row.

## Slurm script

The routine invocation is now the live line. With per-batch commits as the whole resumability story, resubmitting after a timeout with `--reset` live would delete everything the killed job committed, relocating the same human-error hazard the issue names. The reset variant is commented out with a warning.

---

## Verification

`gofmt`, `go vet`, `go build ./...`, `go test ./...` clean; CI green.

**Unit tests (run in CI).** `TestStartProgressHeartbeat` asserts the heartbeat reports repeatedly on the timer, reports the live count and a positive elapsed time, and emits nothing after `stop` returns — a mutation making `stop` a no-op fails it.

**DB integration tests** (gated on `LAW_TEST_DBSTR`, skipped in CI) run against a throwaway Postgres 17 — all 4 pass, including a new `TestStreamUnprocessedCitationsResumesIntegration` covering the resume property: save one batch, stream again, assert only the unsaved citations come back.

**Shutdown behaviour** was tested end-to-end by loading `db/schema.sql` into a throwaway Postgres 17, seeding 2M citations, and signalling the real binary at different points — every row of the table in §3 is a measured result, not an expectation.

**The migration** was applied to a throwaway database with matching constraints and `law_admin` ownership: the view's unprocessed count equals the literal anti-join count, it reports 0 rather than vanishing when everything is processed, `migrate:up` re-runs cleanly, and `migrate:down` restores the previous definition exactly.

Not verified: an end-to-end run against the production database, which needs write access via `LAW_DBSTR`.

## Follow-ups worth filing

- **Partial reset.** The issue's third bullet is now workable — `DELETE ... WHERE status = 'skipped_junk'` plus a re-run without `--reset` picks up exactly those rows — but only via hand-written SQL. A `--reset-status=` flag would remove that.
- **Routine-run cost once `citation_links` is full.** With 62.4M rows linked, the hash anti join builds a ~2–3 GB hash against `work_mem = 256MB` and spills, so even a run with nothing to do rescans the table.
- **Possibly dead index.** `citation_links_cite_normalized_idx` shows `idx_scan = 8` lifetime versus 328M for the PK, and is one of three btrees maintained per inserted row. Two views reference the *column*, which is not the same as using the index. Needs verification and its own migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)