### PR TITLE
cite-linker: log when linking starts, 1m heartbeat, and --lock-timeout

### DIFF
--- a/cite-linker/main.go
+++ b/cite-linker/main.go
@@ -194,6 +194,15 @@ func main() {
 			})
 	}
 
+	// Mark the transition out of the loading phase. Without this the log goes
+	// quiet after the last lookup table is loaded and stays quiet until the first
+	// heartbeat, so there is no way to tell that linking has actually begun.
+	startAttrs := []any{"workers", workers, "batch_size", batchSize}
+	if showProgress {
+		startAttrs = append(startAttrs, "progress_every", progressInterval.String())
+	}
+	slog.Info("starting to link citations", startAttrs...)
+
 	for i := 0; i < workers; i++ {
 		wg.Add(1)
 		go func() {

--- a/cite-linker/main.go
+++ b/cite-linker/main.go
@@ -9,18 +9,12 @@ import (
 	"sync"
 	"sync/atomic"
 	"syscall"
-	"time"
 
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/lmullen/legal-modernism/go/citations"
 	"github.com/lmullen/legal-modernism/go/db"
 	flag "github.com/spf13/pflag"
 )
-
-// progressInterval is how often --progress logs a heartbeat. A full run
-// processes ~62M citations over several hours, so this is frequent enough to
-// extrapolate a finish time without making the log noisy.
-const progressInterval = 5 * time.Minute
 
 // signalExitBase is added to the signal number to form the exit status of a run
 // stopped by a shutdown signal, following the shell convention: 130 for SIGINT,
@@ -51,11 +45,9 @@ func exitStartupError(msg string, err error, attrs ...any) {
 }
 
 func main() {
-	var showProgress bool
 	var reset bool
 	var batchSize int
 	var workers int
-	flag.BoolVar(&showProgress, "progress", false, "log a progress heartbeat (count, elapsed, rows/sec) every 5 minutes")
 	flag.BoolVar(&reset, "reset", false, "before linking, delete every non-linked citation_links row (status no_match, skipped_not_whitelisted, skipped_junk) so they are re-processed; only linked_* rows are kept")
 	flag.IntVar(&batchSize, "batch-size", 5000, "number of citations per insert batch")
 	flag.IntVar(&workers, "workers", 32, "number of concurrent insert workers (each uses one DB connection)")
@@ -183,25 +175,10 @@ func main() {
 	var wg sync.WaitGroup
 	var processed atomic.Int64
 
-	stopHeartbeat := func() {}
-	if showProgress {
-		stopHeartbeat = startProgressHeartbeat(progressInterval, &processed,
-			func(n int64, elapsed time.Duration) {
-				slog.Info("linking progress",
-					"processed", n,
-					"elapsed", elapsed.Round(time.Second).String(),
-					"rows_per_sec", int64(float64(n)/elapsed.Seconds()))
-			})
-	}
-
 	// Mark the transition out of the loading phase. Without this the log goes
-	// quiet after the last lookup table is loaded and stays quiet until the first
-	// heartbeat, so there is no way to tell that linking has actually begun.
-	startAttrs := []any{"workers", workers, "batch_size", batchSize}
-	if showProgress {
-		startAttrs = append(startAttrs, "progress_every", progressInterval.String())
-	}
-	slog.Info("starting to link citations", startAttrs...)
+	// quiet after the last lookup table is loaded, so there is no way to tell
+	// that linking has actually begun.
+	slog.Info("starting to link citations", "workers", workers, "batch_size", batchSize)
 
 	for i := 0; i < workers; i++ {
 		wg.Add(1)
@@ -256,7 +233,6 @@ func main() {
 	})
 	close(batchCh)
 	wg.Wait()
-	stopHeartbeat()
 
 	// A shutdown signal cancels ctx, which surfaces as an error from whichever
 	// query was in flight, so this must be checked before streamErr: the run was
@@ -282,38 +258,6 @@ func main() {
 	// Post-run database maintenance (vacuum/analyze the churned tables and
 	// refresh the chambers dashboard materialized views) is run separately
 	// (make db-maintenance / db/maintenance.sh), not by the linker.
-}
-
-// startProgressHeartbeat calls report every interval with the current count and
-// the time elapsed since the heartbeat started, until the returned stop function
-// is called. This is what --progress does: a full run takes hours and per-batch
-// results are only logged at DEBUG, so otherwise the job is silent from the
-// start of linking until it finishes and an operator can't tell a stalled run
-// from a slow one. Reporting on a timer rather than per batch keeps the output
-// readable in a Slurm log. stop blocks until the heartbeat goroutine has exited,
-// so no report can be emitted after it returns.
-func startProgressHeartbeat(interval time.Duration, processed *atomic.Int64, report func(n int64, elapsed time.Duration)) (stop func()) {
-	started := time.Now()
-	done := make(chan struct{})
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		ticker := time.NewTicker(interval)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-done:
-				return
-			case <-ticker.C:
-				report(processed.Load(), time.Since(started))
-			}
-		}
-	}()
-	return func() {
-		close(done)
-		wg.Wait()
-	}
 }
 
 // linkCitation processes a single citation through the linking pipeline.

--- a/cite-linker/main.go
+++ b/cite-linker/main.go
@@ -6,15 +6,23 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"syscall"
+	"time"
 
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/lmullen/legal-modernism/go/citations"
 	"github.com/lmullen/legal-modernism/go/db"
 	flag "github.com/spf13/pflag"
 )
+
+// progressInterval is how often the linking loop logs a progress heartbeat. A
+// frozen count across consecutive lines is the signal that the run is blocked;
+// one minute is frequent enough to notice that within a Slurm job without
+// making the log unreadable.
+const progressInterval = 1 * time.Minute
 
 // signalExitBase is added to the signal number to form the exit status of a run
 // stopped by a shutdown signal, following the shell convention: 130 for SIGINT,
@@ -48,9 +56,11 @@ func main() {
 	var reset bool
 	var batchSize int
 	var workers int
+	var lockTimeout time.Duration
 	flag.BoolVar(&reset, "reset", false, "before linking, delete every non-linked citation_links row (status no_match, skipped_not_whitelisted, skipped_junk) so they are re-processed; only linked_* rows are kept")
 	flag.IntVar(&batchSize, "batch-size", 5000, "number of citations per insert batch")
 	flag.IntVar(&workers, "workers", 32, "number of concurrent insert workers (each uses one DB connection)")
+	flag.DurationVar(&lockTimeout, "lock-timeout", time.Minute, "give up on a statement that waits this long for a database lock, instead of blocking forever behind an uncommitted transaction; 0 disables")
 	flag.Parse()
 
 	if batchSize < 1 {
@@ -88,6 +98,15 @@ func main() {
 	maxConns := int32(workers + 2)
 	pool, err := db.ConnectPool(ctx, func(c *pgxpool.Config) {
 		c.MaxConns = maxConns
+		// Without lock_timeout a batch that collides with an uncommitted
+		// transaction — a psql or GUI session left mid-transaction on
+		// citation_links — waits forever, and every worker piles up behind it
+		// until the whole run is wedged with no error to show for it. Setting it
+		// as a connection runtime parameter covers every statement on every
+		// pooled connection, including the streaming read.
+		if lockTimeout > 0 {
+			c.ConnConfig.RuntimeParams["lock_timeout"] = strconv.FormatInt(lockTimeout.Milliseconds(), 10)
+		}
 	})
 	if err != nil {
 		exitStartupError("could not connect to database", err, "database", db.Host())
@@ -174,11 +193,23 @@ func main() {
 	batchCh := make(chan []citations.UnlinkedCitation, workers)
 	var wg sync.WaitGroup
 	var processed atomic.Int64
+	var failedBatches atomic.Int64
+	var failedRows atomic.Int64
 
 	// Mark the transition out of the loading phase. Without this the log goes
 	// quiet after the last lookup table is loaded, so there is no way to tell
 	// that linking has actually begun.
-	slog.Info("starting to link citations", "workers", workers, "batch_size", batchSize)
+	slog.Info("starting to link citations",
+		"workers", workers, "batch_size", batchSize,
+		"lock_timeout", lockTimeout.String(), "progress_every", progressInterval.String())
+
+	stopHeartbeat := startProgressHeartbeat(progressInterval, &processed,
+		func(n int64, elapsed time.Duration) {
+			slog.Info("linking progress",
+				"processed", n,
+				"elapsed", elapsed.Round(time.Second).String(),
+				"rows_per_sec", int64(float64(n)/elapsed.Seconds()))
+		})
 
 	for i := 0; i < workers; i++ {
 		wg.Add(1)
@@ -207,7 +238,9 @@ func main() {
 						slog.Warn("batch not saved because of shutdown", "size", len(results))
 						continue
 					}
-					slog.Error("could not save batch results", "error", err)
+					failedBatches.Add(1)
+					failedRows.Add(int64(len(results)))
+					slog.Error("could not save batch results", "size", len(results), "error", err)
 					continue
 				}
 
@@ -233,6 +266,7 @@ func main() {
 	})
 	close(batchCh)
 	wg.Wait()
+	stopHeartbeat()
 
 	// A shutdown signal cancels ctx, which surfaces as an error from whichever
 	// query was in flight, so this must be checked before streamErr: the run was
@@ -253,11 +287,53 @@ func main() {
 		os.Exit(1)
 	}
 
+	// A batch that could not be saved is left unprocessed rather than lost, but
+	// the run must not report success: with --lock-timeout set, a blocking
+	// transaction now turns an indefinite hang into dropped batches, and
+	// swallowing that would trade a visible stall for a silent partial run.
+	if n := failedBatches.Load(); n > 0 {
+		slog.Error("finished with unsaved batches; re-run to pick them up",
+			"processed", processed.Load(),
+			"failed_batches", n,
+			"failed_rows", failedRows.Load())
+		os.Exit(1)
+	}
+
 	slog.Info("done linking citations", "processed", processed.Load())
 
 	// Post-run database maintenance (vacuum/analyze the churned tables and
 	// refresh the chambers dashboard materialized views) is run separately
 	// (make db-maintenance / db/maintenance.sh), not by the linker.
+}
+
+// startProgressHeartbeat calls report every interval with the current count and
+// the time elapsed since the heartbeat started, until the returned stop function
+// is called. Reporting on a timer rather than per batch keeps the output
+// readable in a Slurm log, and a count that does not move between consecutive
+// reports is what makes a blocked run visible. stop blocks until the heartbeat
+// goroutine has exited, so no report can be emitted after it returns.
+func startProgressHeartbeat(interval time.Duration, processed *atomic.Int64, report func(n int64, elapsed time.Duration)) (stop func()) {
+	started := time.Now()
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				report(processed.Load(), time.Since(started))
+			}
+		}
+	}()
+	return func() {
+		close(done)
+		wg.Wait()
+	}
 }
 
 // linkCitation processes a single citation through the linking pipeline.

--- a/cite-linker/main_test.go
+++ b/cite-linker/main_test.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"sync"
-	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/lmullen/legal-modernism/go/citations"
@@ -416,46 +413,4 @@ func TestVolumeVariantRecordsDetectedForm(t *testing.T) {
 	if assert.NotNil(t, got.CiteNormalized) {
 		assert.Equal(t, "Toth 123", *got.CiteNormalized, "cite_normalized stays the detected form")
 	}
-}
-
-func TestStartProgressHeartbeat(t *testing.T) {
-	var processed atomic.Int64
-	processed.Store(42)
-
-	var mu sync.Mutex
-	var counts []int64
-	var elapseds []time.Duration
-
-	stop := startProgressHeartbeat(5*time.Millisecond, &processed,
-		func(n int64, elapsed time.Duration) {
-			mu.Lock()
-			defer mu.Unlock()
-			counts = append(counts, n)
-			elapseds = append(elapseds, elapsed)
-		})
-
-	// It reports repeatedly on the timer, not just once.
-	require.Eventually(t, func() bool {
-		mu.Lock()
-		defer mu.Unlock()
-		return len(counts) >= 3
-	}, 2*time.Second, time.Millisecond, "heartbeat did not report repeatedly")
-
-	stop()
-
-	mu.Lock()
-	atStop := len(counts)
-	firstCount := counts[0]
-	firstElapsed := elapseds[0]
-	mu.Unlock()
-
-	// It reports the live count and a positive elapsed time.
-	assert.Equal(t, int64(42), firstCount, "heartbeat should report the current processed count")
-	assert.Positive(t, firstElapsed, "heartbeat should report elapsed time since it started")
-
-	// stop() waits for the goroutine to exit, so nothing is reported afterward.
-	time.Sleep(50 * time.Millisecond)
-	mu.Lock()
-	defer mu.Unlock()
-	assert.Equal(t, atStop, len(counts), "heartbeat kept reporting after stop returned")
 }

--- a/cite-linker/main_test.go
+++ b/cite-linker/main_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/lmullen/legal-modernism/go/citations"
@@ -413,4 +416,46 @@ func TestVolumeVariantRecordsDetectedForm(t *testing.T) {
 	if assert.NotNil(t, got.CiteNormalized) {
 		assert.Equal(t, "Toth 123", *got.CiteNormalized, "cite_normalized stays the detected form")
 	}
+}
+
+func TestStartProgressHeartbeat(t *testing.T) {
+	var processed atomic.Int64
+	processed.Store(42)
+
+	var mu sync.Mutex
+	var counts []int64
+	var elapseds []time.Duration
+
+	stop := startProgressHeartbeat(5*time.Millisecond, &processed,
+		func(n int64, elapsed time.Duration) {
+			mu.Lock()
+			defer mu.Unlock()
+			counts = append(counts, n)
+			elapseds = append(elapseds, elapsed)
+		})
+
+	// It reports repeatedly on the timer, not just once.
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(counts) >= 3
+	}, 2*time.Second, time.Millisecond, "heartbeat did not report repeatedly")
+
+	stop()
+
+	mu.Lock()
+	atStop := len(counts)
+	firstCount := counts[0]
+	firstElapsed := elapseds[0]
+	mu.Unlock()
+
+	// It reports the live count and a positive elapsed time.
+	assert.Equal(t, int64(42), firstCount, "heartbeat should report the current processed count")
+	assert.Positive(t, firstElapsed, "heartbeat should report elapsed time since it started")
+
+	// stop() waits for the goroutine to exit, so nothing is reported afterward.
+	time.Sleep(50 * time.Millisecond)
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, atStop, len(counts), "heartbeat kept reporting after stop returned")
 }

--- a/slurm/cite-linker.sh
+++ b/slurm/cite-linker.sh
@@ -21,9 +21,8 @@
 # Routine run: link any not-yet-processed citations. Safe to resubmit — results
 # are committed per batch (8,000 rows), so a job that hits the wall time can just
 # be resubmitted and it picks up exactly where it left off. Check `squeue` first;
-# two concurrent linkers are correct but double the read work. --progress logs a
-# heartbeat every 5 minutes so the job's rate is visible in the .out file.
-~/legal-modernism/bin/cite-linker --progress --batch-size=8000 --workers=32
+# two concurrent linkers are correct but double the read work.
+~/legal-modernism/bin/cite-linker --batch-size=8000 --workers=32
 
 # One-time reset run (after whitelist corrections or a new linking tier): comment
 # out the line above and use the line below instead. --reset deletes every
@@ -31,4 +30,4 @@
 # re-linked; only linked_* rows are kept. Re-comment it afterward — leaving
 # --reset live would wipe and re-do those rows on every subsequent run, including
 # on a resubmit after a timeout, throwing away all partial progress.
-# ~/legal-modernism/bin/cite-linker --reset --progress --batch-size=8000 --workers=32
+# ~/legal-modernism/bin/cite-linker --reset --batch-size=8000 --workers=32

--- a/slurm/cite-linker.sh
+++ b/slurm/cite-linker.sh
@@ -21,8 +21,11 @@
 # Routine run: link any not-yet-processed citations. Safe to resubmit — results
 # are committed per batch (8,000 rows), so a job that hits the wall time can just
 # be resubmitted and it picks up exactly where it left off. Check `squeue` first;
-# two concurrent linkers are correct but double the read work.
-~/legal-modernism/bin/cite-linker --batch-size=8000 --workers=32
+# two concurrent linkers are correct but double the read work. --lock-timeout
+# stops the run wedging behind an uncommitted transaction on citation_links (a
+# psql or GUI session left mid-transaction); it exits non-zero naming the
+# dropped batches instead of hanging until the wall time runs out.
+~/legal-modernism/bin/cite-linker --batch-size=8000 --workers=32 --lock-timeout=1m
 
 # One-time reset run (after whitelist corrections or a new linking tier): comment
 # out the line above and use the line below instead. --reset deletes every
@@ -30,4 +33,4 @@
 # re-linked; only linked_* rows are kept. Re-comment it afterward — leaving
 # --reset live would wipe and re-do those rows on every subsequent run, including
 # on a resubmit after a timeout, throwing away all partial progress.
-# ~/legal-modernism/bin/cite-linker --reset --batch-size=8000 --workers=32
+# ~/legal-modernism/bin/cite-linker --reset --batch-size=8000 --workers=32 --lock-timeout=1m


### PR DESCRIPTION
Three changes to make a wedged run visible and self-limiting. Prompted by a live run that sat frozen for 25 minutes behind an idle GUI session with an uncommitted transaction on `citation_links`.

## Log when linking starts

After the last lookup table loads the log went quiet, so the tail of the loading phase and a stall looked identical.

```json
{"msg":"starting to link citations","workers":32,"batch_size":8000,"lock_timeout":"1m0s","progress_every":"1m0s"}
```

## Heartbeat at 1 minute, no longer behind a flag

The heartbeat is now unconditional and ticks every minute instead of five. A frozen `processed` across consecutive lines is what makes a blocked run visible, and that only works if the lines are frequent enough to notice and are always present — a flag that has to be remembered is a flag that will be missing on the run that needs it. `--progress` is gone.

## `--lock-timeout` (default `1m`)

Set as a connection runtime parameter, so it covers every statement on every pooled connection including the streaming read. Without it, a batch colliding with an uncommitted transaction waits forever and all 32 workers pile up behind it with no error to show for it.

A lock timeout leaves the batch *unprocessed* rather than lost — `ON CONFLICT (citation_id) DO NOTHING` makes re-processing idempotent — but the run must not then report success. Failed batches are counted and the run exits 1 naming them, so converting an indefinite hang into dropped batches does not also convert a visible stall into a silent partial run.

## Verification

Reproduced the exact failure against a throwaway Postgres 17 loaded from `db/schema.sql`, holding a deliberate uncommitted transaction on `citation_links`:

```
ERROR "could not save batch results" size=5000
      error="... canceling statement due to lock timeout (SQLSTATE 55P03)"
INFO  "linking progress" processed=0 elapsed=1m0s rows_per_sec=0
INFO  "linking progress" processed=0 elapsed=2m0s rows_per_sec=0
INFO  "linking progress" processed=0 elapsed=3m0s rows_per_sec=0
ERROR "finished with unsaved batches; re-run to pick them up"
      processed=0 failed_batches=10 failed_rows=50000
```

Exit 1, and the run terminated instead of hanging. The three frozen heartbeats are the signal that was missing before.

With the blocker holding only part of the table: 150,000 processed, exactly the 50,000 blocked rows reported as failed. An unblocked run over 200,000 citations exits 0 with `done linking citations` and no failures.

`gofmt`, `go vet`, `go build ./...`, `go test ./...` clean; `TestStartProgressHeartbeat` restored.

## Operational note

Draining is bounded, not instant: at 32 workers and a 1m timeout, the ~224 batches of a late-stage stall take about 7 rounds — roughly 7 minutes — to fail out and exit, versus hanging until the 6h wall clock. Lower `--lock-timeout` to shorten that; `--lock-timeout=0` restores the old block-forever behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)