### PR TITLE
Add workflow_dispatch to chambers CI/CD workflow

### DIFF
--- a/.github/workflows/cicd--chambers.yml
+++ b/.github/workflows/cicd--chambers.yml
@@ -1,6 +1,7 @@
 name: Build & Publish chambers Docker Image
 
 on:
+  workflow_dispatch:
   push:
     branches: [
       "main"


### PR DESCRIPTION
Allows the chambers build-and-publish workflow to be triggered manually from the Actions tab, matching the website workflow.