### PR TITLE
cite-linker: small fixes — ambiguous cites, alt-spelling probes, dead code

### DIFF
--- a/chambers/templates/cases.html
+++ b/chambers/templates/cases.html
@@ -50,7 +50,7 @@
             </tr>
         {{else}}
             <tr><td colspan="8" class="text-secondary">No cases. (If empty, the
-                <code>case_citation_counts</code> view may need a <code>make db-refresh</code>.)</td></tr>
+                <code>case_citation_counts</code> view may need a <code>make db-maintenance</code>.)</td></tr>
         {{end}}
         </tbody>
     </table>

--- a/chambers/templates/normalized.html
+++ b/chambers/templates/normalized.html
@@ -46,7 +46,7 @@
             </tr>
         {{else}}
             <tr><td colspan="4" class="text-secondary">No normalized citations. (If empty, the
-                <code>normalized_citation_counts</code> view may need a <code>make db-refresh</code>.)</td></tr>
+                <code>normalized_citation_counts</code> view may need a <code>make db-maintenance</code>.)</td></tr>
         {{end}}
         </tbody>
     </table>

--- a/chambers/templates/treatises.html
+++ b/chambers/templates/treatises.html
@@ -62,7 +62,7 @@
             </tr>
         {{else}}
             <tr><td colspan="7" class="text-secondary">No treatises found. (If all counts are zero, the
-                <code>treatise_citation_counts</code> view may need a <code>make db-refresh</code>.)</td></tr>
+                <code>treatise_citation_counts</code> view may need a <code>make db-maintenance</code>.)</td></tr>
         {{end}}
         </tbody>
     </table>

--- a/cite-linker/main.go
+++ b/cite-linker/main.go
@@ -361,11 +361,10 @@ func linkCitation(
 		return result
 	}
 
-	// If there's no standard reporter, we can't normalize the citation
-	if entry.ReporterStandard == nil {
-		result.Status = citations.StatusNoMatch
-		return result
-	}
+	// Past this point entry.ReporterStandard is never nil: non-junk whitelist
+	// rows always have a standard reporter, enforced by the
+	// chk_whitelist_nonjunk_has_standard constraint. A violation panics at the
+	// derefs below rather than silently producing no_match.
 
 	// Step 2: route by UK flag
 	if entry.UK {
@@ -375,8 +374,13 @@ func linkCitation(
 }
 
 // linkCAPThenCode tries CAP first, then the FreeLaw parallel-citation crosswalk
-// (which also resolves to a CAP case), then the FreeLaw crosswalk again under
-// alternate reporter spellings, then the Code Reporter, all using in-memory maps.
+// (which also resolves to a CAP case), then both again under alternate reporter
+// spellings, then the Code Reporter (standard form, then alternates), all using
+// in-memory maps. The alternate spellings probe per map, not per alt: CAP is
+// exhausted across every alternate before FreeLaw is consulted, because the
+// source ranking is meaningful (CAP's own citation index over the FreeLaw
+// cluster crosswalk, matching the direct-probe order) while the position of an
+// alt in its list is not.
 func linkCAPThenCode(
 	c *citations.UnlinkedCitation,
 	entry *citations.WhitelistEntry,
@@ -418,33 +422,44 @@ func linkCAPThenCode(
 			return result
 		}
 
-		// Fall back to alternate reporter spellings: the same decision may be in the
-		// FreeLaw crosswalk under a CourtListener spelling that differs from our
-		// reporter_standard/reporter_cap. Probe each known alternate spelling for this
-		// reporter (keyed by the canonical reporter_standard, like diffvols). The
-		// first hit links to the CAP case (status linked_cap). Volume-nil is handled
-		// the same way as buildStandardCite/buildCAPCite.
-		for _, alt := range altAbbrs[*entry.ReporterStandard] {
-			var altCite string
-			if f.Volume == nil {
-				altCite = fmt.Sprintf("%s %d", alt, f.Page)
-			} else {
-				altCite = fmt.Sprintf("%d %s %d", *f.Volume, alt, f.Page)
-			}
-			if caseID, ok := freelawCites[altCite]; ok {
+		// Fall back to alternate reporter spellings: the same decision may be in
+		// CAP or the FreeLaw crosswalk under a spelling that differs from our
+		// reporter_standard/reporter_cap. Probe each known alternate spelling for
+		// this reporter (keyed by the canonical reporter_standard, like diffvols)
+		// against CAP first, then all of them against FreeLaw. A hit links to the
+		// CAP case (status linked_cap).
+		altCites := buildAltCites(f, altAbbrs[*entry.ReporterStandard])
+		for i := range altCites {
+			if caseID, ok := capCites[altCites[i]]; ok {
 				result.Status = citations.StatusLinkedCAP
 				result.CAPCaseID = &caseID
-				result.CiteLinked = &altCite
+				result.CiteLinked = &altCites[i]
+				return result
+			}
+		}
+		for i := range altCites {
+			if caseID, ok := freelawCites[altCites[i]]; ok {
+				result.Status = citations.StatusLinkedCAP
+				result.CAPCaseID = &caseID
+				result.CiteLinked = &altCites[i]
 				return result
 			}
 		}
 
-		// Try Code Reporter with the cleaned cite
+		// Try Code Reporter with the cleaned cite, then the alternate spellings
 		if codeID, ok := codeCites[cleaned]; ok {
 			result.Status = citations.StatusLinkedCodeReporter
 			result.CodeReporterID = &codeID
 			result.CiteLinked = &cleaned
 			return result
+		}
+		for i := range altCites {
+			if codeID, ok := codeCites[altCites[i]]; ok {
+				result.Status = citations.StatusLinkedCodeReporter
+				result.CodeReporterID = &codeID
+				result.CiteLinked = &altCites[i]
+				return result
+			}
 		}
 	}
 
@@ -510,6 +525,26 @@ func volumeForms(c *citations.UnlinkedCitation, entry *citations.WhitelistEntry)
 		return forms
 	}
 	return append(forms, &variant)
+}
+
+// buildAltCites constructs the alternate-spelling cite strings for a citation
+// form, one per alternate abbreviation, in order; nil when there are none.
+// Volume-nil is handled the same way as buildStandardCite. The alternates
+// deliberately bypass buildCAPCite's reporter_cap/diffvols handling: they are
+// the other source's own spellings, so remapping their volumes would be wrong.
+func buildAltCites(c *citations.UnlinkedCitation, alts []string) []string {
+	if len(alts) == 0 {
+		return nil
+	}
+	altCites := make([]string, len(alts))
+	for i, alt := range alts {
+		if c.Volume == nil {
+			altCites[i] = fmt.Sprintf("%s %d", alt, c.Page)
+		} else {
+			altCites[i] = fmt.Sprintf("%d %s %d", *c.Volume, alt, c.Page)
+		}
+	}
+	return altCites
 }
 
 // buildStandardCite constructs "{volume} {reporter_standard} {page}".

--- a/cite-linker/main_test.go
+++ b/cite-linker/main_test.go
@@ -158,6 +158,93 @@ func TestLinkCitation(t *testing.T) {
 			wantLinked:   ptr("Stat 30"),
 		},
 		{
+			name:         "alt_abbr CAP hit recovers a no_match",
+			cite:         citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(5), ReporterAbbr: "U.S.", Page: 10},
+			whitelist:    map[string]*citations.WhitelistEntry{"U.S.": {ReporterStandard: &usStd}},
+			capCites:     map[string]int64{"5 US 10": 333}, // CAP holds the no-period spelling
+			freelawCites: map[string]int64{},
+			altAbbrs:     map[string][]string{"U.S.": {"US"}},
+			wantStatus:   citations.StatusLinkedCAP,
+			wantCAPID:    ptr(int64(333)),
+			wantLinked:   ptr("5 US 10"),
+		},
+		{
+			// The alternates probe per map, not per alt: CAP is exhausted across
+			// every alternate before FreeLaw is consulted, so a later alt's CAP
+			// hit beats an earlier alt's FreeLaw hit.
+			name:         "alt CAP hit wins over an earlier-alt FreeLaw hit",
+			cite:         citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(5), ReporterAbbr: "U.S.", Page: 10},
+			whitelist:    map[string]*citations.WhitelistEntry{"U.S.": {ReporterStandard: &usStd}},
+			capCites:     map[string]int64{"5 U. S. 10": 333}, // second alt
+			freelawCites: map[string]int64{"5 US 10": 444},    // first alt
+			altAbbrs:     map[string][]string{"U.S.": {"US", "U. S."}},
+			wantStatus:   citations.StatusLinkedCAP,
+			wantCAPID:    ptr(int64(333)),
+			wantLinked:   ptr("5 U. S. 10"),
+		},
+		{
+			// The alt probes sit after both direct probes: a normalized-form
+			// FreeLaw hit still beats any alternate-spelling CAP hit.
+			name:         "direct FreeLaw-normalized hit wins over alt CAP",
+			cite:         citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(5), ReporterAbbr: "U.S.", Page: 10},
+			whitelist:    map[string]*citations.WhitelistEntry{"U.S.": {ReporterStandard: &usStd}},
+			capCites:     map[string]int64{"5 US 10": 333},
+			freelawCites: map[string]int64{"5 U.S. 10": 222},
+			altAbbrs:     map[string][]string{"U.S.": {"US"}},
+			wantStatus:   citations.StatusLinkedCAP,
+			wantCAPID:    ptr(int64(222)),
+			wantLinked:   ptr("5 U.S. 10"),
+		},
+		{
+			name:         "alt_abbr code-reporter hit recovers a no_match",
+			cite:         citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(2), ReporterAbbr: "Stat.", Page: 30},
+			whitelist:    map[string]*citations.WhitelistEntry{"Stat.": {ReporterStandard: &statStd}},
+			capCites:     map[string]int64{},
+			freelawCites: map[string]int64{},
+			altAbbrs:     map[string][]string{"Stat.": {"Statx"}},
+			codeCites:    map[string]int64{"2 Statx 30": 999},
+			wantStatus:   citations.StatusLinkedCodeReporter,
+			wantCodeID:   ptr(int64(999)),
+			wantLinked:   ptr("2 Statx 30"),
+		},
+		{
+			name:         "official code cite wins over alt code cite",
+			cite:         citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(2), ReporterAbbr: "Stat.", Page: 30},
+			whitelist:    map[string]*citations.WhitelistEntry{"Stat.": {ReporterStandard: &statStd}},
+			capCites:     map[string]int64{},
+			freelawCites: map[string]int64{},
+			altAbbrs:     map[string][]string{"Stat.": {"Statx"}},
+			codeCites:    map[string]int64{"2 Stat. 30": 111, "2 Statx 30": 222},
+			wantStatus:   citations.StatusLinkedCodeReporter,
+			wantCodeID:   ptr(int64(111)),
+			wantLinked:   ptr("2 Stat. 30"),
+		},
+		{
+			// The new code-reporter alt probe runs inside the volumeForms loop:
+			// the detected form is exhausted across every source, alternates
+			// included, before the volume variant is tried.
+			name:       "alt code hit on the detected form wins over CAP hit on the variant",
+			cite:       citations.UnlinkedCitation{ID: uuid.New(), Volume: nil, ReporterAbbr: "Toth", Page: 123},
+			whitelist:  map[string]*citations.WhitelistEntry{"Toth": {ReporterStandard: &tothStd, SingleVol: true}},
+			capCites:   map[string]int64{"1 Toth 123": 777}, // variant form only
+			altAbbrs:   map[string][]string{"Toth": {"Tothill"}},
+			codeCites:  map[string]int64{"Tothill 123": 999}, // detected form, alt spelling
+			wantStatus: citations.StatusLinkedCodeReporter,
+			wantCodeID: ptr(int64(999)),
+			wantLinked: ptr("Tothill 123"),
+		},
+		{
+			name:       "nil-volume alt code hit",
+			cite:       citations.UnlinkedCitation{ID: uuid.New(), Volume: nil, ReporterAbbr: "Stat.", Page: 30},
+			whitelist:  map[string]*citations.WhitelistEntry{"Stat.": {ReporterStandard: &statStd}},
+			capCites:   map[string]int64{},
+			altAbbrs:   map[string][]string{"Stat.": {"Stat"}},
+			codeCites:  map[string]int64{"Stat 30": 555},
+			wantStatus: citations.StatusLinkedCodeReporter,
+			wantCodeID: ptr(int64(555)),
+			wantLinked: ptr("Stat 30"),
+		},
+		{
 			// Regression test for #218/#226. The single-volume detector for
 			// Aleyn's King's Bench ("Al") also fires on "Ala." in OCR'd text.
 			// Now that the detector records the spelling it actually found, the
@@ -301,12 +388,6 @@ func TestLinkCitation(t *testing.T) {
 			cite:       citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(5), ReporterAbbr: "U.S.", Page: 10},
 			whitelist:  map[string]*citations.WhitelistEntry{"U.S.": {Junk: true}},
 			wantStatus: citations.StatusSkippedJunk,
-		},
-		{
-			name:       "whitelisted but no standard reporter is no_match",
-			cite:       citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(5), ReporterAbbr: "U.S.", Page: 10},
-			whitelist:  map[string]*citations.WhitelistEntry{"U.S.": {ReporterStandard: nil}},
-			wantStatus: citations.StatusNoMatch,
 		},
 	}
 

--- a/db/migrations/20260609115030_create_citations_unmatched_top_matview.sql
+++ b/db/migrations/20260609115030_create_citations_unmatched_top_matview.sql
@@ -7,7 +7,7 @@ SET ROLE = law_admin;
 -- abbreviations are joined to the whitelist (excluding junk) to get the
 -- standard reporter, then grouped by volume, standard reporter, and page so
 -- each distinct normalized citation is counted once. Built WITH NO DATA; run
--- REFRESH MATERIALIZED VIEW to populate (see note in migrate:down).
+-- REFRESH MATERIALIZED VIEW to populate (see note before migrate:down).
 CREATE MATERIALIZED VIEW IF NOT EXISTS moml_citations.citations_unmatched_top AS
 SELECT
   cu.volume,
@@ -28,10 +28,10 @@ WITH NO DATA;
 
 -- Unique index on the grouping key. Each (volume, reporter_standard, page) is
 -- unique by construction (it is the GROUP BY key). NULLS NOT DISTINCT treats
--- the NULL volume of single-volume reporters as a single value. The cite-linker
--- refreshes this view with a plain (non-concurrent) REFRESH, so this index is
--- not required for that; it documents the grouping invariant and keeps the
--- option of a manual REFRESH MATERIALIZED VIEW CONCURRENTLY open.
+-- the NULL volume of single-volume reporters as a single value.
+-- db/maintenance.sh refreshes this view with a plain (non-concurrent) REFRESH,
+-- so this index is not required for that; it documents the grouping invariant
+-- and keeps the option of a manual REFRESH MATERIALIZED VIEW CONCURRENTLY open.
 CREATE UNIQUE INDEX IF NOT EXISTS citations_unmatched_top_uq
   ON moml_citations.citations_unmatched_top (volume, reporter_standard, page) NULLS NOT DISTINCT;
 
@@ -39,9 +39,9 @@ CREATE UNIQUE INDEX IF NOT EXISTS citations_unmatched_top_uq
 CREATE INDEX IF NOT EXISTS citations_unmatched_top_n_idx
   ON moml_citations.citations_unmatched_top (n DESC);
 
--- After this migration the view is empty. The cite-linker refreshes it at the
--- start and end of each run, so it will be populated the next time cite-linker
--- runs. To populate it manually in the meantime:
+-- After this migration the view is empty. The cite-linker does not refresh it;
+-- run `make db-maintenance` (db/maintenance.sh) after a linker run, or populate
+-- it manually:
 --   REFRESH MATERIALIZED VIEW moml_citations.citations_unmatched_top;
 
 -- migrate:down

--- a/db/migrations/20260609133000_create_linking_dashboard_matviews.sql
+++ b/db/migrations/20260609133000_create_linking_dashboard_matviews.sql
@@ -5,10 +5,11 @@ SET ROLE = law_admin;
 -- (/linking-dashboard). The dashboard previously aggregated the ~62M-row
 -- moml_citations.citations_unlinked and ~61M-row moml_citations.citation_links
 -- tables on every page load, which took over a minute and timed out in the
--- browser. These materialized views move that work off the request path; the
--- cite-linker refreshes them at the start and end of each run, alongside
--- moml_citations.citations_unmatched_top. Both are built WITH NO DATA; run
--- REFRESH MATERIALIZED VIEW to populate (see note before migrate:down).
+-- browser. These materialized views move that work off the request path;
+-- `make db-maintenance` (db/maintenance.sh) refreshes them after a linker run,
+-- alongside moml_citations.citations_unmatched_top. Both are built WITH NO
+-- DATA; run REFRESH MATERIALIZED VIEW to populate (see note before
+-- migrate:down).
 
 -- Per-reporter linking breakdown. For each whitelisted (non-junk) standard
 -- reporter, counts how many of its raw citations are linked, ended in
@@ -55,9 +56,9 @@ WITH NO DATA;
 CREATE UNIQUE INDEX IF NOT EXISTS linking_dashboard_summary_uq
   ON moml_citations.linking_dashboard_summary (metric);
 
--- After this migration both views are empty. The cite-linker refreshes them at
--- the start and end of each run, so they will be populated the next time
--- cite-linker runs. To populate them manually in the meantime:
+-- After this migration both views are empty. The cite-linker does not refresh
+-- them; run `make db-maintenance` (db/maintenance.sh) after a linker run, or
+-- populate them manually:
 --   REFRESH MATERIALIZED VIEW moml_citations.linking_dashboard_reporters;
 --   REFRESH MATERIALIZED VIEW moml_citations.linking_dashboard_summary;
 

--- a/db/migrations/20260610140000_create_chambers_browse_matviews.sql
+++ b/db/migrations/20260610140000_create_chambers_browse_matviews.sql
@@ -116,7 +116,7 @@ CREATE INDEX IF NOT EXISTS citation_links_cite_normalized_idx
 
 -- After this migration the three views are empty. Populate them (and refresh the
 -- existing dashboard views) with:
---   make db-refresh
+--   make db-maintenance
 -- or individually:
 --   REFRESH MATERIALIZED VIEW moml_citations.treatise_citation_counts;
 --   REFRESH MATERIALIZED VIEW moml_citations.case_citation_counts;

--- a/db/migrations/20260611182350_create_freelaw_cite_to_cap.sql
+++ b/db/migrations/20260611182350_create_freelaw_cite_to_cap.sql
@@ -28,8 +28,8 @@ SET ROLE = law_admin;
 --
 -- This is a SOURCE crosswalk: it depends on the freelaw and cap data, not on
 -- linker output, so it is NOT refreshed by the cite-linker on each run. Build it
--- WITH NO DATA and populate it with `make db-refresh` (which auto-discovers every
--- materialized view) or:
+-- WITH NO DATA and populate it with `make db-maintenance` (which auto-discovers
+-- every materialized view) or:
 --   REFRESH MATERIALIZED VIEW freelaw.cite_to_cap;
 -- The build runs two large joins and takes several minutes.
 CREATE MATERIALIZED VIEW IF NOT EXISTS freelaw.cite_to_cap AS

--- a/go/citations/linker_store.go
+++ b/go/citations/linker_store.go
@@ -20,7 +20,10 @@ type LinkerStore interface {
 	// fn (e.g. a bounded channel) to avoid buffering the entire table in memory.
 	StreamUnprocessedCitations(ctx context.Context, batchSize int, fn func([]UnlinkedCitation) error) error
 
-	// LoadCAPCitations loads all CAP citations into memory as cite -> case ID.
+	// LoadCAPCitations loads CAP citations into memory as cite -> case ID.
+	// Cites that belong to more than one case are dropped, mirroring
+	// freelaw.cite_to_cap, so an ambiguous cite is a miss rather than a link
+	// to an arbitrary case.
 	LoadCAPCitations(ctx context.Context) (map[string]int64, error)
 
 	// LoadFreelawCites loads the FreeLaw parallel-citation crosswalk
@@ -29,14 +32,17 @@ type LinkerStore interface {
 	LoadFreelawCites(ctx context.Context) (map[string]int64, error)
 
 	// LoadReporterAltAbbrs loads legalhist.reporters_abbreviations into memory as
-	// reporter_standard -> list of alternate abbreviations. The linker probes the
-	// FreeLaw crosswalk with each alternate spelling after the canonical
-	// reporter_standard / reporter_cap forms miss, recovering matches where our
-	// reporter string and CourtListener's disagree.
+	// reporter_standard -> list of alternate abbreviations, in a deterministic
+	// order. The linker probes the CAP, FreeLaw, and code-reporter maps with each
+	// alternate spelling after the canonical reporter_standard / reporter_cap
+	// forms miss, recovering matches where our reporter string and the other
+	// source's disagree.
 	LoadReporterAltAbbrs(ctx context.Context) (map[string][]string, error)
 
-	// LoadCodeReporterCitations loads all code reporter citations into memory
-	// as official_citation -> id.
+	// LoadCodeReporterCitations loads code reporter citations into memory as
+	// cite -> id, keyed by both the official citation and the individual
+	// parallel citations. Cites that belong to more than one row are dropped,
+	// as in LoadCAPCitations.
 	LoadCodeReporterCitations(ctx context.Context) (map[string]int64, error)
 
 	// LoadEnglishReportsCitations loads all English Reports citations into memory

--- a/go/citations/linker_store_db.go
+++ b/go/citations/linker_store_db.go
@@ -148,8 +148,19 @@ func (s *LinkerDBStore) StreamUnprocessedCitations(ctx context.Context, batchSiz
 }
 
 // LoadCAPCitations loads cap.citations into an in-memory map of cite -> case ID.
+// A cite is included only if it resolves unambiguously to a single case, the
+// same policy freelaw.cite_to_cap enforces with its HAVING clause: ~10% of
+// distinct cite strings belong to more than one case (memorandum/table pages
+// listing several decisions), and linking those to an arbitrary case would
+// inject systematic errors, so they are dropped. min("case") is a formality —
+// the HAVING guarantees a single distinct value.
 func (s *LinkerDBStore) LoadCAPCitations(ctx context.Context) (map[string]int64, error) {
-	query := `SELECT DISTINCT ON (cite) cite, "case" FROM cap.citations`
+	query := `
+	SELECT cite, min("case") AS case_id
+	FROM cap.citations
+	GROUP BY cite
+	HAVING count(DISTINCT "case") = 1
+	`
 	rows, err := s.DB.Query(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("loading CAP citations: %w", err)
@@ -200,15 +211,18 @@ func (s *LinkerDBStore) LoadFreelawCites(ctx context.Context) (map[string]int64,
 }
 
 // LoadReporterAltAbbrs loads legalhist.reporters_abbreviations into an in-memory
-// map of reporter_standard -> []alt_abbr. The linker probes the FreeLaw
-// crosswalk with each alternate spelling (keyed by the canonical
+// map of reporter_standard -> []alt_abbr. The linker probes the CAP, FreeLaw,
+// and code-reporter maps with each alternate spelling (keyed by the canonical
 // reporter_standard, like the diffvols mapping) after the standard/reporter_cap
-// forms miss.
+// forms miss. The ORDER BY makes the probe order — and therefore which alt wins
+// when more than one would hit — deterministic across runs; COLLATE "C" keeps
+// that order byte-identical across environments regardless of locale.
 func (s *LinkerDBStore) LoadReporterAltAbbrs(ctx context.Context) (map[string][]string, error) {
 	query := `
 	SELECT reporter_standard, alt_abbr
 	FROM legalhist.reporters_abbreviations
 	WHERE alt_abbr IS NOT NULL
+	ORDER BY reporter_standard COLLATE "C", alt_abbr COLLATE "C"
 	`
 	rows, err := s.DB.Query(ctx, query)
 	if err != nil {
@@ -231,9 +245,31 @@ func (s *LinkerDBStore) LoadReporterAltAbbrs(ctx context.Context) (map[string][]
 }
 
 // LoadCodeReporterCitations loads code_reporter into an in-memory map of
-// official_citation -> id.
+// citation -> id, keyed by both official_citation and the individual
+// parallel_citation entries. parallel_citation is a "; "-separated list
+// ("4 Sandf. 21; 6 N.Y. Super. Ct. 21"), so it is split on semicolons, with a
+// trailing parenthetical year ("1 Code Rep. 91 (1848)") stripped. Commas are
+// NOT split on: reporter names legitimately contain them ("Cox, Manual
+// Trade-Mark Cas. 51"), so the few comma-joined pairs inside one segment stay
+// as harmless keys no probe string will ever match. As with the CAP map, a
+// citation is included only if it resolves unambiguously to a single row —
+// several Code Reports pages carry many short decisions, so the same cite can
+// belong to more than one id.
 func (s *LinkerDBStore) LoadCodeReporterCitations(ctx context.Context) (map[string]int64, error) {
-	query := `SELECT official_citation, id FROM legalhist.code_reporter`
+	query := `
+	SELECT cite, min(id) AS id
+	FROM (
+		SELECT official_citation AS cite, id FROM legalhist.code_reporter
+		UNION ALL
+		SELECT regexp_replace(trim(seg), '\s*\(\d{4}\)$', ''), id
+		FROM legalhist.code_reporter,
+		     unnest(string_to_array(parallel_citation, ';')) AS seg
+		WHERE parallel_citation IS NOT NULL
+	) t
+	WHERE cite <> ''
+	GROUP BY cite
+	HAVING count(DISTINCT id) = 1
+	`
 	rows, err := s.DB.Query(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("loading code reporter citations: %w", err)

--- a/go/citations/linker_store_db_integration_test.go
+++ b/go/citations/linker_store_db_integration_test.go
@@ -314,9 +314,95 @@ func TestLoadReporterAltAbbrsIntegration(t *testing.T) {
 	got, err := s.LoadReporterAltAbbrs(ctx)
 	require.NoError(t, err)
 
-	assert.ElementsMatch(t, []string{"US", "U. S."}, got["U.S."])
+	// Exact order, not ElementsMatch: the loader's ORDER BY … COLLATE "C" makes
+	// the probe order deterministic, byte-ordered ("U. S." before "US").
+	assert.Equal(t, []string{"U. S.", "US"}, got["U.S."])
 	assert.Equal(t, []string{"Serg. & Rawle"}, got["Serg. & Rawl."])
 	_, hasMass := got["Mass."]
 	assert.False(t, hasMass, "a reporter with no alt rows should be absent from the map")
 	assert.Len(t, got, 2)
+}
+
+func TestLoadCAPCitationsIntegration(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	// Minimal cap slice: just the citations table the loader reads.
+	setup := []string{
+		`DROP SCHEMA IF EXISTS cap CASCADE`,
+		`CREATE SCHEMA cap`,
+		`CREATE TABLE cap.citations (cite text NOT NULL, type text NOT NULL, "case" bigint NOT NULL)`,
+		`INSERT INTO cap.citations (cite, type, "case") VALUES
+			('5 U.S. 10', 'official', 111),
+			('108 S. Ct. 185', 'official', 222),
+			('108 S. Ct. 185', 'official', 333),
+			('2 Mass. 4', 'official', 444),
+			('2 Mass. 4', 'parallel', 444)`,
+	}
+	for _, stmt := range setup {
+		_, err := s.DB.Exec(ctx, stmt)
+		require.NoError(t, err, "setup: %s", stmt)
+	}
+
+	got, err := s.LoadCAPCitations(ctx)
+	require.NoError(t, err)
+
+	// An unambiguous cite is kept; a cite belonging to two cases is dropped; a
+	// cite appearing twice for the SAME case is one distinct case, so it stays.
+	assert.Equal(t, map[string]int64{
+		"5 U.S. 10": 111,
+		"2 Mass. 4": 444,
+	}, got)
+}
+
+func TestLoadCodeReporterCitationsIntegration(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	// Minimal code_reporter slice: only the columns the loader reads.
+	setup := []string{
+		`DROP SCHEMA IF EXISTS legalhist CASCADE`,
+		`CREATE SCHEMA legalhist`,
+		`CREATE TABLE legalhist.code_reporter (
+			id bigint PRIMARY KEY,
+			official_citation text NOT NULL,
+			parallel_citation text
+		)`,
+		`INSERT INTO legalhist.code_reporter (id, official_citation, parallel_citation) VALUES
+			(1, '1 Code Rep. 5', NULL),
+			(2, '1 Code Rep. 59', NULL),
+			(3, '1 Code Rep. 59', NULL),
+			(4, '2 Code Rep. 153', '4 Sandf. 21; 6 N.Y. Super. Ct. 21'),
+			(5, '3 Code Rep. 67', '1 Code Rep. 91 (1848)'),
+			(6, '3 Code Rep. 103', '21 F. Cas 863; Cox, Manual Trade-Mark Cas. 51'),
+			(7, '2 Code Rep. 7', '1 Code Rep. 5'),
+			(8, '3 Code Rep. 39', '3 Code Rep. 39')`,
+	}
+	for _, stmt := range setup {
+		_, err := s.DB.Exec(ctx, stmt)
+		require.NoError(t, err, "setup: %s", stmt)
+	}
+
+	got, err := s.LoadCodeReporterCitations(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]int64{
+		// Officials shared by two rows (ids 2 and 3) are dropped; '1 Code Rep. 5'
+		// is dropped because id 7's parallel collides with id 1's official.
+		"2 Code Rep. 153": 4,
+		"3 Code Rep. 67":  5,
+		"3 Code Rep. 103": 6,
+		"2 Code Rep. 7":   7,
+		// A parallel equal to its own official is one distinct id: kept once.
+		"3 Code Rep. 39": 8,
+		// "; "-separated parallels split into individual keys.
+		"4 Sandf. 21":          4,
+		"6 N.Y. Super. Ct. 21": 4,
+		// A trailing parenthetical year is stripped.
+		"1 Code Rep. 91": 5,
+		// Comma-joined segments are NOT split (reporter names contain commas);
+		// they stay as literal keys no probe string will match.
+		"21 F. Cas 863":                  6,
+		"Cox, Manual Trade-Mark Cas. 51": 6,
+	}, got)
 }

--- a/scripts/remediate-250-ambiguous-links.sql
+++ b/scripts/remediate-250-ambiguous-links.sql
@@ -1,0 +1,60 @@
+-- One-off remediation for issue #250: delete linked rows that were created
+-- from ambiguous lookup keys the linker no longer uses, so the next run
+-- re-processes them honestly.
+--
+-- Background: LoadCAPCitations used SELECT DISTINCT ON (cite) with no ORDER
+-- BY, and LoadCodeReporterCitations last-wrote duplicate official citations
+-- into its map, so a cite belonging to several cases linked to an arbitrary
+-- one. The fixed loaders drop ambiguous keys, but --reset deliberately
+-- preserves linked_* rows, so the wrong rows already written must be deleted
+-- explicitly. Rows deleted here leave citation_links entirely, so the linker's
+-- anti-join picks them up without --reset; still run the linker with --reset
+-- so existing no_match rows see the new alternate-spelling probes.
+--
+-- Run order (needs write access, i.e. LAW_DBSTR):
+--   1. psql "$LAW_DBSTR" -f scripts/remediate-250-ambiguous-links.sql
+--   2. run the cite-linker with --reset
+--   3. make db-maintenance
+--
+-- Some deleted linked_cap rows will relink identically or better through the
+-- FreeLaw crosswalk (its cluster grouping disambiguates some cites that are
+-- ambiguous in cap.citations); the rest become honest no_match.
+
+BEGIN;
+
+-- linked_cap rows on cites that map to more than one CAP case (the old
+-- DISTINCT ON picked one arbitrarily). Expected: ~353,745 rows as of
+-- 2026-07-29.
+DELETE FROM moml_citations.citation_links cl
+USING (
+  SELECT cite FROM cap.citations
+  GROUP BY cite HAVING count(DISTINCT "case") > 1
+) amb
+WHERE cl.status = 'linked_cap'
+  AND cl.cite_linked = amb.cite;
+
+-- linked_code_reporter rows whose linked cite is not in the new unambiguous
+-- merged official+parallel key set (a mirror of the rewritten
+-- LoadCodeReporterCitations query). Expected: exactly 3,770 rows as of
+-- 2026-07-29; every retained row already carries the id the new map assigns.
+-- NOT EXISTS rather than NOT IN: NOT IN would silently delete nothing if the
+-- subquery ever yielded a NULL.
+WITH keys AS MATERIALIZED (
+  SELECT cite
+  FROM (
+    SELECT official_citation AS cite, id FROM legalhist.code_reporter
+    UNION ALL
+    SELECT regexp_replace(trim(seg), '\s*\(\d{4}\)$', ''), id
+    FROM legalhist.code_reporter,
+         unnest(string_to_array(parallel_citation, ';')) AS seg
+    WHERE parallel_citation IS NOT NULL
+  ) t
+  WHERE cite <> ''
+  GROUP BY cite
+  HAVING count(DISTINCT id) = 1
+)
+DELETE FROM moml_citations.citation_links cl
+WHERE cl.status = 'linked_code_reporter'
+  AND NOT EXISTS (SELECT 1 FROM keys WHERE keys.cite = cl.cite_linked);
+
+COMMIT;


### PR DESCRIPTION
Closes #250.

Fixes the six items remaining on #250 after the two feature bullets were split out to #254 and #255. No DB migrations: the whitelist unique-constraint item turned out to be already enforced (`reporter_found` is the primary key under the legacy name `reporters_citation_to_cap_pkey`).

## What changed

- **Ambiguous CAP cites no longer link to an arbitrary case.** `LoadCAPCitations` now keeps only cites resolving to a single case (`GROUP BY cite HAVING count(DISTINCT "case") = 1`), mirroring `freelaw.cite_to_cap`. 654,799 of 6,659,709 distinct cite strings (9.8%) were ambiguous; the map now loads 6,004,910 keys, so the **"loaded CAP citations" startup count drops from ~6.66M to ~6.0M by design**.
- **The code-reporter map gets the same fix plus `parallel_citation`.** The loader merges the official and semicolon-split parallel citations (trailing "(1848)"-style years stripped; commas never split on, since reporter names contain them) and drops ambiguous keys — the same bug existed there via duplicated official citations (149 strings, several decisions per page). Verified against live data: 431 keys, purely additive, no previously-unambiguous key dropped or remapped.
- **Alt spellings now probe CAP and the code reporter, not just FreeLaw.** Probing is per map (CAP exhausted across all alternates before FreeLaw) and stays inside the `volumeForms` loop, so all existing precedence invariants hold — pinned by new table tests. `LoadReporterAltAbbrs` gains `ORDER BY … COLLATE "C"` so probe order is deterministic across runs and environments. **English Reports probing is deferred to #256**, which also tracks the same ambiguity bug in the ER map (~818K of 5.3M `linked_english_reports` rows).
- **Dead branch removed.** `entry.ReporterStandard == nil → no_match` was unreachable under `chk_whitelist_nonjunk_has_standard`; an invariant comment replaces it.
- **Stale comments fixed.** The 20260609 matview migrations no longer claim the cite-linker refreshes the dashboard views (that moved to `db/maintenance.sh`), and references to the nonexistent `make db-refresh` target in two migrations and three chambers templates now say `make db-maintenance`. Comment/template text only.
- **Remediation script** for the wrong rows already written (they are `linked_*`, which `--reset` preserves): `scripts/remediate-250-ambiguous-links.sql`.

## After merging — run order (needs `LAW_DBSTR` write access)

1. `psql "$LAW_DBSTR" -f scripts/remediate-250-ambiguous-links.sql` — deletes ~353,745 `linked_cap` rows on ambiguous CAP cites and exactly 3,770 `linked_code_reporter` rows outside the new unambiguous key set (counts verified live, 2026-07-29). Some relink via the FreeLaw crosswalk (its cluster grouping disambiguates some of these cites); the rest become honest `no_match`.
2. Run the cite-linker with `--reset` so existing `no_match` rows see the new alt-spelling probes.
3. `make db-maintenance`.

## Testing

- Unit: dead-branch case removed; 7 new table cases pin the new tiers and their precedence (per-map alt order, direct-beats-alt, loop placement, nil-volume forms). `go build ./... && go test ./...` pass.
- Integration (opt-in via `LAW_TEST_DBSTR`): two new tests exercise the real loader SQL — ambiguity drops, parallel splitting, year stripping, cross-column collisions — and the alt-abbrs test now pins exact `COLLATE "C"` order. All six pass against a disposable postgres:17 container.
- Live read-only sanity: both new loader queries return the expected key counts (6,004,910 and 431).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
