### PR TITLE
cite-linker: record which tier the linking cascade reached

### DIFF
--- a/cite-linker/main.go
+++ b/cite-linker/main.go
@@ -184,6 +184,14 @@ func main() {
 	}
 	slog.Info("loaded English Reports citations", "entries", len(erCites))
 
+	// Assemble the lookup tables, which also walks every loaded cite string once
+	// to build the reporter/volume indexes a no_match is attributed with.
+	slog.Info("indexing cite strings by reporter and volume")
+	tables := newLinkTables(whitelist, diffvols, capCites, freelawCites, altAbbrs, codeCites, erCites)
+	slog.Info("indexed cite strings",
+		"us_reporters", len(tables.us.reporters), "us_volumes", len(tables.us.volumes),
+		"uk_reporters", len(tables.uk.reporters), "uk_volumes", len(tables.uk.volumes))
+
 	// Bounded pipeline. A single streaming reader (this goroutine, inside
 	// StreamUnprocessedCitations) feeds batches to a fixed pool of insert
 	// workers through a bounded channel. The channel capacity bounds how many
@@ -225,7 +233,7 @@ func main() {
 				results := make([]*citations.LinkResult, len(batch))
 				statusCounts := make(map[string]int)
 				for j := range batch {
-					r := linkCitation(&batch[j], whitelist, diffvols, capCites, freelawCites, altAbbrs, codeCites, erCites)
+					r := linkCitation(&batch[j], tables)
 					results[j] = r
 					statusCounts[r.Status]++
 				}
@@ -336,10 +344,27 @@ func startProgressHeartbeat(interval time.Duration, processed *atomic.Int64, rep
 	}
 }
 
-// linkCitation processes a single citation through the linking pipeline.
-// All lookups are in-memory map accesses — no database queries.
-func linkCitation(
-	c *citations.UnlinkedCitation,
+// linkTables holds every in-memory lookup table the cascade reads, together with
+// the derived indexes that let a failure report which tier it reached. It is
+// built once at startup and never written to afterwards, which is what makes it
+// safe to share across the insert workers.
+type linkTables struct {
+	whitelist    map[string]*citations.WhitelistEntry
+	diffvols     map[string]map[int]*citations.DiffVolEntry
+	capCites     map[string]int64
+	freelawCites map[string]int64
+	altAbbrs     map[string][]string
+	codeCites    map[string]int64
+	erCites      map[string]string
+
+	// us indexes the three maps the US cascade probes as a unit; uk indexes the
+	// English Reports. Building them walks every cite string once, which is why
+	// it happens here rather than per citation.
+	us *citeIndex
+	uk *citeIndex
+}
+
+func newLinkTables(
 	whitelist map[string]*citations.WhitelistEntry,
 	diffvols map[string]map[int]*citations.DiffVolEntry,
 	capCites map[string]int64,
@@ -347,11 +372,28 @@ func linkCitation(
 	altAbbrs map[string][]string,
 	codeCites map[string]int64,
 	erCites map[string]string,
-) *citations.LinkResult {
+) *linkTables {
+	return &linkTables{
+		whitelist:    whitelist,
+		diffvols:     diffvols,
+		capCites:     capCites,
+		freelawCites: freelawCites,
+		altAbbrs:     altAbbrs,
+		codeCites:    codeCites,
+		erCites:      erCites,
+		us:           newCiteIndex(capCites, freelawCites, codeCites),
+		uk:           newCiteIndex(erCites),
+	}
+}
+
+// linkCitation processes a single citation through the linking pipeline.
+// All lookups are in-memory map accesses — no database queries.
+func linkCitation(c *citations.UnlinkedCitation, t *linkTables) *citations.LinkResult {
 	result := &citations.LinkResult{CitationID: c.ID}
 
-	// Step 1: whitelist check
-	entry, ok := whitelist[c.ReporterAbbr]
+	// Step 1: whitelist check. Neither skip records a tier: the status is already
+	// the whole explanation, and there was no cascade to reach a tier in.
+	entry, ok := t.whitelist[c.ReporterAbbr]
 	if !ok {
 		result.Status = citations.StatusSkippedNotWhitelisted
 		return result
@@ -368,9 +410,9 @@ func linkCitation(
 
 	// Step 2: route by UK flag
 	if entry.UK {
-		return linkEnglishReports(c, entry, erCites, result)
+		return linkEnglishReports(c, entry, t, result)
 	}
-	return linkCAPThenCode(c, entry, diffvols, capCites, freelawCites, altAbbrs, codeCites, result)
+	return linkCAPThenCode(c, entry, t, result)
 }
 
 // linkCAPThenCode tries CAP first, then the FreeLaw parallel-citation crosswalk
@@ -384,29 +426,34 @@ func linkCitation(
 func linkCAPThenCode(
 	c *citations.UnlinkedCitation,
 	entry *citations.WhitelistEntry,
-	diffvols map[string]map[int]*citations.DiffVolEntry,
-	capCites map[string]int64,
-	freelawCites map[string]int64,
-	altAbbrs map[string][]string,
-	codeCites map[string]int64,
+	t *linkTables,
 	result *citations.LinkResult,
 ) *citations.LinkResult {
 
 	citeCleaned := buildStandardCite(c, entry)
-	citeNormalized := buildCAPCite(c, entry, diffvols)
+	citeNormalized := buildCAPCite(c, entry, t.diffvols)
 	result.CiteCleaned = &citeCleaned
 	result.CiteNormalized = &citeNormalized
+
+	// Every cite string probed below, in order, so a no_match can be attributed to
+	// the tier the cascade actually reached rather than to a second, drifting
+	// reimplementation of which forms get tried. The capacity covers the common
+	// case (one volume form, cleaned plus normalized, a couple of alternates)
+	// without reallocating.
+	probes := make([]string, 0, 8)
 
 	// Run the whole cascade for the form we detected before trying the volume
 	// variant, so an existing link can never be rewired: the variant only ever
 	// turns a no_match into a link.
 	for _, f := range volumeForms(c, entry) {
 		cleaned := buildStandardCite(f, entry)
-		normalized := buildCAPCite(f, entry, diffvols)
+		normalized := buildCAPCite(f, entry, t.diffvols)
+		probes = append(probes, normalized, cleaned)
 
 		// Try CAP with the normalized cite
-		if caseID, ok := capCites[normalized]; ok {
+		if caseID, ok := t.capCites[normalized]; ok {
 			result.Status = citations.StatusLinkedCAP
+			result.MatchTier = citations.TierCAPDirect
 			result.CAPCaseID = &caseID
 			result.CiteLinked = &normalized
 			return result
@@ -414,9 +461,11 @@ func linkCAPThenCode(
 
 		// Fall back to the FreeLaw crosswalk: if any parallel form of this decision
 		// is in our CAP data, this reaches the CAP case from the form we detected.
-		// The result is still a CAP link (status linked_cap).
-		if caseID, ok := freelawCites[normalized]; ok {
+		// The result is still a CAP link (status linked_cap), distinguished from a
+		// direct hit only by the tier.
+		if caseID, ok := t.freelawCites[normalized]; ok {
 			result.Status = citations.StatusLinkedCAP
+			result.MatchTier = citations.TierCAPFreelaw
 			result.CAPCaseID = &caseID
 			result.CiteLinked = &normalized
 			return result
@@ -428,18 +477,21 @@ func linkCAPThenCode(
 		// this reporter (keyed by the canonical reporter_standard, like diffvols)
 		// against CAP first, then all of them against FreeLaw. A hit links to the
 		// CAP case (status linked_cap).
-		altCites := buildAltCites(f, altAbbrs[*entry.ReporterStandard])
+		altCites := buildAltCites(f, t.altAbbrs[*entry.ReporterStandard])
+		probes = append(probes, altCites...)
 		for i := range altCites {
-			if caseID, ok := capCites[altCites[i]]; ok {
+			if caseID, ok := t.capCites[altCites[i]]; ok {
 				result.Status = citations.StatusLinkedCAP
+				result.MatchTier = citations.TierCAPAltSpelling
 				result.CAPCaseID = &caseID
 				result.CiteLinked = &altCites[i]
 				return result
 			}
 		}
 		for i := range altCites {
-			if caseID, ok := freelawCites[altCites[i]]; ok {
+			if caseID, ok := t.freelawCites[altCites[i]]; ok {
 				result.Status = citations.StatusLinkedCAP
+				result.MatchTier = citations.TierCAPFreelawAltSpelling
 				result.CAPCaseID = &caseID
 				result.CiteLinked = &altCites[i]
 				return result
@@ -447,15 +499,17 @@ func linkCAPThenCode(
 		}
 
 		// Try Code Reporter with the cleaned cite, then the alternate spellings
-		if codeID, ok := codeCites[cleaned]; ok {
+		if codeID, ok := t.codeCites[cleaned]; ok {
 			result.Status = citations.StatusLinkedCodeReporter
+			result.MatchTier = citations.TierCodeDirect
 			result.CodeReporterID = &codeID
 			result.CiteLinked = &cleaned
 			return result
 		}
 		for i := range altCites {
-			if codeID, ok := codeCites[altCites[i]]; ok {
+			if codeID, ok := t.codeCites[altCites[i]]; ok {
 				result.Status = citations.StatusLinkedCodeReporter
+				result.MatchTier = citations.TierCodeAltSpelling
 				result.CodeReporterID = &codeID
 				result.CiteLinked = &altCites[i]
 				return result
@@ -464,7 +518,22 @@ func linkCAPThenCode(
 	}
 
 	result.Status = citations.StatusNoMatch
+	result.MatchTier = usTier(probes, t.us, diffvolsMissing(c, entry, t.diffvols))
 	return result
+}
+
+// diffvolsMissing reports whether this citation's reporter renumbers its volumes
+// in CAP but no legalhist.reporters_diffvols row covers the cited volume — the
+// case where buildCAPCite has to fall back to the untranslated volume number, so
+// every probe built from it is a guess. A volume-less citation is not counted:
+// there is no volume to translate, and buildCAPCite does not consult diffvols for
+// one either.
+func diffvolsMissing(c *citations.UnlinkedCitation, entry *citations.WhitelistEntry, diffvols map[string]map[int]*citations.DiffVolEntry) bool {
+	if !entry.CAPDifferent || c.Volume == nil {
+		return false
+	}
+	_, ok := diffvols[*entry.ReporterStandard][*c.Volume]
+	return !ok
 }
 
 // linkEnglishReports tries to link a UK citation to the English Reports
@@ -472,20 +541,24 @@ func linkCAPThenCode(
 func linkEnglishReports(
 	c *citations.UnlinkedCitation,
 	entry *citations.WhitelistEntry,
-	erCites map[string]string,
+	t *linkTables,
 	result *citations.LinkResult,
 ) *citations.LinkResult {
 	citeCleaned := buildStandardCite(c, entry)
 	result.CiteCleaned = &citeCleaned
 	result.CiteNormalized = &citeCleaned
 
+	probes := make([]string, 0, 2)
+
 	// The English Reports are inconsistent about the redundant volume on
 	// single-volume nominate reporters: most are stored bare ("Cro Eliz 1") but
 	// some carry it ("1 Vern 1"), so try both forms.
 	for _, f := range volumeForms(c, entry) {
 		cite := buildStandardCite(f, entry)
-		if erID, ok := erCites[cite]; ok {
+		probes = append(probes, cite)
+		if erID, ok := t.erCites[cite]; ok {
 			result.Status = citations.StatusLinkedEnglishReports
+			result.MatchTier = citations.TierERDirect
 			result.ERCaseID = &erID
 			result.CiteLinked = &cite
 			return result
@@ -493,6 +566,7 @@ func linkEnglishReports(
 	}
 
 	result.Status = citations.StatusNoMatch
+	result.MatchTier = ukTier(probes, t.uk)
 	return result
 }
 

--- a/cite-linker/main_test.go
+++ b/cite-linker/main_test.go
@@ -28,12 +28,14 @@ func TestLinkCitation(t *testing.T) {
 		name         string
 		cite         citations.UnlinkedCitation
 		whitelist    map[string]*citations.WhitelistEntry
+		diffvols     map[string]map[int]*citations.DiffVolEntry
 		capCites     map[string]int64
 		freelawCites map[string]int64
 		altAbbrs     map[string][]string
 		codeCites    map[string]int64
 		erCites      map[string]string
 		wantStatus   string
+		wantTier     string
 		wantCAPID    *int64
 		wantCodeID   *int64
 		wantERID     *string
@@ -46,6 +48,7 @@ func TestLinkCitation(t *testing.T) {
 			capCites:     map[string]int64{"5 U.S. 10": 111},
 			freelawCites: map[string]int64{"5 U.S. 10": 222},
 			wantStatus:   citations.StatusLinkedCAP,
+			wantTier:     citations.TierCAPDirect,
 			wantCAPID:    ptr(int64(111)),
 			wantLinked:   ptr("5 U.S. 10"),
 		},
@@ -56,6 +59,7 @@ func TestLinkCitation(t *testing.T) {
 			capCites:     map[string]int64{},
 			freelawCites: map[string]int64{"5 U.S. 10": 222},
 			wantStatus:   citations.StatusLinkedCAP,
+			wantTier:     citations.TierCAPFreelaw,
 			wantCAPID:    ptr(int64(222)),
 			wantLinked:   ptr("5 U.S. 10"),
 		},
@@ -67,6 +71,7 @@ func TestLinkCitation(t *testing.T) {
 			freelawCites: map[string]int64{},
 			codeCites:    map[string]int64{"2 Stat. 30": 999},
 			wantStatus:   citations.StatusLinkedCodeReporter,
+			wantTier:     citations.TierCodeDirect,
 			wantCodeID:   ptr(int64(999)),
 			wantLinked:   ptr("2 Stat. 30"),
 		},
@@ -78,6 +83,7 @@ func TestLinkCitation(t *testing.T) {
 			freelawCites: map[string]int64{},
 			codeCites:    map[string]int64{},
 			wantStatus:   citations.StatusNoMatch,
+			wantTier:     citations.TierUSReporterAbsent,
 			wantLinked:   nil,
 		},
 		{
@@ -87,6 +93,7 @@ func TestLinkCitation(t *testing.T) {
 			freelawCites: map[string]int64{"1 Q.B. 20": 222},
 			erCites:      map[string]string{"1 Q.B. 20": "er-1"},
 			wantStatus:   citations.StatusLinkedEnglishReports,
+			wantTier:     citations.TierERDirect,
 			wantERID:     ptr("er-1"),
 			wantLinked:   ptr("1 Q.B. 20"),
 		},
@@ -98,6 +105,7 @@ func TestLinkCitation(t *testing.T) {
 			freelawCites: map[string]int64{"5 US 10": 333}, // CourtListener spelling, no periods
 			altAbbrs:     map[string][]string{"U.S.": {"US"}},
 			wantStatus:   citations.StatusLinkedCAP,
+			wantTier:     citations.TierCAPFreelawAltSpelling,
 			wantCAPID:    ptr(int64(333)),
 			wantLinked:   ptr("5 US 10"),
 		},
@@ -109,6 +117,7 @@ func TestLinkCitation(t *testing.T) {
 			freelawCites: map[string]int64{"5 US 10": 333},
 			altAbbrs:     map[string][]string{"U.S.": {"US"}},
 			wantStatus:   citations.StatusLinkedCAP,
+			wantTier:     citations.TierCAPDirect,
 			wantCAPID:    ptr(int64(111)),
 			wantLinked:   ptr("5 U.S. 10"),
 		},
@@ -120,6 +129,7 @@ func TestLinkCitation(t *testing.T) {
 			freelawCites: map[string]int64{"5 U.S. 10": 222, "5 US 10": 333},
 			altAbbrs:     map[string][]string{"U.S.": {"US"}},
 			wantStatus:   citations.StatusLinkedCAP,
+			wantTier:     citations.TierCAPFreelaw,
 			wantCAPID:    ptr(int64(222)),
 			wantLinked:   ptr("5 U.S. 10"),
 		},
@@ -132,6 +142,7 @@ func TestLinkCitation(t *testing.T) {
 			altAbbrs:     map[string][]string{"Stat.": {"Statx"}}, // present but never matches FreeLaw
 			codeCites:    map[string]int64{"2 Stat. 30": 999},
 			wantStatus:   citations.StatusLinkedCodeReporter,
+			wantTier:     citations.TierCodeDirect,
 			wantCodeID:   ptr(int64(999)),
 			wantLinked:   ptr("2 Stat. 30"),
 		},
@@ -143,6 +154,7 @@ func TestLinkCitation(t *testing.T) {
 			freelawCites: map[string]int64{"5 US 10": 333},
 			altAbbrs:     map[string][]string{"U.S.": {"USA", "US"}}, // first misses, second hits
 			wantStatus:   citations.StatusLinkedCAP,
+			wantTier:     citations.TierCAPFreelawAltSpelling,
 			wantCAPID:    ptr(int64(333)),
 			wantLinked:   ptr("5 US 10"),
 		},
@@ -154,6 +166,7 @@ func TestLinkCitation(t *testing.T) {
 			freelawCites: map[string]int64{"Stat 30": 444},
 			altAbbrs:     map[string][]string{"Stat.": {"Stat"}},
 			wantStatus:   citations.StatusLinkedCAP,
+			wantTier:     citations.TierCAPFreelawAltSpelling,
 			wantCAPID:    ptr(int64(444)),
 			wantLinked:   ptr("Stat 30"),
 		},
@@ -165,6 +178,7 @@ func TestLinkCitation(t *testing.T) {
 			freelawCites: map[string]int64{},
 			altAbbrs:     map[string][]string{"U.S.": {"US"}},
 			wantStatus:   citations.StatusLinkedCAP,
+			wantTier:     citations.TierCAPAltSpelling,
 			wantCAPID:    ptr(int64(333)),
 			wantLinked:   ptr("5 US 10"),
 		},
@@ -179,6 +193,7 @@ func TestLinkCitation(t *testing.T) {
 			freelawCites: map[string]int64{"5 US 10": 444},    // first alt
 			altAbbrs:     map[string][]string{"U.S.": {"US", "U. S."}},
 			wantStatus:   citations.StatusLinkedCAP,
+			wantTier:     citations.TierCAPAltSpelling,
 			wantCAPID:    ptr(int64(333)),
 			wantLinked:   ptr("5 U. S. 10"),
 		},
@@ -192,6 +207,7 @@ func TestLinkCitation(t *testing.T) {
 			freelawCites: map[string]int64{"5 U.S. 10": 222},
 			altAbbrs:     map[string][]string{"U.S.": {"US"}},
 			wantStatus:   citations.StatusLinkedCAP,
+			wantTier:     citations.TierCAPFreelaw,
 			wantCAPID:    ptr(int64(222)),
 			wantLinked:   ptr("5 U.S. 10"),
 		},
@@ -204,6 +220,7 @@ func TestLinkCitation(t *testing.T) {
 			altAbbrs:     map[string][]string{"Stat.": {"Statx"}},
 			codeCites:    map[string]int64{"2 Statx 30": 999},
 			wantStatus:   citations.StatusLinkedCodeReporter,
+			wantTier:     citations.TierCodeAltSpelling,
 			wantCodeID:   ptr(int64(999)),
 			wantLinked:   ptr("2 Statx 30"),
 		},
@@ -216,6 +233,7 @@ func TestLinkCitation(t *testing.T) {
 			altAbbrs:     map[string][]string{"Stat.": {"Statx"}},
 			codeCites:    map[string]int64{"2 Stat. 30": 111, "2 Statx 30": 222},
 			wantStatus:   citations.StatusLinkedCodeReporter,
+			wantTier:     citations.TierCodeDirect,
 			wantCodeID:   ptr(int64(111)),
 			wantLinked:   ptr("2 Stat. 30"),
 		},
@@ -230,6 +248,7 @@ func TestLinkCitation(t *testing.T) {
 			altAbbrs:   map[string][]string{"Toth": {"Tothill"}},
 			codeCites:  map[string]int64{"Tothill 123": 999}, // detected form, alt spelling
 			wantStatus: citations.StatusLinkedCodeReporter,
+			wantTier:   citations.TierCodeAltSpelling,
 			wantCodeID: ptr(int64(999)),
 			wantLinked: ptr("Tothill 123"),
 		},
@@ -241,6 +260,7 @@ func TestLinkCitation(t *testing.T) {
 			altAbbrs:   map[string][]string{"Stat.": {"Stat"}},
 			codeCites:  map[string]int64{"Stat 30": 555},
 			wantStatus: citations.StatusLinkedCodeReporter,
+			wantTier:   citations.TierCodeAltSpelling,
 			wantCodeID: ptr(int64(555)),
 			wantLinked: ptr("Stat 30"),
 		},
@@ -260,6 +280,7 @@ func TestLinkCitation(t *testing.T) {
 			capCites:   map[string]int64{"12 Ala. 672": 555},
 			erCites:    map[string]string{"Al 672": "aleyn-false-positive"},
 			wantStatus: citations.StatusLinkedCAP,
+			wantTier:   citations.TierCAPDirect,
 			wantCAPID:  ptr(int64(555)),
 			wantLinked: ptr("12 Ala. 672"),
 		},
@@ -276,6 +297,7 @@ func TestLinkCitation(t *testing.T) {
 			},
 			erCites:    map[string]string{"Al 672": "aleyn-false-positive"},
 			wantStatus: citations.StatusNoMatch,
+			wantTier:   citations.TierUSReporterAbsent,
 			wantLinked: nil,
 		},
 		{
@@ -286,6 +308,7 @@ func TestLinkCitation(t *testing.T) {
 			altAbbrs:     map[string][]string{"Q.B.": {"QB"}},
 			erCites:      map[string]string{}, // no English Reports match
 			wantStatus:   citations.StatusNoMatch,
+			wantTier:     citations.TierUKReporterAbsent,
 			wantLinked:   nil,
 		},
 		{
@@ -297,6 +320,7 @@ func TestLinkCitation(t *testing.T) {
 			whitelist:  map[string]*citations.WhitelistEntry{"Toth": {ReporterStandard: &tothStd, SingleVol: true}},
 			capCites:   map[string]int64{"1 Toth 123": 777},
 			wantStatus: citations.StatusLinkedCAP,
+			wantTier:   citations.TierCAPDirect,
 			wantCAPID:  ptr(int64(777)),
 			wantLinked: ptr("1 Toth 123"),
 		},
@@ -309,6 +333,7 @@ func TestLinkCitation(t *testing.T) {
 			whitelist:  map[string]*citations.WhitelistEntry{"Cro Eliz": {ReporterStandard: &croStd, UK: true, SingleVol: true}},
 			erCites:    map[string]string{"Cro Eliz 5": "er-cro-5"},
 			wantStatus: citations.StatusLinkedEnglishReports,
+			wantTier:   citations.TierERDirect,
 			wantERID:   ptr("er-cro-5"),
 			wantLinked: ptr("Cro Eliz 5"),
 		},
@@ -321,6 +346,7 @@ func TestLinkCitation(t *testing.T) {
 			whitelist:  map[string]*citations.WhitelistEntry{"Vern": {ReporterStandard: &vernStd, UK: true, SingleVol: true}},
 			erCites:    map[string]string{"1 Vern 12": "er-vern-12"},
 			wantStatus: citations.StatusLinkedEnglishReports,
+			wantTier:   citations.TierERDirect,
 			wantERID:   ptr("er-vern-12"),
 			wantLinked: ptr("1 Vern 12"),
 		},
@@ -333,6 +359,7 @@ func TestLinkCitation(t *testing.T) {
 			freelawCites: map[string]int64{"1 Tothill 123": 555},
 			altAbbrs:     map[string][]string{"Toth": {"Tothill"}},
 			wantStatus:   citations.StatusLinkedCAP,
+			wantTier:     citations.TierCAPFreelawAltSpelling,
 			wantCAPID:    ptr(int64(555)),
 			wantLinked:   ptr("1 Tothill 123"),
 		},
@@ -346,6 +373,7 @@ func TestLinkCitation(t *testing.T) {
 			capCites:   map[string]int64{"1 Toth 123": 888},
 			codeCites:  map[string]int64{"Toth 123": 999},
 			wantStatus: citations.StatusLinkedCodeReporter,
+			wantTier:   citations.TierCodeDirect,
 			wantCodeID: ptr(int64(999)),
 			wantLinked: ptr("Toth 123"),
 		},
@@ -357,6 +385,7 @@ func TestLinkCitation(t *testing.T) {
 			whitelist:  map[string]*citations.WhitelistEntry{"Toth": {ReporterStandard: &tothStd, SingleVol: true}},
 			capCites:   map[string]int64{"Toth 123": 777, "1 Toth 123": 888},
 			wantStatus: citations.StatusNoMatch,
+			wantTier:   citations.TierUSVolumeAbsent,
 			wantLinked: nil,
 		},
 		{
@@ -367,6 +396,7 @@ func TestLinkCitation(t *testing.T) {
 			whitelist:  map[string]*citations.WhitelistEntry{"U.S.": {ReporterStandard: &usStd}},
 			capCites:   map[string]int64{"1 U.S. 10": 111},
 			wantStatus: citations.StatusNoMatch,
+			wantTier:   citations.TierUSVolumeAbsent,
 			wantLinked: nil,
 		},
 		{
@@ -375,6 +405,7 @@ func TestLinkCitation(t *testing.T) {
 			whitelist:  map[string]*citations.WhitelistEntry{"U.S.": {ReporterStandard: &usStd}},
 			capCites:   map[string]int64{"U.S. 10": 111},
 			wantStatus: citations.StatusNoMatch,
+			wantTier:   citations.TierUSVolumeAbsent,
 			wantLinked: nil,
 		},
 		{
@@ -389,15 +420,55 @@ func TestLinkCitation(t *testing.T) {
 			whitelist:  map[string]*citations.WhitelistEntry{"U.S.": {Junk: true}},
 			wantStatus: citations.StatusSkippedJunk,
 		},
+		{
+			// The volume is in CAP and only the page missed, which is the
+			// pin-cite pool #242 is about — the tier is what makes it countable
+			// without a per-reporter query.
+			name:       "reporter and volume present, page missed, is us_page_absent",
+			cite:       citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(5), ReporterAbbr: "U.S.", Page: 10},
+			whitelist:  map[string]*citations.WhitelistEntry{"U.S.": {ReporterStandard: &usStd}},
+			capCites:   map[string]int64{"5 U.S. 11": 111}, // same volume, different page
+			wantStatus: citations.StatusNoMatch,
+			wantTier:   citations.TierUSPageAbsent,
+		},
+		{
+			// A reporter that renumbers in CAP with no diffvols row for the cited
+			// volume: every probe was built on an untranslated volume number, so
+			// this outranks the volume and page tiers even though the probed
+			// volume happens to exist in CAP.
+			name:       "unmapped diffvols volume is us_diffvols_missing",
+			cite:       citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(7), ReporterAbbr: "Stat.", Page: 30},
+			whitelist:  map[string]*citations.WhitelistEntry{"Stat.": {ReporterStandard: &statStd, CAPDifferent: true}},
+			diffvols:   map[string]map[int]*citations.DiffVolEntry{"Stat.": {2: {CAPVol: 81, CAPReporter: "Stat."}}},
+			capCites:   map[string]int64{"7 Stat. 31": 111},
+			wantStatus: citations.StatusNoMatch,
+			wantTier:   citations.TierUSDiffVolsMissing,
+		},
+		{
+			name:       "UK reporter at another volume is uk_volume_absent",
+			cite:       citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(1), ReporterAbbr: "Q.B.", Page: 20},
+			whitelist:  map[string]*citations.WhitelistEntry{"Q.B.": {ReporterStandard: &qbStd, UK: true}},
+			erCites:    map[string]string{"9 Q.B. 20": "er-9"},
+			wantStatus: citations.StatusNoMatch,
+			wantTier:   citations.TierUKVolumeAbsent,
+		},
+		{
+			name:       "UK volume present, page missed, is uk_page_absent",
+			cite:       citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(1), ReporterAbbr: "Q.B.", Page: 20},
+			whitelist:  map[string]*citations.WhitelistEntry{"Q.B.": {ReporterStandard: &qbStd, UK: true}},
+			erCites:    map[string]string{"1 Q.B. 21": "er-1"},
+			wantStatus: citations.StatusNoMatch,
+			wantTier:   citations.TierUKPageAbsent,
+		},
 	}
-
-	diffvols := map[string]map[int]*citations.DiffVolEntry{}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := linkCitation(&tt.cite, tt.whitelist, diffvols, tt.capCites, tt.freelawCites, tt.altAbbrs, tt.codeCites, tt.erCites)
+			tables := newLinkTables(tt.whitelist, tt.diffvols, tt.capCites, tt.freelawCites, tt.altAbbrs, tt.codeCites, tt.erCites)
+			got := linkCitation(&tt.cite, tables)
 
 			assert.Equal(t, tt.wantStatus, got.Status)
+			assert.Equal(t, tt.wantTier, got.MatchTier)
 			assert.Equal(t, tt.cite.ID, got.CitationID)
 
 			if tt.wantCAPID == nil {
@@ -484,8 +555,9 @@ func TestVolumeVariantRecordsDetectedForm(t *testing.T) {
 	c := &citations.UnlinkedCitation{ID: uuid.New(), Volume: nil, ReporterAbbr: "Toth", Page: 123}
 	whitelist := map[string]*citations.WhitelistEntry{"Toth": {ReporterStandard: &std, SingleVol: true}}
 
-	got := linkCitation(c, whitelist, map[string]map[int]*citations.DiffVolEntry{},
+	tables := newLinkTables(whitelist, map[string]map[int]*citations.DiffVolEntry{},
 		map[string]int64{"1 Toth 123": 777}, nil, nil, nil, nil)
+	got := linkCitation(c, tables)
 
 	assert.Equal(t, citations.StatusLinkedCAP, got.Status)
 	if assert.NotNil(t, got.CiteLinked) {

--- a/cite-linker/tiers.go
+++ b/cite-linker/tiers.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/lmullen/legal-modernism/go/citations"
+)
+
+// citeIndex answers two questions about the cite strings in one or more lookup
+// maps: does this reporter spelling appear at all, and does this reporter appear
+// with this volume. That is what lets a failed cascade report how close it got —
+// nothing to match against, wrong volume, or right volume and wrong page — which
+// is otherwise recoverable only by re-deriving the diagnosis with a query per
+// reporter over the whole citation corpus (issue #255).
+//
+// The index is derived from the same maps the cascade probes, by parsing their
+// keys with the same splitCite the probe strings go through, so the two can never
+// disagree about what a reporter or a volume is.
+type citeIndex struct {
+	reporters map[string]struct{}
+	volumes   map[string]struct{}
+}
+
+// newCiteIndex builds an index over the keys of every given map. Several maps
+// share one index when they are probed as a unit: the US cascade tries CAP, the
+// FreeLaw crosswalk, and the code reporter before giving up, so its tier is the
+// closest approach across all three.
+func newCiteIndex[V any](maps ...map[string]V) *citeIndex {
+	ix := &citeIndex{
+		reporters: make(map[string]struct{}),
+		volumes:   make(map[string]struct{}),
+	}
+	for _, m := range maps {
+		for cite := range m {
+			vol, reporter, ok := splitCite(cite)
+			if !ok {
+				continue
+			}
+			ix.reporters[reporter] = struct{}{}
+			ix.volumes[volumeKey(vol, reporter)] = struct{}{}
+		}
+	}
+	return ix
+}
+
+// reached reports whether any of the cite strings probed named a reporter the
+// index knows, and whether any named a reporter-and-volume it knows. A probe
+// string the index cannot parse is ignored rather than counted as a miss.
+func (ix *citeIndex) reached(probes []string) (reporter, volume bool) {
+	for _, p := range probes {
+		vol, rep, ok := splitCite(p)
+		if !ok {
+			continue
+		}
+		if _, found := ix.reporters[rep]; found {
+			reporter = true
+		}
+		if _, found := ix.volumes[volumeKey(vol, rep)]; found {
+			volume = true
+			// The volume implies the reporter, and nothing deeper is recorded, so
+			// there is no reason to keep looking.
+			return true, true
+		}
+	}
+	return reporter, volume
+}
+
+// volumeKey joins a volume and reporter into a map key. The NUL separator cannot
+// occur in either part, so no volume/reporter pair can collide with another.
+func volumeKey(vol, reporter string) string {
+	return vol + "\x00" + reporter
+}
+
+// splitCite splits a cite string of the form "{volume} {reporter} {page}" into
+// its volume and reporter parts, discarding the page; vol is empty for the
+// volume-less form "{reporter} {page}" that single-volume reporters use. ok is
+// false when the string is not a cite at all, which is not hypothetical: the
+// code-reporter map deliberately holds keys like "Cox, Manual Trade-Mark Cas."
+// that no probe will ever match.
+//
+// Volume and page stay strings because they are only ever compared with other
+// cite strings built the same way; parsing them to int would add failure modes
+// for no gain.
+func splitCite(cite string) (vol, reporter string, ok bool) {
+	sp := strings.LastIndexByte(cite, ' ')
+	if sp <= 0 || !allDigits(cite[sp+1:]) {
+		return "", "", false // no page, so not a cite
+	}
+	head := cite[:sp]
+	if v := strings.IndexByte(head, ' '); v > 0 && allDigits(head[:v]) {
+		return head[:v], head[v+1:], true
+	}
+	return "", head, true
+}
+
+// allDigits reports whether s is a non-empty run of ASCII digits.
+func allDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// usTier reports which tier a US cascade that failed to link reached, given
+// every cite string it probed. diffvolsMissing takes precedence over the volume
+// and page tiers: when a reporter renumbers in CAP and no reporters_diffvols row
+// covers the cited volume, every probe was built on a volume number we know to be
+// untranslated, so how far those probes got says nothing about the citation.
+func usTier(probes []string, ix *citeIndex, diffvolsMissing bool) string {
+	reporter, volume := ix.reached(probes)
+	switch {
+	case !reporter:
+		return citations.TierUSReporterAbsent
+	case diffvolsMissing:
+		return citations.TierUSDiffVolsMissing
+	case !volume:
+		return citations.TierUSVolumeAbsent
+	default:
+		return citations.TierUSPageAbsent
+	}
+}
+
+// ukTier reports which tier an English Reports cascade that failed to link
+// reached. There is no diffvols equivalent on this route.
+func ukTier(probes []string, ix *citeIndex) string {
+	reporter, volume := ix.reached(probes)
+	switch {
+	case !reporter:
+		return citations.TierUKReporterAbsent
+	case !volume:
+		return citations.TierUKVolumeAbsent
+	default:
+		return citations.TierUKPageAbsent
+	}
+}

--- a/cite-linker/tiers_test.go
+++ b/cite-linker/tiers_test.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/lmullen/legal-modernism/go/citations"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitCite(t *testing.T) {
+	tests := []struct {
+		name         string
+		cite         string
+		wantVol      string
+		wantReporter string
+		wantOK       bool
+	}{
+		{"volume, reporter, page", "17 Mass. 210", "17", "Mass.", true},
+		{"multi-word reporter", "1 Ves Sen 1", "1", "Ves Sen", true},
+		{"no volume", "Cro Eliz 1", "", "Cro Eliz", true},
+		{"no volume, single-word reporter", "Stat 30", "", "Stat", true},
+		{"multi-digit volume and page", "123 U.S. 4567", "123", "U.S.", true},
+		{
+			// A reporter whose own name starts with something numeric-looking
+			// must not have it read as a volume.
+			name: "leading token that is not all digits is part of the reporter",
+			cite: "2d Cir. 5", wantVol: "", wantReporter: "2d Cir.", wantOK: true,
+		},
+		{
+			// The code-reporter map holds keys like this on purpose; they must not
+			// pollute the reporter set.
+			name: "no page is not a cite",
+			cite: "Cox, Manual Trade-Mark Cas.", wantOK: false,
+		},
+		{"empty string", "", "", "", false},
+		{"page only", "210", "", "", false},
+		{"leading space", " 210", "", "", false},
+		{"trailing space", "17 Mass. ", "", "", false},
+		{"non-numeric page", "17 Mass. cciii", "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vol, reporter, ok := splitCite(tt.cite)
+			assert.Equal(t, tt.wantOK, ok)
+			if !tt.wantOK {
+				return
+			}
+			assert.Equal(t, tt.wantVol, vol, "volume")
+			assert.Equal(t, tt.wantReporter, reporter, "reporter")
+		})
+	}
+}
+
+func TestCiteIndexReached(t *testing.T) {
+	// One index over two maps, the way the US cascade indexes CAP, FreeLaw, and
+	// the code reporter together.
+	ix := newCiteIndex(
+		map[string]int64{"17 Mass. 210": 1, "5 U.S. 10": 2, "Cro Eliz 1": 3},
+		map[string]int64{"9 Q.B. 20": 4, "Cox, Manual Trade-Mark Cas.": 5},
+	)
+
+	tests := []struct {
+		name         string
+		probes       []string
+		wantReporter bool
+		wantVolume   bool
+	}{
+		{"exact hit", []string{"17 Mass. 210"}, true, true},
+		{"same volume, other page", []string{"17 Mass. 999"}, true, true},
+		{"known reporter, unknown volume", []string{"22 Mass. 210"}, true, false},
+		{"unknown reporter", []string{"1 Nonesuch 5"}, false, false},
+		{"volume-less form is its own volume bucket", []string{"Mass. 210"}, true, false},
+		{"volume-less reporter matches only bare", []string{"Cro Eliz 9"}, true, true},
+		{"volume-less reporter under a volume 1", []string{"1 Cro Eliz 9"}, true, false},
+		{"a later probe supplies the volume", []string{"22 Mass. 1", "17 Mass. 1"}, true, true},
+		{"the reporter is found even when no probe has its volume", []string{"22 Mass. 1", "23 Mass. 1"}, true, false},
+		{"second map is indexed too", []string{"9 Q.B. 21"}, true, true},
+		{"unparsable probes are ignored", []string{"Cox, Manual Trade-Mark Cas."}, false, false},
+		{"no probes", nil, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reporter, volume := ix.reached(tt.probes)
+			assert.Equal(t, tt.wantReporter, reporter, "reporter found")
+			assert.Equal(t, tt.wantVolume, volume, "volume found")
+		})
+	}
+}
+
+// TestCiteIndexSkipsUnparsableKeys checks that a map key that is not a cite
+// contributes nothing to either set, so it can never make a reporter look
+// present.
+func TestCiteIndexSkipsUnparsableKeys(t *testing.T) {
+	ix := newCiteIndex(map[string]int64{"Cox, Manual Trade-Mark Cas.": 1, "210": 2, "": 3})
+	assert.Empty(t, ix.reporters)
+	assert.Empty(t, ix.volumes)
+}
+
+func TestUSTier(t *testing.T) {
+	ix := newCiteIndex(map[string]int64{"17 Mass. 210": 1})
+
+	tests := []struct {
+		name            string
+		probes          []string
+		diffvolsMissing bool
+		want            string
+	}{
+		{"unknown reporter", []string{"1 Nonesuch 5"}, false, citations.TierUSReporterAbsent},
+		{"unknown volume", []string{"22 Mass. 5"}, false, citations.TierUSVolumeAbsent},
+		{"known volume, unknown page", []string{"17 Mass. 5"}, false, citations.TierUSPageAbsent},
+		{
+			// The diffvols gap outranks both the volume and page tiers: the probes
+			// were built on a volume number we know to be untranslated, so how
+			// far they got is not evidence about the citation.
+			name:   "diffvols gap outranks the page tier",
+			probes: []string{"17 Mass. 5"}, diffvolsMissing: true,
+			want: citations.TierUSDiffVolsMissing,
+		},
+		{
+			// ...but an absent reporter is more fundamental and still wins.
+			name:   "an absent reporter outranks the diffvols gap",
+			probes: []string{"1 Nonesuch 5"}, diffvolsMissing: true,
+			want: citations.TierUSReporterAbsent,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, usTier(tt.probes, ix, tt.diffvolsMissing))
+		})
+	}
+}
+
+func TestUKTier(t *testing.T) {
+	ix := newCiteIndex(map[string]string{"1 Ves Sen 1": "er-1"})
+
+	assert.Equal(t, citations.TierUKReporterAbsent, ukTier([]string{"1 Nonesuch 5"}, ix))
+	assert.Equal(t, citations.TierUKVolumeAbsent, ukTier([]string{"4 Ves Sen 100"}, ix),
+		"Vesey Junior volumes cited as Vesey Senior are a volume-range miss")
+	assert.Equal(t, citations.TierUKPageAbsent, ukTier([]string{"1 Ves Sen 100"}, ix))
+}
+
+// TestDiffvolsMissing covers the three ways the diffvols check can decline to
+// fire, since a false positive here would mislabel every no_match for the
+// reporter.
+func TestDiffvolsMissing(t *testing.T) {
+	std := "Smith Pa."
+	diffvols := map[string]map[int]*citations.DiffVolEntry{
+		std: {31: {CAPVol: 81, CAPReporter: "Pa."}},
+	}
+	renumbering := &citations.WhitelistEntry{ReporterStandard: &std, CAPDifferent: true}
+	plain := &citations.WhitelistEntry{ReporterStandard: &std}
+
+	cite := func(vol *int) *citations.UnlinkedCitation {
+		return &citations.UnlinkedCitation{ReporterAbbr: "Sm.", Volume: vol, Page: 635}
+	}
+
+	assert.True(t, diffvolsMissing(cite(ptr(7)), renumbering, diffvols),
+		"a renumbering reporter with no row for the cited volume")
+	assert.False(t, diffvolsMissing(cite(ptr(31)), renumbering, diffvols),
+		"the cited volume has a row")
+	assert.False(t, diffvolsMissing(cite(ptr(7)), plain, diffvols),
+		"the reporter does not renumber in CAP")
+	assert.False(t, diffvolsMissing(cite(nil), renumbering, diffvols),
+		"no volume to translate, and buildCAPCite does not consult diffvols either")
+}

--- a/db/migrations/20260729212710_citation-links-match-tier.sql
+++ b/db/migrations/20260729212710_citation-links-match-tier.sql
@@ -1,0 +1,134 @@
+-- migrate:up
+SET ROLE = law_admin;
+
+-- Record how far the cite-linker got with each citation, not just whether it
+-- succeeded (issue #255).
+--
+-- citation_links.status says "no_match" for 20.1M citations without saying which
+-- tier of the cascade was exhausted, so the diagnosis behind #242-#248 had to be
+-- re-derived by query -- roughly 50 seconds per reporter against
+-- citations_unmatched_top, which itself only covers combos occurring 5 or more
+-- times. The linker already knows the answer: by the time it writes no_match it
+-- has probed the CAP, FreeLaw, code-reporter, and English Reports maps, every
+-- alternate spelling, and both volume forms, all in memory.
+--
+-- This is a separate column rather than sub-statuses of no_match because
+-- citations.ResetUnlinked deletes exactly three literal statuses (no_match,
+-- skipped_not_whitelisted, skipped_junk), so a new status would silently escape
+-- --reset, and because every SQL consumer keys on status: the linked% patterns in
+-- linking_dashboard_reporters and normalized_citation_counts, the status =
+-- 'linked_cap' filters in case_citation_counts, and the subtraction in
+-- citation_links_status. A new column is invisible to all of them.
+--
+-- A failure tier is the *closest approach across every target probed*, ordered
+-- reporter_absent < volume_absent < page_absent, so a citation whose reporter is
+-- missing from CAP but present in the code reporter reports the code-reporter
+-- outcome. A single value is honest in a way a separate target column would not
+-- be: a US no_match exhausted CAP and FreeLaw and the code reporter, so naming
+-- one target would be a half-truth. That is why failure tiers carry a route
+-- prefix (us_/uk_) while success tiers, where exactly one target matched, name
+-- the target (cap_/code_/er_). Either way the prefix carries the route, which is
+-- why this needs no uk column and no join to legalhist.reporters.
+--
+-- The column is left NULL for skipped_not_whitelisted and skipped_junk, where
+-- status is already the whole explanation and no cascade ran.
+ALTER TABLE moml_citations.citation_links
+  ADD COLUMN IF NOT EXISTS match_tier text;
+
+-- The allowed set is constrained here because status's is not: it lives only in
+-- the Go constants in go/citations/linker.go, which is what left its vocabulary
+-- ambiguous. This list must stay in step with the Tier constants in that file.
+-- Values are not required to be present (no NOT NULL, no status-conditional
+-- check) so that this applies to the rows already in the table; they populate as
+-- the linker rewrites them.
+--
+-- us_page_ambiguous, us_page_gap, uk_page_ambiguous, uk_page_gap,
+-- cap_page_interior, and er_page_interior are the outcomes of the page-range
+-- matching in #242 and #243, listed now so those issues need no constraint
+-- change. Until they land, a page-level miss is us_page_absent / uk_page_absent.
+ALTER TABLE moml_citations.citation_links
+  DROP CONSTRAINT IF EXISTS chk_citation_links_match_tier;
+ALTER TABLE moml_citations.citation_links
+  ADD CONSTRAINT chk_citation_links_match_tier CHECK (
+    match_tier IS NULL OR match_tier IN (
+      -- no_match, US route (CAP -> FreeLaw -> alternate spellings -> code reporter)
+      'us_reporter_absent',       -- no probed reporter spelling appears in any US source
+      'us_diffvols_missing',      -- renumbers in CAP, but no reporters_diffvols row for this volume
+      'us_volume_absent',         -- reporter present, this volume never appears
+      'us_page_absent',           -- reporter and volume present, page is not a first-page cite
+      'us_page_ambiguous',        -- #242: page falls inside two or more case spans
+      'us_page_gap',              -- #242: page falls inside no case span in a covered volume
+      -- no_match, UK route (English Reports)
+      'uk_reporter_absent',
+      'uk_volume_absent',
+      'uk_page_absent',
+      'uk_page_ambiguous',        -- #243
+      'uk_page_gap',              -- #243
+      -- linked_*: which probe produced the link
+      'cap_direct',               -- cap.citations, under the normalized cite
+      'cap_freelaw',              -- freelaw.cite_to_cap, under the normalized cite
+      'cap_alt_spelling',         -- cap.citations, under a reporters_abbreviations alternate
+      'cap_freelaw_alt_spelling', -- freelaw.cite_to_cap, under an alternate
+      'cap_page_interior',        -- #242: unique containment in a case's page span
+      'code_direct',
+      'code_alt_spelling',
+      'er_direct',
+      'er_page_interior'          -- #243
+    )
+  );
+
+-- Aggregated tiers per reporter. A materialized view because the reporter
+-- breakdown needs the citations_unlinked/whitelist join that makes the
+-- re-derivation expensive in the first place; db/maintenance.sh discovers
+-- materialized views from the system catalogs, so it picks this up without
+-- editing. Junk and non-whitelisted citations are excluded, matching
+-- linking_dashboard_reporters -- the tier only describes citations the linker
+-- actually tried to match -- so the counts here total less than citation_links.
+CREATE MATERIALIZED VIEW IF NOT EXISTS moml_citations.linking_dashboard_tiers AS
+SELECT wl.reporter_standard,
+       cl.status,
+       cl.match_tier,
+       count(*) AS n
+FROM moml_citations.citations_unlinked cu
+  JOIN legalhist.whitelist wl ON cu.reporter_abbr = wl.reporter_found
+  LEFT JOIN moml_citations.citation_links cl ON cl.citation_id = cu.id
+WHERE wl.reporter_standard IS NOT NULL
+  AND wl.junk = false
+GROUP BY wl.reporter_standard, cl.status, cl.match_tier
+WITH NO DATA;
+
+-- NULLS NOT DISTINCT because both status and match_tier are nullable here:
+-- status is NULL for unprocessed citations (the LEFT JOIN) and match_tier is NULL
+-- for every row until the linker populates it. Without it those rows would not
+-- collide and the index would not enforce uniqueness -- which REFRESH
+-- MATERIALIZED VIEW CONCURRENTLY requires.
+CREATE UNIQUE INDEX IF NOT EXISTS linking_dashboard_tiers_uq
+  ON moml_citations.linking_dashboard_tiers (reporter_standard, status, match_tier)
+  NULLS NOT DISTINCT;
+
+-- Corpus-wide rollup. Reads the materialized view rather than citation_links, so
+-- it answers instantly and needs no refresh of its own; it is as stale as the
+-- last db-maintenance run. Query linking_dashboard_tiers directly for the
+-- per-reporter breakdown (which reporters dominate a tier).
+--
+-- A NULL status is a citation with no citation_links row at all, labelled
+-- 'unprocessed' as in citation_links_status. Its tier is NULL for the same
+-- reason: no cascade has run for it yet.
+CREATE OR REPLACE VIEW moml_citations.linking_tier_summary AS
+SELECT COALESCE(status, 'unprocessed') AS status,
+       match_tier,
+       sum(n) AS n,
+       round(100.0 * sum(n) / sum(sum(n)) OVER (PARTITION BY status), 2) AS pct_of_status
+FROM moml_citations.linking_dashboard_tiers
+GROUP BY status, match_tier
+ORDER BY sum(n) DESC;
+
+-- migrate:down
+SET ROLE = law_admin;
+
+DROP VIEW IF EXISTS moml_citations.linking_tier_summary;
+DROP MATERIALIZED VIEW IF EXISTS moml_citations.linking_dashboard_tiers;
+ALTER TABLE moml_citations.citation_links
+  DROP CONSTRAINT IF EXISTS chk_citation_links_match_tier;
+ALTER TABLE moml_citations.citation_links
+  DROP COLUMN IF EXISTS match_tier;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1311,7 +1311,9 @@ CREATE TABLE moml_citations.citation_links (
     cite_cleaned text,
     cite_normalized text,
     cite_linked text,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    match_tier text,
+    CONSTRAINT chk_citation_links_match_tier CHECK (((match_tier IS NULL) OR (match_tier = ANY (ARRAY['us_reporter_absent'::text, 'us_diffvols_missing'::text, 'us_volume_absent'::text, 'us_page_absent'::text, 'us_page_ambiguous'::text, 'us_page_gap'::text, 'uk_reporter_absent'::text, 'uk_volume_absent'::text, 'uk_page_absent'::text, 'uk_page_ambiguous'::text, 'uk_page_gap'::text, 'cap_direct'::text, 'cap_freelaw'::text, 'cap_alt_spelling'::text, 'cap_freelaw_alt_spelling'::text, 'cap_page_interior'::text, 'code_direct'::text, 'code_alt_spelling'::text, 'er_direct'::text, 'er_page_interior'::text]))))
 );
 
 
@@ -1440,6 +1442,37 @@ UNION ALL
    FROM moml_citations.citation_links
   GROUP BY citation_links.status
   WITH NO DATA;
+
+
+--
+-- Name: linking_dashboard_tiers; Type: MATERIALIZED VIEW; Schema: moml_citations; Owner: -
+--
+
+CREATE MATERIALIZED VIEW moml_citations.linking_dashboard_tiers AS
+ SELECT wl.reporter_standard,
+    cl.status,
+    cl.match_tier,
+    count(*) AS n
+   FROM ((moml_citations.citations_unlinked cu
+     JOIN legalhist.whitelist wl ON ((cu.reporter_abbr = wl.reporter_found)))
+     LEFT JOIN moml_citations.citation_links cl ON ((cl.citation_id = cu.id)))
+  WHERE ((wl.reporter_standard IS NOT NULL) AND (wl.junk = false))
+  GROUP BY wl.reporter_standard, cl.status, cl.match_tier
+  WITH NO DATA;
+
+
+--
+-- Name: linking_tier_summary; Type: VIEW; Schema: moml_citations; Owner: -
+--
+
+CREATE VIEW moml_citations.linking_tier_summary AS
+ SELECT COALESCE(status, 'unprocessed'::text) AS status,
+    match_tier,
+    sum(n) AS n,
+    round(((100.0 * sum(n)) / sum(sum(n)) OVER (PARTITION BY linking_dashboard_tiers.status)), 2) AS pct_of_status
+   FROM moml_citations.linking_dashboard_tiers
+  GROUP BY status, match_tier
+  ORDER BY (sum(n)) DESC;
 
 
 --
@@ -2210,6 +2243,13 @@ CREATE UNIQUE INDEX linking_dashboard_summary_uq ON moml_citations.linking_dashb
 
 
 --
+-- Name: linking_dashboard_tiers_uq; Type: INDEX; Schema: moml_citations; Owner: -
+--
+
+CREATE UNIQUE INDEX linking_dashboard_tiers_uq ON moml_citations.linking_dashboard_tiers USING btree (reporter_standard, status, match_tier) NULLS NOT DISTINCT;
+
+
+--
 -- Name: normalized_citation_counts_count_idx; Type: INDEX; Schema: moml_citations; Owner: -
 --
 
@@ -2561,4 +2601,6 @@ INSERT INTO sys_admin.migrations_dbmate (version) VALUES
     ('20260727212625'),
     ('20260728162040'),
     ('20260728174121'),
-    ('20260729133619');
+    ('20260729133619'),
+    ('20260729191037'),
+    ('20260729212710');

--- a/go/citations/linker.go
+++ b/go/citations/linker.go
@@ -39,6 +39,7 @@ type UnlinkedCitation struct {
 type LinkResult struct {
 	CitationID     uuid.UUID
 	Status         string
+	MatchTier      string // how far the cascade got, see the Tier constants; "" (SQL NULL) for skipped
 	CAPCaseID      *int64
 	CodeReporterID *int64
 	ERCaseID       *string
@@ -55,4 +56,41 @@ const (
 	StatusSkippedNotWhitelisted = "skipped_not_whitelisted"
 	StatusSkippedJunk           = "skipped_junk"
 	StatusNoMatch               = "no_match"
+)
+
+// Tier constants for LinkResult.MatchTier: how far the linking cascade got with
+// a citation. Status says whether a citation linked; the tier says why it did
+// not, or which probe succeeded when it did. Without it the 20M no_match rows
+// are undifferentiated and the reason has to be re-derived by query.
+//
+// The failure tiers carry a route prefix (us_/uk_) rather than a target prefix
+// because a failure exhausts the whole cascade: a US no_match missed CAP and the
+// FreeLaw crosswalk and the code reporter, so naming any one target would be a
+// half-truth. They report the closest approach across every target probed,
+// ordered reporter_absent (nothing to match against) through page_absent (right
+// reporter, right volume, wrong page — the pin-cite pool). The success tiers name
+// the target that produced the link, since exactly one did.
+//
+// The values are constrained in SQL by chk_citation_links_match_tier; adding one
+// here needs a migration to widen that constraint.
+const (
+	// no_match, US route (CAP -> FreeLaw -> alternate spellings -> code reporter).
+	TierUSReporterAbsent  = "us_reporter_absent"  // no probed reporter spelling appears in any US source
+	TierUSDiffVolsMissing = "us_diffvols_missing" // reporter renumbers in CAP, but no reporters_diffvols row covers this volume
+	TierUSVolumeAbsent    = "us_volume_absent"    // reporter present, this volume never appears
+	TierUSPageAbsent      = "us_page_absent"      // reporter and volume present, page is not a first-page cite
+
+	// no_match, UK route (English Reports).
+	TierUKReporterAbsent = "uk_reporter_absent"
+	TierUKVolumeAbsent   = "uk_volume_absent"
+	TierUKPageAbsent     = "uk_page_absent"
+
+	// linked_*: which probe produced the link.
+	TierCAPDirect             = "cap_direct"               // cap.citations, under the normalized cite
+	TierCAPFreelaw            = "cap_freelaw"              // freelaw.cite_to_cap, under the normalized cite
+	TierCAPAltSpelling        = "cap_alt_spelling"         // cap.citations, under a reporters_abbreviations alternate
+	TierCAPFreelawAltSpelling = "cap_freelaw_alt_spelling" // freelaw.cite_to_cap, under an alternate
+	TierCodeDirect            = "code_direct"              // legalhist.code_reporter, under the cleaned cite
+	TierCodeAltSpelling       = "code_alt_spelling"        // legalhist.code_reporter, under an alternate
+	TierERDirect              = "er_direct"                // english_reports.cases
 )

--- a/go/citations/linker_store_db.go
+++ b/go/citations/linker_store_db.go
@@ -321,13 +321,17 @@ func (s *LinkerDBStore) LoadEnglishReportsCitations(ctx context.Context) (map[st
 
 // SaveLinkResults batch-inserts multiple link results in a single statement.
 //
-// Rather than build a VALUES list with up to batchSize*8 placeholders (which
+// Rather than build a VALUES list with up to batchSize*9 placeholders (which
 // runs into Postgres's 65535-parameter limit at large batch sizes and forces
 // the server to parse a huge statement on every batch), it passes one array per
-// column and expands them server-side with unnest(). That is a fixed 8-parameter
+// column and expands them server-side with unnest(). That is a fixed 9-parameter
 // statement regardless of batch size, so it parses/plans cheaply and keeps the
 // wire payload compact. citation_id is sent as text[] and cast to uuid in SQL to
 // avoid relying on driver-side uuid-array encoding.
+//
+// An empty MatchTier is sent as SQL NULL: the skip statuses reach no tier, and a
+// NULL keeps them out of every tier aggregate instead of inventing a bucket for
+// them.
 func (s *LinkerDBStore) SaveLinkResults(ctx context.Context, results []*LinkResult) error {
 	if len(results) == 0 {
 		return nil
@@ -335,6 +339,7 @@ func (s *LinkerDBStore) SaveLinkResults(ctx context.Context, results []*LinkResu
 
 	ids := make([]string, len(results))
 	statuses := make([]string, len(results))
+	tiers := make([]*string, len(results))
 	capIDs := make([]*int64, len(results))
 	codeIDs := make([]*int64, len(results))
 	erIDs := make([]*string, len(results))
@@ -344,6 +349,9 @@ func (s *LinkerDBStore) SaveLinkResults(ctx context.Context, results []*LinkResu
 	for i, r := range results {
 		ids[i] = r.CitationID.String()
 		statuses[i] = r.Status
+		if r.MatchTier != "" {
+			tiers[i] = &r.MatchTier
+		}
 		capIDs[i] = r.CAPCaseID
 		codeIDs[i] = r.CodeReporterID
 		erIDs[i] = r.ERCaseID
@@ -354,13 +362,13 @@ func (s *LinkerDBStore) SaveLinkResults(ctx context.Context, results []*LinkResu
 
 	query := `
 	INSERT INTO moml_citations.citation_links
-		(citation_id, status, cap_case_id, code_reporter_id, er_case_id, cite_cleaned, cite_normalized, cite_linked)
-	SELECT u.citation_id::uuid, u.status, u.cap_case_id, u.code_reporter_id, u.er_case_id, u.cite_cleaned, u.cite_normalized, u.cite_linked
-	FROM unnest($1::text[], $2::text[], $3::bigint[], $4::bigint[], $5::text[], $6::text[], $7::text[], $8::text[])
-		AS u(citation_id, status, cap_case_id, code_reporter_id, er_case_id, cite_cleaned, cite_normalized, cite_linked)
+		(citation_id, status, match_tier, cap_case_id, code_reporter_id, er_case_id, cite_cleaned, cite_normalized, cite_linked)
+	SELECT u.citation_id::uuid, u.status, u.match_tier, u.cap_case_id, u.code_reporter_id, u.er_case_id, u.cite_cleaned, u.cite_normalized, u.cite_linked
+	FROM unnest($1::text[], $2::text[], $3::text[], $4::bigint[], $5::bigint[], $6::text[], $7::text[], $8::text[], $9::text[])
+		AS u(citation_id, status, match_tier, cap_case_id, code_reporter_id, er_case_id, cite_cleaned, cite_normalized, cite_linked)
 	ON CONFLICT (citation_id) DO NOTHING`
 
-	_, err := s.DB.Exec(ctx, query, ids, statuses, capIDs, codeIDs, erIDs, cleaned, normalized, linked)
+	_, err := s.DB.Exec(ctx, query, ids, statuses, tiers, capIDs, codeIDs, erIDs, cleaned, normalized, linked)
 	if err != nil {
 		return fmt.Errorf("batch saving %d link results: %w", len(results), err)
 	}

--- a/go/citations/linker_store_db_integration_test.go
+++ b/go/citations/linker_store_db_integration_test.go
@@ -50,6 +50,7 @@ func newTestStore(t *testing.T) *LinkerDBStore {
 		`CREATE TABLE moml_citations.citation_links (
 			citation_id uuid PRIMARY KEY,
 			status text NOT NULL,
+			match_tier text,
 			cap_case_id bigint,
 			code_reporter_id bigint,
 			er_case_id text,
@@ -197,18 +198,19 @@ func TestSaveLinkResultsIntegration(t *testing.T) {
 
 	results := []*LinkResult{
 		// A CAP link: cap_case_id set, the rest of the case IDs nil.
-		{CitationID: idCAP, Status: StatusLinkedCAP, CAPCaseID: &capID,
+		{CitationID: idCAP, Status: StatusLinkedCAP, MatchTier: TierCAPDirect, CAPCaseID: &capID,
 			CiteCleaned: &cleaned, CiteNormalized: &normalized, CiteLinked: &linked},
 		// A code-reporter link.
-		{CitationID: idCode, Status: StatusLinkedCodeReporter, CodeReporterID: &codeID,
+		{CitationID: idCode, Status: StatusLinkedCodeReporter, MatchTier: TierCodeDirect, CodeReporterID: &codeID,
 			CiteCleaned: &cleaned, CiteNormalized: &normalized, CiteLinked: &linked},
 		// An English Reports link (text id).
-		{CitationID: idER, Status: StatusLinkedEnglishReports, ERCaseID: &erID,
+		{CitationID: idER, Status: StatusLinkedEnglishReports, MatchTier: TierERDirect, ERCaseID: &erID,
 			CiteCleaned: &cleaned, CiteNormalized: &normalized, CiteLinked: &linked},
-		// no_match: cite_cleaned/normalized set, everything else nil.
-		{CitationID: idNoMatch, Status: StatusNoMatch,
+		// no_match: cite_cleaned/normalized and the tier set, everything else nil.
+		{CitationID: idNoMatch, Status: StatusNoMatch, MatchTier: TierUSPageAbsent,
 			CiteCleaned: &cleaned, CiteNormalized: &normalized},
-		// skipped: all nullable columns nil. Exercises NULL encoding in every array.
+		// skipped: all nullable columns nil, including an empty MatchTier that has
+		// to arrive as SQL NULL. Exercises NULL encoding in every array.
 		{CitationID: idSkipped, Status: StatusSkippedNotWhitelisted},
 	}
 
@@ -217,21 +219,24 @@ func TestSaveLinkResultsIntegration(t *testing.T) {
 	// Read each row back and verify the values (and the NULLs) round-tripped.
 	type row struct {
 		status                          string
+		tier                            *string
 		capCaseID, codeReporterID       *int64
 		erCaseID, cleaned, norm, linked *string
 	}
 	read := func(id uuid.UUID) row {
 		var r row
 		err := s.DB.QueryRow(ctx,
-			`SELECT status, cap_case_id, code_reporter_id, er_case_id, cite_cleaned, cite_normalized, cite_linked
+			`SELECT status, match_tier, cap_case_id, code_reporter_id, er_case_id, cite_cleaned, cite_normalized, cite_linked
 			 FROM moml_citations.citation_links WHERE citation_id = $1`, id).
-			Scan(&r.status, &r.capCaseID, &r.codeReporterID, &r.erCaseID, &r.cleaned, &r.norm, &r.linked)
+			Scan(&r.status, &r.tier, &r.capCaseID, &r.codeReporterID, &r.erCaseID, &r.cleaned, &r.norm, &r.linked)
 		require.NoError(t, err)
 		return r
 	}
 
 	cap := read(idCAP)
 	assert.Equal(t, StatusLinkedCAP, cap.status)
+	require.NotNil(t, cap.tier)
+	assert.Equal(t, TierCAPDirect, *cap.tier)
 	require.NotNil(t, cap.capCaseID)
 	assert.Equal(t, capID, *cap.capCaseID)
 	assert.Nil(t, cap.codeReporterID)
@@ -241,18 +246,24 @@ func TestSaveLinkResultsIntegration(t *testing.T) {
 
 	code := read(idCode)
 	assert.Equal(t, StatusLinkedCodeReporter, code.status)
+	require.NotNil(t, code.tier)
+	assert.Equal(t, TierCodeDirect, *code.tier)
 	require.NotNil(t, code.codeReporterID)
 	assert.Equal(t, codeID, *code.codeReporterID)
 	assert.Nil(t, code.capCaseID)
 
 	er := read(idER)
 	assert.Equal(t, StatusLinkedEnglishReports, er.status)
+	require.NotNil(t, er.tier)
+	assert.Equal(t, TierERDirect, *er.tier)
 	require.NotNil(t, er.erCaseID)
 	assert.Equal(t, erID, *er.erCaseID)
 	assert.Nil(t, er.capCaseID)
 
 	nm := read(idNoMatch)
 	assert.Equal(t, StatusNoMatch, nm.status)
+	require.NotNil(t, nm.tier)
+	assert.Equal(t, TierUSPageAbsent, *nm.tier)
 	assert.Nil(t, nm.capCaseID)
 	require.NotNil(t, nm.cleaned)
 	assert.Equal(t, cleaned, *nm.cleaned)
@@ -260,6 +271,7 @@ func TestSaveLinkResultsIntegration(t *testing.T) {
 
 	sk := read(idSkipped)
 	assert.Equal(t, StatusSkippedNotWhitelisted, sk.status)
+	assert.Nil(t, sk.tier, "an empty MatchTier must be stored as NULL, not as an empty string")
 	assert.Nil(t, sk.capCaseID)
 	assert.Nil(t, sk.codeReporterID)
 	assert.Nil(t, sk.erCaseID)

--- a/go/citations/linker_tier_constraint_test.go
+++ b/go/citations/linker_tier_constraint_test.go
@@ -1,0 +1,84 @@
+package citations
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestMatchTierConstantsAreAllowedBySQL guards the one way the tier column can
+// fail in production: chk_citation_links_match_tier rejects a value the linker
+// emits, which aborts the whole insert batch rather than one row. The tier names
+// live in two places by necessity — Go writes them, SQL constrains them — so this
+// reads every Tier* constant straight out of the source (no hand-maintained list
+// to drift) and requires each one to appear in some migration.
+func TestMatchTierConstantsAreAllowedBySQL(t *testing.T) {
+	tiers := tierConstants(t)
+	require.NotEmpty(t, tiers, "found no Tier* constants; has the naming changed?")
+
+	migrations, err := filepath.Glob(filepath.Join("..", "..", "db", "migrations", "*.sql"))
+	require.NoError(t, err)
+	require.NotEmpty(t, migrations, "found no migrations to check against")
+
+	// Every migration is searched, not just the one that adds the constraint, so
+	// that widening it later in its own migration also satisfies this.
+	var sql strings.Builder
+	for _, m := range migrations {
+		b, err := os.ReadFile(m)
+		require.NoError(t, err)
+		sql.Write(b)
+	}
+	all := sql.String()
+
+	for name, value := range tiers {
+		require.Contains(t, all, "'"+value+"'",
+			"%s = %q is not allowed by any migration; widen chk_citation_links_match_tier", name, value)
+	}
+}
+
+// tierConstants returns every Tier*-named string constant declared in this
+// package, keyed by constant name.
+func tierConstants(t *testing.T) map[string]string {
+	t.Helper()
+
+	pkgs, err := parser.ParseDir(token.NewFileSet(), ".", nil, 0)
+	require.NoError(t, err)
+
+	tiers := make(map[string]string)
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			for _, decl := range file.Decls {
+				gen, ok := decl.(*ast.GenDecl)
+				if !ok || gen.Tok != token.CONST {
+					continue
+				}
+				for _, spec := range gen.Specs {
+					vs, ok := spec.(*ast.ValueSpec)
+					if !ok {
+						continue
+					}
+					for i, ident := range vs.Names {
+						if !strings.HasPrefix(ident.Name, "Tier") || i >= len(vs.Values) {
+							continue
+						}
+						lit, ok := vs.Values[i].(*ast.BasicLit)
+						if !ok || lit.Kind != token.STRING {
+							continue
+						}
+						value, err := strconv.Unquote(lit.Value)
+						require.NoError(t, err)
+						tiers[ident.Name] = value
+					}
+				}
+			}
+		}
+	}
+	return tiers
+}


### PR DESCRIPTION
Closes #255. Part of #165.

`citation_links.status` says whether a citation linked, never why it did not. So the diagnosis behind #242–#248 had to be re-derived by query — about **50 seconds per reporter** against `citations_unmatched_top`, which itself only covers combos occurring five or more times, and which has to be refreshed first. The linker already knows the answer: by the time it writes `no_match` it has probed CAP, the FreeLaw crosswalk, every alternate spelling, and the code reporter, all in memory.

This adds `moml_citations.citation_links.match_tier`, populated at every exit from the cascade, plus the views to aggregate it.

## The values

A **failure** records the closest approach across every target probed, ordered `reporter_absent` (nothing to match against) through `page_absent` (right reporter, right volume, wrong page — the pin-cite pool):

| tier | meaning | pool it names |
|---|---|---|
| `us_reporter_absent` | no probed reporter spelling appears in any US source | #248, the 207 zero-link reporters (5.30M cites) |
| `us_diffvols_missing` | renumbers in CAP, no `reporters_diffvols` row for this volume | #246, the Pa. nominates |
| `us_volume_absent` | reporter present, this volume never appears | #244, the misrouting signature |
| `us_page_absent` | reporter and volume present, page is not a first-page cite | #242, the largest US bucket |
| `uk_reporter_absent` / `uk_volume_absent` / `uk_page_absent` | same three, English Reports | #244 (≥378K for Ves Sen alone), #243 |

A **link** records which probe produced it — `cap_direct`, `cap_freelaw`, `cap_alt_spelling`, `cap_freelaw_alt_spelling`, `code_direct`, `code_alt_spelling`, `er_direct`. Beyond what #255 asked for, but free at write time, and the only way to see the yield of the alternate-spelling probing from #250 without diffing whole runs.

The failure tiers carry a route prefix (`us_`/`uk_`) rather than a target prefix because a failure exhausts the whole cascade: a US `no_match` missed CAP *and* FreeLaw *and* the code reporter, so naming any one target would be a half-truth. Success tiers name the target, since exactly one matched. `us_page_ambiguous`, `us_page_gap`, `cap_page_interior` and the `uk_`/`er_` equivalents are already allowed by the CHECK so #242 and #243 need no constraint change.

## Why a column, not sub-statuses of `no_match`

- `ResetUnlinked` deletes three *literal* statuses, so a new status would silently escape `--reset`.
- Every SQL consumer keys on `status`: the `linked%` patterns in `linking_dashboard_reporters` and `normalized_citation_counts`, the equality filters in `case_citation_counts`, the subtraction in `citation_links_status`. A column is invisible to all of them.
- The allowed set is constrained in SQL (`chk_citation_links_match_tier`), which `status` never was — its vocabulary lives only in Go constants, and that is what left it ambiguous.

## How the tier is derived

`cite-linker/tiers.go` adds a `citeIndex` over the same maps the cascade probes, keyed by reporter and by reporter+volume, built once at startup (62K reporter+volume pairs for CAP, so a few MB; startup logs the sizes). The cascade collects the cite strings it actually probed and the tier is derived from those, so there is no second, drifting implementation of which forms get tried.

`linkCitation` took eight map arguments and needed two more, so the maps and indexes are now one `linkTables` struct built in `main()`.

## Views

- `moml_citations.linking_dashboard_tiers` — per reporter, materialized because the reporter breakdown needs the `citations_unlinked`/`whitelist` join that makes re-derivation expensive. `db/maintenance.sh` discovers materialized views from the catalogs, so it needs no editing.
- `moml_citations.linking_tier_summary` — corpus-wide rollup over the matview, so it answers instantly. `select * from moml_citations.linking_tier_summary;` is the whole #242–#248 diagnosis.

Both exclude junk and non-whitelisted citations, matching `linking_dashboard_reporters`, so their totals sit below `citation_links`: the tier only describes citations the linker actually tried to match.

## Verification

Beyond the unit tests, against a throwaway Postgres 17:

- The migration applies, is idempotent on a second `up`, and its `down` leaves zero objects, no column, and no constraint; `up` works again afterwards.
- The CHECK rejects an unknown tier; `REFRESH MATERIALIZED VIEW CONCURRENTLY` works, so the `NULLS NOT DISTINCT` unique index does its job.
- Both views produce correct output on seeded rows, including a junk reporter excluded and an unprocessed citation surfacing as `unprocessed`.
- `SaveLinkResults` round-trips through the real 9-array `unnest` insert, including the empty-tier → SQL NULL case.

`go/citations/linker_tier_constraint_test.go` reads every `Tier*` constant out of the source with `go/ast` — no hand-maintained list to drift — and requires each to be allowed by some migration. A mismatch there would abort whole insert batches at runtime rather than failing one row. Confirmed it catches drift by breaking a value and watching it fail.

## Notes for the reviewer

- The migration is **already applied** to the live database, and `db/schema.sql` is regenerated. #254 merged while this branch was in flight; main is merged in here, and the only conflict was the dbmate version list at the end of the dump — main recorded `20260729191037`, this branch recorded `20260729212710`, both are applied so both rows stay. #254 changed no DDL, so the rest merged cleanly. Every version recorded in `schema.sql` now has a migration file on this branch.
- Existing rows keep `match_tier` NULL until the linker rewrites them — the column is nullable with no default, so applying it was instant on the 62.5M-row table.
- `chambers` still reads only `linking_dashboard_summary`/`_reporters`; surfacing tiers in the dashboard is separate work.
- Related: [a caveat on #242](https://github.com/chnm/legal-modernism/issues/242#issuecomment-5125258088) — `cap.cases.first_page`/`last_page` are in a different pagination from the citation for the early Mass. and Johns. volumes, so the page-range matcher needs its intervals built from `cap.citations` cite pages instead. Worth reading before `us_page_absent` gets acted on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
