### PR TITLE
slurm: right-size cite-linker to its measured usage

### DIFF
--- a/slurm/cite-linker.sh
+++ b/slurm/cite-linker.sh
@@ -2,14 +2,24 @@
 
 # Run the citation linker to link detected citations to cases
 
+# Resources are sized for the routine run below, from job 9215377: 8m12s wall,
+# 7m37s of CPU time (0.93 cores average), 2.6GB peak RAM. The work waits on the
+# database, not on cores, and --workers is a count of DB connections rather than
+# threads, so 4 cores still carries 32 concurrent queries. Memory is bounded and
+# nearly independent of how many citations are pending: the lookup tables are the
+# bulk of it, and the streaming reader keeps only --workers batches in flight.
+# A routine run that does hit the wall time is safe to resubmit, so the time
+# limit is a short-queue optimization, not a cliff. Raise --mem if the CAP or
+# FreeLaw tables grow enough to push peak RAM past ~4GB.
+
 #SBATCH --job-name=cite-linker
 #SBATCH --output=/scratch/%u/logs/%j-%x-%N.out
 #SBATCH --error=/scratch/%u/logs/%j-%x-%N.log
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
-#SBATCH --cpus-per-task=24
-#SBATCH --time=06:00:00
-#SBATCH --mem=12GB
+#SBATCH --cpus-per-task=4
+#SBATCH --time=01:00:00
+#SBATCH --mem=6GB
 #SBATCH --partition=normal
 #SBATCH --mail-user lmullen@gmu.edu
 #SBATCH --mail-type BEGIN
@@ -33,4 +43,14 @@
 # re-linked; only linked_* rows are kept. Re-comment it afterward — leaving
 # --reset live would wipe and re-do those rows on every subsequent run, including
 # on a resubmit after a timeout, throwing away all partial progress.
+#
+# Submit this path with a longer wall time than the directive above:
+#
+#     sbatch --time=06:00:00 slurm/cite-linker.sh
+#
+# It re-processes tens of millions of rows through the per-citation path rather
+# than the handful a routine run sees, and it is the one case where a timeout is
+# expensive: because --reset starts by deleting, a resubmit restarts from scratch
+# instead of resuming. Cores and memory need no override — neither scales with the
+# row count.
 # ~/legal-modernism/bin/cite-linker --reset --batch-size=8000 --workers=32 --lock-timeout=1m


### PR DESCRIPTION
Job `9215377` finished in **8m12s** using **7m37s of CPU time** (0.93 cores average) and **2.6GB** of RAM, against a request of 24 cores, 12GB, and six hours. The linker waits on Postgres, not on cores, so the request was paying for parallelism it cannot use.

| Directive | Was | Now | Measured |
|---|---|---|---|
| `--cpus-per-task` | 24 | 4 | 0.93 cores average |
| `--mem` | 12GB | 6GB | 2.6GB peak |
| `--time` | 06:00:00 | 01:00:00 | 8m12s |

**Cores.** The 4% utilization is real rather than a measurement artifact. Note that `--workers=32` counts DB connections (the pool is sized `workers+2`), not threads, so the smaller core count does not reduce linking concurrency — 32 I/O-blocked goroutines multiplex fine over 4 procs.

**Memory.** Safe to cut because peak RAM is nearly independent of how many citations are pending: the pre-loaded lookup tables (CAP cites, FreeLaw crosswalk, English Reports, code cites) are the bulk of it, and the streaming reader from #221 keeps only `--workers` batches in flight rather than buffering the 62M-row table. 6GB leaves ~2.3x headroom for corpus growth.

**Wall time — the one value not taken from the 8-minute measurement.** This script serves two workloads, and sizing the directive to the incremental run alone would set a trap for the other. The six hours existed for the `--reset` path, which re-processes tens of millions of rows through the per-citation path after 4103d92 removed the bulk pre-pass, and where a timeout is genuinely expensive: `--reset` begins by deleting, so a resubmit restarts from scratch instead of resuming. Rather than size the directive for the rare destructive run, the directive now fits the routine run — where a timeout costs nothing, since batches commit as they go — and the reset block documents `sbatch --time=06:00:00 slurm/cite-linker.sh` to override it.

The added comments also record where these numbers came from, so the next re-sizing starts from evidence instead of guesswork.

## Testing

Not submitted to hopper — I can't reach the scheduler, so the numbers are right-sized from the reported job stats rather than confirmed by a run. `bash -n` passes and the directives/comments are the only change.

One thing to watch after merge: if routine runs start creeping past ~30 minutes as the corpus grows, raise the 1h limit rather than relying on resubmits to catch up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)