### PR TITLE
cite-linker: link pin cites by page-range matching

### DIFF
--- a/cite-linker/main.go
+++ b/cite-linker/main.go
@@ -184,13 +184,48 @@ func main() {
 	}
 	slog.Info("loaded English Reports citations", "entries", len(erCites))
 
+	slog.Info("loading CAP case page spans")
+	capSpans, err := store.LoadCAPCaseSpans(ctx)
+	if err != nil {
+		exitStartupError("could not load CAP case page spans", err)
+	}
+	slog.Info("loaded CAP case page spans", "entries", len(capSpans))
+
+	slog.Info("loading English Reports case page spans")
+	erSpans, err := store.LoadERCaseSpans(ctx)
+	if err != nil {
+		exitStartupError("could not load English Reports case page spans", err)
+	}
+	slog.Info("loaded English Reports case page spans", "entries", len(erSpans))
+
 	// Assemble the lookup tables, which also walks every loaded cite string once
-	// to build the reporter/volume indexes a no_match is attributed with.
+	// to build the reporter/volume indexes a no_match is attributed with, and the
+	// page-range indexes that resolve pin cites.
 	slog.Info("indexing cite strings by reporter and volume")
-	tables := newLinkTables(whitelist, diffvols, capCites, freelawCites, altAbbrs, codeCites, erCites)
+	tables := newLinkTables(whitelist, diffvols, capCites, freelawCites, altAbbrs, codeCites, erCites, capSpans, erSpans)
 	slog.Info("indexed cite strings",
 		"us_reporters", len(tables.us.reporters), "us_volumes", len(tables.us.volumes),
 		"uk_reporters", len(tables.uk.reporters), "uk_volumes", len(tables.uk.volumes))
+
+	// The span arrays are large and fully consumed by the indexes; drop the
+	// references so the 7M-element CAP slice can be collected before linking
+	// starts rather than sitting alongside the maps for the whole run.
+	capSpans, erSpans = nil, nil
+
+	capVols, capSpanCount := tables.capRanges.size()
+	erVols, erSpanCount := tables.erRanges.size()
+	slog.Info("indexed case page spans",
+		"cap_volumes", capVols, "cap_spans", capSpanCount,
+		"er_volumes", erVols, "er_spans", erSpanCount)
+
+	// A malformed span index mislinks silently and at scale, so verify the
+	// invariant that has to hold by construction before any citation is linked.
+	if err := tables.capRanges.checkSelfConsistency(); err != nil {
+		exitStartupError("page span index is inconsistent", err, "index", "cap")
+	}
+	if err := tables.erRanges.checkSelfConsistency(); err != nil {
+		exitStartupError("page span index is inconsistent", err, "index", "er")
+	}
 
 	// Bounded pipeline. A single streaming reader (this goroutine, inside
 	// StreamUnprocessedCitations) feeds batches to a fixed pool of insert
@@ -362,6 +397,12 @@ type linkTables struct {
 	// it happens here rather than per citation.
 	us *citeIndex
 	uk *citeIndex
+
+	// capRanges and erRanges resolve pin cites — citations to an interior page of
+	// a case — after the exact cascade has missed. Either may be nil, in which
+	// case range matching is simply skipped.
+	capRanges *rangeIndex[int64]
+	erRanges  *rangeIndex[string]
 }
 
 func newLinkTables(
@@ -372,6 +413,8 @@ func newLinkTables(
 	altAbbrs map[string][]string,
 	codeCites map[string]int64,
 	erCites map[string]string,
+	capSpans []citations.CaseSpan[int64],
+	erSpans []citations.CaseSpan[string],
 ) *linkTables {
 	return &linkTables{
 		whitelist:    whitelist,
@@ -383,6 +426,8 @@ func newLinkTables(
 		erCites:      erCites,
 		us:           newCiteIndex(capCites, freelawCites, codeCites),
 		uk:           newCiteIndex(erCites),
+		capRanges:    newRangeIndex(capSpans),
+		erRanges:     newRangeIndex(erSpans),
 	}
 }
 
@@ -517,8 +562,43 @@ func linkCAPThenCode(
 		}
 	}
 
+	// Every exact form missed. Before giving up, try page-range matching: the
+	// citation may be a pin cite to an interior page of a case, which no
+	// first-page cite string can ever equal. This runs last so it can only turn a
+	// no_match into a link, never rewire one the exact cascade already made.
+	//
+	// Skipped when diffvols is missing, for the same reason usTier reports that
+	// tier ahead of the volume and page ones: the reporter renumbers in CAP and no
+	// reporters_diffvols row covers this volume, so every probe carries a volume
+	// number known to be untranslated. An exact miss on such a probe is harmless,
+	// but a range hit is not — the wrong volume of the right reporter is densely
+	// populated, so containment would confidently return a case from it. Measured
+	// over the current no_match pool this suppresses 45,077 otherwise-plausible
+	// links that would all have been fabricated.
+	missingDiffvols := diffvolsMissing(c, entry, t.diffvols)
+	if t.capRanges != nil && !missingDiffvols {
+		switch caseID, outcome := t.capRanges.probe(probes); outcome {
+		case rangeHit:
+			result.Status = citations.StatusLinkedCAP
+			result.MatchTier = citations.TierCAPPageInterior
+			result.CAPCaseID = &caseID
+			// No cite string matched, so there is nothing to record as the cite
+			// that linked; CiteLinked stays nil and the tier is what identifies
+			// how this row was made.
+			return result
+		case rangeAmbiguous:
+			result.Status = citations.StatusNoMatch
+			result.MatchTier = citations.TierUSPageAmbiguous
+			return result
+		case rangeGap:
+			result.Status = citations.StatusNoMatch
+			result.MatchTier = citations.TierUSPageGap
+			return result
+		}
+	}
+
 	result.Status = citations.StatusNoMatch
-	result.MatchTier = usTier(probes, t.us, diffvolsMissing(c, entry, t.diffvols))
+	result.MatchTier = usTier(probes, t.us, missingDiffvols)
 	return result
 }
 
@@ -561,6 +641,27 @@ func linkEnglishReports(
 			result.MatchTier = citations.TierERDirect
 			result.ERCaseID = &erID
 			result.CiteLinked = &cite
+			return result
+		}
+	}
+
+	// As on the US route, fall back to page-range matching for pin cites. The
+	// English Reports record no page ranges of their own, so spans here are
+	// bounded only by the next cite and maxSpanPages.
+	if t.erRanges != nil {
+		switch erID, outcome := t.erRanges.probe(probes); outcome {
+		case rangeHit:
+			result.Status = citations.StatusLinkedEnglishReports
+			result.MatchTier = citations.TierERPageInterior
+			result.ERCaseID = &erID
+			return result
+		case rangeAmbiguous:
+			result.Status = citations.StatusNoMatch
+			result.MatchTier = citations.TierUKPageAmbiguous
+			return result
+		case rangeGap:
+			result.Status = citations.StatusNoMatch
+			result.MatchTier = citations.TierUKPageGap
 			return result
 		}
 	}

--- a/cite-linker/main_test.go
+++ b/cite-linker/main_test.go
@@ -19,6 +19,7 @@ func TestLinkCitation(t *testing.T) {
 	qbStd := "Q.B."
 	statStd := "Stat."
 	tothStd := "Toth"
+	massStd := "Mass."
 	croStd := "Cro Eliz"
 	vernStd := "Vern"
 	alaStd := "Ala."
@@ -34,6 +35,8 @@ func TestLinkCitation(t *testing.T) {
 		altAbbrs     map[string][]string
 		codeCites    map[string]int64
 		erCites      map[string]string
+		capSpans     []citations.CaseSpan[int64]
+		erSpans      []citations.CaseSpan[string]
 		wantStatus   string
 		wantTier     string
 		wantCAPID    *int64
@@ -460,11 +463,119 @@ func TestLinkCitation(t *testing.T) {
 			wantStatus: citations.StatusNoMatch,
 			wantTier:   citations.TierUKPageAbsent,
 		},
+		{
+			// The whole point of #242: a citation to an interior page of a case,
+			// which no first-page cite string can ever equal.
+			name:       "CAP pin cite links by page range",
+			cite:       citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(17), ReporterAbbr: "Mass.", Page: 479},
+			whitelist:  map[string]*citations.WhitelistEntry{"Mass.": {ReporterStandard: &massStd}},
+			capCites:   map[string]int64{"17 Mass. 478": 478, "17 Mass. 591": 591},
+			capSpans:   span17Mass,
+			wantStatus: citations.StatusLinkedCAP,
+			wantTier:   citations.TierCAPPageInterior,
+			wantCAPID:  ptr(int64(478)),
+			// No cite string matched, so there is nothing to record as the cite
+			// that linked.
+			wantLinked: nil,
+		},
+		{
+			name:       "CAP page in a coverage hole is us_page_gap, not a link",
+			cite:       citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(17), ReporterAbbr: "Mass.", Page: 507},
+			whitelist:  map[string]*citations.WhitelistEntry{"Mass.": {ReporterStandard: &massStd}},
+			capCites:   map[string]int64{"17 Mass. 478": 478},
+			capSpans:   span17Mass,
+			wantStatus: citations.StatusNoMatch,
+			wantTier:   citations.TierUSPageGap,
+		},
+		{
+			name:      "CAP page owned by two cases is us_page_ambiguous, not a link",
+			cite:      citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(1), ReporterAbbr: "Mass.", Page: 12},
+			whitelist: map[string]*citations.WhitelistEntry{"Mass.": {ReporterStandard: &massStd}},
+			capSpans: []citations.CaseSpan[int64]{
+				{Cite: "1 Mass. 10", ID: 101, Length: 5},
+				{Cite: "1 Mass. 10", ID: 102, Length: 5},
+			},
+			wantStatus: citations.StatusNoMatch,
+			wantTier:   citations.TierUSPageAmbiguous,
+		},
+		{
+			// Range matching runs only after every exact form has missed, so it can
+			// never rewire a link the exact cascade already made.
+			name:       "exact CAP hit is not preempted by an available page range",
+			cite:       citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(17), ReporterAbbr: "Mass.", Page: 478},
+			whitelist:  map[string]*citations.WhitelistEntry{"Mass.": {ReporterStandard: &massStd}},
+			capCites:   map[string]int64{"17 Mass. 478": 999},
+			capSpans:   span17Mass,
+			wantStatus: citations.StatusLinkedCAP,
+			wantTier:   citations.TierCAPDirect,
+			wantCAPID:  ptr(int64(999)),
+			wantLinked: ptr("17 Mass. 478"),
+		},
+		{
+			name:       "English Reports pin cite links by page range",
+			cite:       citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(1), ReporterAbbr: "Q.B.", Page: 23},
+			whitelist:  map[string]*citations.WhitelistEntry{"Q.B.": {ReporterStandard: &qbStd, UK: true}},
+			erCites:    map[string]string{"1 Q.B. 20": "er-20"},
+			erSpans:    []citations.CaseSpan[string]{{Cite: "1 Q.B. 20", ID: "er-20"}, {Cite: "1 Q.B. 30", ID: "er-30"}},
+			wantStatus: citations.StatusLinkedEnglishReports,
+			wantTier:   citations.TierERPageInterior,
+			wantERID:   ptr("er-20"),
+		},
+		{
+			name:       "English Reports page owned by two cases is uk_page_ambiguous",
+			cite:       citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(1), ReporterAbbr: "Q.B.", Page: 23},
+			whitelist:  map[string]*citations.WhitelistEntry{"Q.B.": {ReporterStandard: &qbStd, UK: true}},
+			erSpans:    []citations.CaseSpan[string]{{Cite: "1 Q.B. 20", ID: "er-a"}, {Cite: "1 Q.B. 20", ID: "er-b"}},
+			wantStatus: citations.StatusNoMatch,
+			wantTier:   citations.TierUKPageAmbiguous,
+		},
+		{
+			// A single-volume reporter cited without its redundant volume 1 has to
+			// reach the range index under the variant form too, since CAP always
+			// keys on a volume.
+			name:       "single-volume reporter pin cite reaches the range index as volume 1",
+			cite:       citations.UnlinkedCitation{ID: uuid.New(), Volume: nil, ReporterAbbr: "Toth", Page: 125},
+			whitelist:  map[string]*citations.WhitelistEntry{"Toth": {ReporterStandard: &tothStd, SingleVol: true}},
+			capSpans:   []citations.CaseSpan[int64]{{Cite: "1 Toth 123", ID: 777, Length: 10}},
+			wantStatus: citations.StatusLinkedCAP,
+			wantTier:   citations.TierCAPPageInterior,
+			wantCAPID:  ptr(int64(777)),
+		},
+		{
+			// A reporter that is not single_vol must NOT have a volume guessed for
+			// it: 2.9M no_match citations carry no volume at all (#261), and
+			// resolving those against volume 1 would be a fabricated link. The
+			// reporter is present in CAP here, so this fails on the volume rather
+			// than falling out earlier for want of anything to match.
+			name:       "volume-less cite to a multi-volume reporter is not resolved against volume 1",
+			cite:       citations.UnlinkedCitation{ID: uuid.New(), Volume: nil, ReporterAbbr: "Mass.", Page: 479},
+			whitelist:  map[string]*citations.WhitelistEntry{"Mass.": {ReporterStandard: &massStd}},
+			capCites:   map[string]int64{"1 Mass. 470": 1470},
+			capSpans:   []citations.CaseSpan[int64]{{Cite: "1 Mass. 470", ID: 1470, Length: 40}},
+			wantStatus: citations.StatusNoMatch,
+			wantTier:   citations.TierUSVolumeAbsent,
+		},
+		{
+			// The reporter renumbers in CAP but no diffvols row covers volume 7, so
+			// every probe carries an untranslated volume. Volume 7 of the CAP
+			// reporter exists and has a case spanning the page, but linking to it
+			// would be inventing a citation the treatise never made.
+			name:      "diffvols gap suppresses range matching rather than linking the wrong volume",
+			cite:      citations.UnlinkedCitation{ID: uuid.New(), Volume: ptr(7), ReporterAbbr: "Stat.", Page: 33},
+			whitelist: map[string]*citations.WhitelistEntry{"Stat.": {ReporterStandard: &statStd, CAPDifferent: true}},
+			diffvols:  map[string]map[int]*citations.DiffVolEntry{"Stat.": {2: {CAPVol: 81, CAPReporter: "Stat."}}},
+			capCites:  map[string]int64{"7 Stat. 30": 111},
+			capSpans:  []citations.CaseSpan[int64]{{Cite: "7 Stat. 30", ID: 111, Length: 10}},
+			// Without the guard this would be a confident TierCAPPageInterior link
+			// to case 111.
+			wantStatus: citations.StatusNoMatch,
+			wantTier:   citations.TierUSDiffVolsMissing,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tables := newLinkTables(tt.whitelist, tt.diffvols, tt.capCites, tt.freelawCites, tt.altAbbrs, tt.codeCites, tt.erCites)
+			tables := newLinkTables(tt.whitelist, tt.diffvols, tt.capCites, tt.freelawCites, tt.altAbbrs, tt.codeCites, tt.erCites, tt.capSpans, tt.erSpans)
 			got := linkCitation(&tt.cite, tables)
 
 			assert.Equal(t, tt.wantStatus, got.Status)
@@ -556,7 +667,7 @@ func TestVolumeVariantRecordsDetectedForm(t *testing.T) {
 	whitelist := map[string]*citations.WhitelistEntry{"Toth": {ReporterStandard: &std, SingleVol: true}}
 
 	tables := newLinkTables(whitelist, map[string]map[int]*citations.DiffVolEntry{},
-		map[string]int64{"1 Toth 123": 777}, nil, nil, nil, nil)
+		map[string]int64{"1 Toth 123": 777}, nil, nil, nil, nil, nil, nil)
 	got := linkCitation(c, tables)
 
 	assert.Equal(t, citations.StatusLinkedCAP, got.Status)

--- a/cite-linker/ranges.go
+++ b/cite-linker/ranges.go
@@ -1,0 +1,254 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/lmullen/legal-modernism/go/citations"
+)
+
+// maxSpanPages bounds how far past its own first page a case may be assumed to
+// run when the source gives no page count of its own — the English Reports, which
+// record no page range at all, and the 0.05% of CAP cases with a NULL first or
+// last page. Without a bound, a case sitting in front of a hole in the corpus
+// silently swallows the whole hole. 40 is just above the 99th percentile of the
+// distance between consecutive CAP cite pages (37), so it rejects holes without
+// truncating real cases.
+const maxSpanPages = 40
+
+// rangeOutcome is what a page-range lookup concluded.
+type rangeOutcome int
+
+const (
+	// rangeMiss: nothing to say. The volume is not indexed, or the page falls
+	// before its first cite. The caller falls back to the reporter/volume tiers.
+	rangeMiss rangeOutcome = iota
+	// rangeHit: exactly one case's span covers the page.
+	rangeHit
+	// rangeAmbiguous: the covering span belongs to more than one case, because
+	// several decisions begin on its first page.
+	rangeAmbiguous
+	// rangeGap: the page is past the end of the preceding case but before the
+	// next one — a hole in the corpus, not an interior page.
+	rangeGap
+)
+
+// span is one case's claim on a run of pages within a reporter-volume, expressed
+// entirely in the pagination the citation uses.
+type span[ID comparable] struct {
+	page   int  // the first page cite for this case
+	bound  int  // pages the case owns, starting at page; 0 when unbounded
+	id     ID   // the case, meaningful only when !shared
+	shared bool // more than one case begins on this page
+}
+
+// rangeIndex answers "which case does page N of this reporter-volume belong to?"
+// for pages that are not themselves first-page cites — pin cites, which the exact
+// cascade can never match.
+//
+// Spans are derived from cite strings alone, never from cap.cases.first_page.
+// Those two are different paginations: first_page describes the scanned printing,
+// and for ~2,770 CAP volumes it drifts from the pagination the citation uses, so
+// containment on it attaches pin cites to the wrong case with full confidence
+// (measured: right 99.4% of the time in volumes where the two agree, wrong 27.5%
+// of the time in volumes where they do not). Working in citation space makes the
+// offset irrelevant.
+//
+// The case's own page count still gets used, but only as a *length*: a length is
+// a difference between two pages in one system, so it survives the offset that an
+// absolute end page does not.
+type rangeIndex[ID comparable] struct {
+	volumes map[string][]span[ID]
+}
+
+// newRangeIndex builds the index from one first-page cite per case per keying.
+// Cite strings it cannot parse are skipped, exactly as newCiteIndex skips them,
+// so the index and the cascade's probes can never disagree about what a cite is.
+func newRangeIndex[ID comparable](spans []citations.CaseSpan[ID]) *rangeIndex[ID] {
+	byVolume := make(map[string][]span[ID])
+	for _, s := range spans {
+		vol, reporter, page, ok := splitCite(s.Cite)
+		if !ok {
+			continue
+		}
+		key := volumeKey(vol, reporter)
+		byVolume[key] = append(byVolume[key], span[ID]{
+			page:  page,
+			bound: s.Length,
+			id:    s.ID,
+		})
+	}
+
+	for key, list := range byVolume {
+		sort.Slice(list, func(i, j int) bool { return list[i].page < list[j].page })
+
+		// Collapse the cases that share a first page into one span marked shared,
+		// then bound each span by whichever is tighter: the distance to the next
+		// case, or the case's own length. They agree whenever the corpus is
+		// complete — CAP's ranges share their boundary page with the next case
+		// 72.8% of the time, which makes length overshoot by one, and the distance
+		// clamps it — so the minimum bites only where a case is missing.
+		out := list[:0]
+		for i := 0; i < len(list); {
+			j := i
+			for j+1 < len(list) && list[j+1].page == list[i].page {
+				j++
+			}
+			cur := list[i]
+			cur.shared = j > i
+			cur.bound = boundFor(cur.bound, nextPage(list, j+1), cur.page)
+			out = append(out, cur)
+			i = j + 1
+		}
+		byVolume[key] = out
+	}
+	return &rangeIndex[ID]{volumes: byVolume}
+}
+
+// nextPage returns the first page of the span at i, or 0 if i is past the end —
+// the volume-final case, which has no successor to bound it.
+func nextPage[ID comparable](list []span[ID], i int) int {
+	if i >= len(list) {
+		return 0
+	}
+	return list[i].page
+}
+
+// boundFor picks how many pages a case owns: the tighter of its own recorded
+// length and the distance to the next case, falling back to maxSpanPages when
+// neither is available. A zero length means the source recorded no page range;
+// a zero next means this is the last case in the volume.
+func boundFor(length, next, page int) int {
+	gap := 0
+	if next > page {
+		gap = next - page
+	}
+	switch {
+	case length > 0 && gap > 0:
+		return min(length, gap)
+	case length > 0:
+		return min(length, maxSpanPages)
+	case gap > 0:
+		return min(gap, maxSpanPages)
+	default:
+		return maxSpanPages
+	}
+}
+
+// lookup finds the case whose span covers page in the given reporter-volume.
+func (ix *rangeIndex[ID]) lookup(vol, reporter string, page int) (ID, rangeOutcome) {
+	var zero ID
+	list := ix.volumes[volumeKey(vol, reporter)]
+	if len(list) == 0 {
+		return zero, rangeMiss
+	}
+	// The last span starting at or before page is the only one that can cover it.
+	i := sort.Search(len(list), func(i int) bool { return list[i].page > page }) - 1
+	if i < 0 {
+		return zero, rangeMiss // page precedes the volume's first case
+	}
+	s := list[i]
+	if s.page == page {
+		// An exact first-page cite is not this index's business. The cascade
+		// already probed it against cap.citations and missed, which means it was
+		// dropped there for belonging to more than one case — a deliberate policy
+		// (#250) that an ambiguous cite is an honest miss rather than a link to an
+		// arbitrary case. Re-resolving it here would quietly undo that decision on
+		// strictly less evidence, since this index sees only the official and
+		// nominative cites while the drop was judged across all of them. Report
+		// nothing and let the reporter/volume tiers describe the miss.
+		return zero, rangeMiss
+	}
+	if s.shared {
+		return zero, rangeAmbiguous
+	}
+	if page >= s.page+s.bound {
+		return zero, rangeGap
+	}
+	return s.id, rangeHit
+}
+
+// probe runs every cite string the cascade tried through the index and reports
+// the best outcome any of them reached, preferring a hit, then an ambiguity, then
+// a gap. Taking the probes verbatim is what keeps the index and the cascade in
+// agreement: there is no second list of forms to drift out of sync.
+//
+// A hit wins over an ambiguity because the probes are alternate spellings of one
+// citation, so one spelling resolving cleanly is real evidence, while another
+// spelling colliding says only that some unrelated reporter-volume is crowded at
+// that page.
+func (ix *rangeIndex[ID]) probe(probes []string) (ID, rangeOutcome) {
+	var (
+		zero ID
+		best = rangeMiss
+		bid  ID
+	)
+	for _, p := range probes {
+		vol, reporter, page, ok := splitCite(p)
+		if !ok {
+			continue
+		}
+		id, outcome := ix.lookup(vol, reporter, page)
+		if outcome == rangeHit {
+			return id, rangeHit
+		}
+		if rank(outcome) > rank(best) {
+			best, bid = outcome, id
+		}
+	}
+	if best == rangeMiss {
+		return zero, rangeMiss
+	}
+	return bid, best
+}
+
+// rank orders outcomes by how much they say about the citation, so probe can keep
+// the most informative one across alternate spellings.
+func rank(o rangeOutcome) int {
+	switch o {
+	case rangeHit:
+		return 3
+	case rangeAmbiguous:
+		return 2
+	case rangeGap:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// checkSelfConsistency verifies that every case's own first-page cite falls
+// inside the span built for it. That has to hold by construction, so a violation
+// means the sort, the collapse, or the bound arithmetic is wrong — and the
+// failure mode of getting it wrong is silent mislinking at scale, not a crash.
+// Shared pages are exempt: they are deliberately unresolvable.
+func (ix *rangeIndex[ID]) checkSelfConsistency() error {
+	for key, list := range ix.volumes {
+		for i, s := range list {
+			if s.shared {
+				continue
+			}
+			if s.bound < 1 {
+				return fmt.Errorf("volume %q span %d (page %d) has bound %d, want >= 1",
+					key, i, s.page, s.bound)
+			}
+			if i > 0 && list[i-1].page >= s.page {
+				return fmt.Errorf("volume %q spans %d and %d are not in ascending page order (%d >= %d)",
+					key, i-1, i, list[i-1].page, s.page)
+			}
+			if i > 0 && list[i-1].page+list[i-1].bound > s.page {
+				return fmt.Errorf("volume %q span %d (pages %d-%d) overlaps the next case at page %d",
+					key, i-1, list[i-1].page, list[i-1].page+list[i-1].bound-1, s.page)
+			}
+		}
+	}
+	return nil
+}
+
+// size reports the number of reporter-volumes and spans held, for the startup log.
+func (ix *rangeIndex[ID]) size() (volumes, spans int) {
+	for _, list := range ix.volumes {
+		spans += len(list)
+	}
+	return len(ix.volumes), spans
+}

--- a/cite-linker/ranges_test.go
+++ b/cite-linker/ranges_test.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/lmullen/legal-modernism/go/citations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// span17Mass is volume 17 of Mass. as CAP actually holds it, abridged to the
+// stretch that makes the point. It is a reprint whose internal pagination runs
+// roughly 110 pages behind the pagination the citation uses, which is why every
+// Length here is far smaller than the difference between the cite pages would
+// suggest if first_page were read as an absolute position.
+//
+//	official cite   first_page  last_page   length
+//	17 Mass. 470       382         388         7
+//	17 Mass. 478       388         416        29
+//	17 Mass. 514       417         445        29
+//	17 Mass. 585       473         478         6
+//	17 Mass. 591       478         490        13
+var span17Mass = []citations.CaseSpan[int64]{
+	{Cite: "17 Mass. 470", ID: 470, Length: 7},
+	{Cite: "17 Mass. 478", ID: 478, Length: 29},
+	{Cite: "17 Mass. 514", ID: 514, Length: 29},
+	{Cite: "17 Mass. 585", ID: 585, Length: 6},
+	{Cite: "17 Mass. 591", ID: 591, Length: 13},
+}
+
+func TestRangeIndexLookup(t *testing.T) {
+	ix := newRangeIndex(span17Mass)
+
+	tests := []struct {
+		name        string
+		page        int
+		wantID      int64
+		wantOutcome rangeOutcome
+	}{
+		{
+			// The case for issue #242. Containment on first_page/last_page puts
+			// page 479 inside [478, 490] and links it to the case cited
+			// 17 Mass. 591, which is a different case entirely. In citation space
+			// the answer is unambiguous.
+			name: "pin cite in a drifted volume resolves to the citation-space owner",
+			page: 479, wantID: 478, wantOutcome: rangeHit,
+		},
+		{
+			// Reaching here means the exact cascade already probed this string and
+			// missed, i.e. cap.citations dropped it as ambiguous. Re-resolving it
+			// would undo that policy on less evidence.
+			name: "an exact first-page cite is left to the exact cascade",
+			page: 478, wantOutcome: rangeMiss,
+		},
+		{"last page a case owns", 506, 478, rangeHit},
+		{
+			// Cites jump 478 -> 514, a 36-page hole, but CAP records the case at
+			// 478 as 29 pages long. Pages 507-513 are in the hole and must not be
+			// attached to it.
+			name: "page in a coverage hole is a gap, not an interior page",
+			page: 507, wantOutcome: rangeGap,
+		},
+		{"page just before the next case is still a gap", 513, 0, rangeGap},
+		{"the next case's own first page is an exact cite", 514, 0, rangeMiss},
+		{"first interior page of the next case", 515, 514, rangeHit},
+		{"page before the volume's first indexed cite", 469, 0, rangeMiss},
+		{
+			// The volume-final case has no successor, so only its own length
+			// bounds it: 591 + 13 - 1 = 603.
+			name: "volume-final case is bounded by its own length",
+			page: 603, wantID: 591, wantOutcome: rangeHit,
+		},
+		{"past the volume-final case's length", 604, 0, rangeGap},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, outcome := ix.lookup("17", "Mass.", tt.page)
+			assert.Equal(t, tt.wantOutcome, outcome)
+			if tt.wantOutcome == rangeHit {
+				assert.Equal(t, tt.wantID, id)
+			}
+		})
+	}
+}
+
+// TestRangeIndexSharedBoundaryPage covers the convention CAP uses 72.8% of the
+// time: a case's last_page is the page the next case begins on, so its length
+// overshoots the distance to the next cite by exactly one. The distance has to
+// win, or every case would claim its successor's first page.
+func TestRangeIndexSharedBoundaryPage(t *testing.T) {
+	ix := newRangeIndex([]citations.CaseSpan[int64]{
+		{Cite: "1 Test 10", ID: 10, Length: 6}, // first_page 10, last_page 15
+		{Cite: "1 Test 15", ID: 15, Length: 5}, // first_page 15, last_page 19
+	})
+
+	id, outcome := ix.lookup("1", "Test", 14)
+	assert.Equal(t, rangeHit, outcome)
+	assert.Equal(t, int64(10), id, "page 14 belongs to the case starting at 10")
+
+	// The clamping itself is what checkSelfConsistency enforces: unclamped, the
+	// case at 10 would run 10-15 and overlap the case that starts at 15.
+	assert.NoError(t, ix.checkSelfConsistency(),
+		"length must be clamped to the distance to the next case")
+
+	_, outcome = ix.lookup("1", "Test", 15)
+	assert.Equal(t, rangeMiss, outcome, "the boundary page is an exact cite for the next case")
+}
+
+// TestRangeIndexCleanTiling covers the other 25.7%: last_page is one before the
+// next case's first_page, so length and distance agree exactly and no page is
+// lost at the boundary.
+func TestRangeIndexCleanTiling(t *testing.T) {
+	ix := newRangeIndex([]citations.CaseSpan[int64]{
+		{Cite: "1 Test 10", ID: 10, Length: 5}, // first_page 10, last_page 14
+		{Cite: "1 Test 15", ID: 15, Length: 5},
+	})
+
+	id, outcome := ix.lookup("1", "Test", 14)
+	assert.Equal(t, rangeHit, outcome)
+	assert.Equal(t, int64(10), id, "the last page of a cleanly tiled case is not lost")
+}
+
+func TestRangeIndexAmbiguousStartPage(t *testing.T) {
+	ix := newRangeIndex([]citations.CaseSpan[int64]{
+		{Cite: "1 Test 10", ID: 101, Length: 5},
+		{Cite: "1 Test 10", ID: 102, Length: 5}, // two decisions begin on page 10
+		{Cite: "1 Test 20", ID: 200, Length: 5},
+	})
+
+	// The shared page itself is an exact cite, so it stays with the exact
+	// cascade like any other; only the interior pages it owns are reported
+	// ambiguous.
+	_, outcome := ix.lookup("1", "Test", 10)
+	assert.Equal(t, rangeMiss, outcome, "the shared start page is an exact cite")
+
+	for _, page := range []int{12, 14} {
+		_, outcome := ix.lookup("1", "Test", page)
+		assert.Equal(t, rangeAmbiguous, outcome, "page %d", page)
+	}
+
+	id, outcome := ix.lookup("1", "Test", 21)
+	assert.Equal(t, rangeHit, outcome, "the next unshared case still resolves")
+	assert.Equal(t, int64(200), id)
+}
+
+// TestRangeIndexNoLengthFallsBackToMaxSpan is the English Reports case, and the
+// 0.05% of CAP cases with a NULL first or last page: with no recorded length the
+// span can only be bounded by the next cite, and by maxSpanPages when there is
+// no next cite either.
+func TestRangeIndexNoLengthFallsBackToMaxSpan(t *testing.T) {
+	ix := newRangeIndex([]citations.CaseSpan[string]{
+		{Cite: "1 E.R. 100", ID: "a"},
+		{Cite: "1 E.R. 300", ID: "b"}, // a 200-page hole, far beyond any real case
+	})
+
+	id, outcome := ix.lookup("1", "E.R.", 100+maxSpanPages-1)
+	assert.Equal(t, rangeHit, outcome)
+	assert.Equal(t, "a", id)
+
+	_, outcome = ix.lookup("1", "E.R.", 100+maxSpanPages)
+	assert.Equal(t, rangeGap, outcome, "an unbounded span must not swallow the hole")
+
+	id, outcome = ix.lookup("1", "E.R.", 300+maxSpanPages-1)
+	assert.Equal(t, rangeHit, outcome, "the volume-final case gets maxSpanPages")
+	assert.Equal(t, "b", id)
+}
+
+func TestRangeIndexUnknownVolume(t *testing.T) {
+	ix := newRangeIndex(span17Mass)
+
+	_, outcome := ix.lookup("18", "Mass.", 479)
+	assert.Equal(t, rangeMiss, outcome, "another volume of the same reporter")
+
+	_, outcome = ix.lookup("17", "Cal.", 479)
+	assert.Equal(t, rangeMiss, outcome, "another reporter at the same volume")
+
+	_, outcome = ix.lookup("", "Mass.", 479)
+	assert.Equal(t, rangeMiss, outcome, "the volume-less form is never a CAP key")
+}
+
+// TestRangeIndexSkipsUnparsableCites mirrors TestCiteIndexSkipsUnparsableKeys:
+// a cite string that is not a cite must be dropped rather than indexed under a
+// junk key.
+func TestRangeIndexSkipsUnparsableCites(t *testing.T) {
+	ix := newRangeIndex([]citations.CaseSpan[int64]{
+		{Cite: "Cox, Manual Trade-Mark Cas.", ID: 1},
+		{Cite: "2013-NMCA-039", ID: 2},
+		{Cite: "1 Test 10", ID: 3, Length: 5},
+	})
+
+	volumes, spans := ix.size()
+	assert.Equal(t, 1, volumes)
+	assert.Equal(t, 1, spans)
+}
+
+func TestRangeIndexProbePrefersHitOverAmbiguity(t *testing.T) {
+	ix := newRangeIndex([]citations.CaseSpan[int64]{
+		// The alternate spelling's volume is crowded at this page...
+		{Cite: "1 Alt 10", ID: 901, Length: 20},
+		{Cite: "1 Alt 10", ID: 902, Length: 20},
+		// ...while the canonical spelling resolves cleanly.
+		{Cite: "1 Test 10", ID: 100, Length: 20},
+	})
+
+	// Probe order deliberately puts the ambiguous spelling first.
+	id, outcome := ix.probe([]string{"1 Alt 12", "1 Test 12"})
+	assert.Equal(t, rangeHit, outcome)
+	assert.Equal(t, int64(100), id)
+}
+
+func TestRangeIndexProbeKeepsMostInformativeMiss(t *testing.T) {
+	ix := newRangeIndex([]citations.CaseSpan[int64]{
+		{Cite: "1 Test 10", ID: 100, Length: 5},
+		{Cite: "1 Test 60", ID: 600, Length: 5},
+	})
+
+	// "9 Test 12" is an unknown volume (miss); "1 Test 20" is in the hole between
+	// 10 and 60 (gap). The gap is the more informative answer.
+	_, outcome := ix.probe([]string{"9 Test 12", "1 Test 20"})
+	assert.Equal(t, rangeGap, outcome)
+
+	_, outcome = ix.probe([]string{"9 Test 12", "8 Test 20"})
+	assert.Equal(t, rangeMiss, outcome, "nothing probed reached the index")
+
+	_, outcome = ix.probe([]string{"Cox, Manual Trade-Mark Cas."})
+	assert.Equal(t, rangeMiss, outcome, "an unparsable probe is ignored, not a miss to report")
+}
+
+func TestRangeIndexSelfConsistency(t *testing.T) {
+	ix := newRangeIndex(span17Mass)
+	require.NoError(t, ix.checkSelfConsistency())
+
+	// Every case must own the page immediately after its own cite page. The cite
+	// page itself is deliberately left to the exact cascade, so this is the
+	// nearest page that exercises the span the case was given — and it is the
+	// invariant that would break if the sort, the collapse, or the bound
+	// arithmetic were wrong.
+	for _, s := range span17Mass {
+		_, _, page, ok := splitCite(s.Cite)
+		require.True(t, ok)
+		id, outcome := ix.lookup("17", "Mass.", page+1)
+		assert.Equal(t, rangeHit, outcome, "cite %q", s.Cite)
+		assert.Equal(t, s.ID, id, "the page after %q belongs to that case", s.Cite)
+	}
+}
+
+// TestRangeIndexEmpty checks that an index built from nothing answers rangeMiss
+// rather than panicking, which is what makes the nil-spans path in the tests and
+// any future partial load safe.
+func TestRangeIndexEmpty(t *testing.T) {
+	ix := newRangeIndex[int64](nil)
+	_, outcome := ix.lookup("17", "Mass.", 479)
+	assert.Equal(t, rangeMiss, outcome)
+	assert.NoError(t, ix.checkSelfConsistency())
+
+	volumes, spans := ix.size()
+	assert.Zero(t, volumes)
+	assert.Zero(t, spans)
+}

--- a/cite-linker/tiers.go
+++ b/cite-linker/tiers.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/lmullen/legal-modernism/go/citations"
@@ -32,7 +33,7 @@ func newCiteIndex[V any](maps ...map[string]V) *citeIndex {
 	}
 	for _, m := range maps {
 		for cite := range m {
-			vol, reporter, ok := splitCite(cite)
+			vol, reporter, _, ok := splitCite(cite)
 			if !ok {
 				continue
 			}
@@ -48,7 +49,7 @@ func newCiteIndex[V any](maps ...map[string]V) *citeIndex {
 // string the index cannot parse is ignored rather than counted as a miss.
 func (ix *citeIndex) reached(probes []string) (reporter, volume bool) {
 	for _, p := range probes {
-		vol, rep, ok := splitCite(p)
+		vol, rep, _, ok := splitCite(p)
 		if !ok {
 			continue
 		}
@@ -72,25 +73,31 @@ func volumeKey(vol, reporter string) string {
 }
 
 // splitCite splits a cite string of the form "{volume} {reporter} {page}" into
-// its volume and reporter parts, discarding the page; vol is empty for the
-// volume-less form "{reporter} {page}" that single-volume reporters use. ok is
-// false when the string is not a cite at all, which is not hypothetical: the
-// code-reporter map deliberately holds keys like "Cox, Manual Trade-Mark Cas."
-// that no probe will ever match.
+// its volume, reporter, and page; vol is empty for the volume-less form
+// "{reporter} {page}" that single-volume reporters use. ok is false when the
+// string is not a cite at all, which is not hypothetical: the code-reporter map
+// deliberately holds keys like "Cox, Manual Trade-Mark Cas." that no probe will
+// ever match.
 //
-// Volume and page stay strings because they are only ever compared with other
-// cite strings built the same way; parsing them to int would add failure modes
-// for no gain.
-func splitCite(cite string) (vol, reporter string, ok bool) {
+// The volume stays a string because it is only ever compared with other cite
+// strings built the same way, and parsing it to int would add failure modes for
+// no gain. The page is parsed, because the range index orders and compares pages
+// numerically. A page that does not fit an int yields ok false rather than a
+// wrapped value.
+func splitCite(cite string) (vol, reporter string, page int, ok bool) {
 	sp := strings.LastIndexByte(cite, ' ')
 	if sp <= 0 || !allDigits(cite[sp+1:]) {
-		return "", "", false // no page, so not a cite
+		return "", "", 0, false // no page, so not a cite
+	}
+	page, err := strconv.Atoi(cite[sp+1:])
+	if err != nil {
+		return "", "", 0, false
 	}
 	head := cite[:sp]
 	if v := strings.IndexByte(head, ' '); v > 0 && allDigits(head[:v]) {
-		return head[:v], head[v+1:], true
+		return head[:v], head[v+1:], page, true
 	}
-	return "", head, true
+	return "", head, page, true
 }
 
 // allDigits reports whether s is a non-empty run of ASCII digits.

--- a/cite-linker/tiers_test.go
+++ b/cite-linker/tiers_test.go
@@ -13,18 +13,19 @@ func TestSplitCite(t *testing.T) {
 		cite         string
 		wantVol      string
 		wantReporter string
+		wantPage     int
 		wantOK       bool
 	}{
-		{"volume, reporter, page", "17 Mass. 210", "17", "Mass.", true},
-		{"multi-word reporter", "1 Ves Sen 1", "1", "Ves Sen", true},
-		{"no volume", "Cro Eliz 1", "", "Cro Eliz", true},
-		{"no volume, single-word reporter", "Stat 30", "", "Stat", true},
-		{"multi-digit volume and page", "123 U.S. 4567", "123", "U.S.", true},
+		{"volume, reporter, page", "17 Mass. 210", "17", "Mass.", 210, true},
+		{"multi-word reporter", "1 Ves Sen 1", "1", "Ves Sen", 1, true},
+		{"no volume", "Cro Eliz 1", "", "Cro Eliz", 1, true},
+		{"no volume, single-word reporter", "Stat 30", "", "Stat", 30, true},
+		{"multi-digit volume and page", "123 U.S. 4567", "123", "U.S.", 4567, true},
 		{
 			// A reporter whose own name starts with something numeric-looking
 			// must not have it read as a volume.
 			name: "leading token that is not all digits is part of the reporter",
-			cite: "2d Cir. 5", wantVol: "", wantReporter: "2d Cir.", wantOK: true,
+			cite: "2d Cir. 5", wantVol: "", wantReporter: "2d Cir.", wantPage: 5, wantOK: true,
 		},
 		{
 			// The code-reporter map holds keys like this on purpose; they must not
@@ -32,22 +33,29 @@ func TestSplitCite(t *testing.T) {
 			name: "no page is not a cite",
 			cite: "Cox, Manual Trade-Mark Cas.", wantOK: false,
 		},
-		{"empty string", "", "", "", false},
-		{"page only", "210", "", "", false},
-		{"leading space", " 210", "", "", false},
-		{"trailing space", "17 Mass. ", "", "", false},
-		{"non-numeric page", "17 Mass. cciii", "", "", false},
+		{
+			// allDigits accepts it, but it overflows an int, so Atoi has to be what
+			// decides. A wrapped page would silently land in the wrong span.
+			name: "page too large for an int is not a cite",
+			cite: "1 Mass. 99999999999999999999", wantOK: false,
+		},
+		{"empty string", "", "", "", 0, false},
+		{"page only", "210", "", "", 0, false},
+		{"leading space", " 210", "", "", 0, false},
+		{"trailing space", "17 Mass. ", "", "", 0, false},
+		{"non-numeric page", "17 Mass. cciii", "", "", 0, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			vol, reporter, ok := splitCite(tt.cite)
+			vol, reporter, page, ok := splitCite(tt.cite)
 			assert.Equal(t, tt.wantOK, ok)
 			if !tt.wantOK {
 				return
 			}
 			assert.Equal(t, tt.wantVol, vol, "volume")
 			assert.Equal(t, tt.wantReporter, reporter, "reporter")
+			assert.Equal(t, tt.wantPage, page, "page")
 		})
 	}
 }

--- a/go/citations/linker.go
+++ b/go/citations/linker.go
@@ -24,6 +24,23 @@ type DiffVolEntry struct {
 	CAPReporter string
 }
 
+// CaseSpan is one first-page cite string, the case it names, and how many pages
+// that case occupies. It is the input to the page-range index that resolves pin
+// cites — citations to an interior page of a case, which can never match a
+// first-page cite string exactly.
+//
+// Length is the source's own page count for the case (last_page - first_page +
+// 1), or 0 when the source records no page range at all, as english_reports.cases
+// does. It is deliberately a length rather than an end page: CAP's first_page and
+// last_page are the pagination of the scanned printing, which for ~2,770 volumes
+// is offset from the pagination the citation uses, so an absolute end page cannot
+// be trusted while a difference between two pages in the same system can.
+type CaseSpan[ID comparable] struct {
+	Cite   string
+	ID     ID
+	Length int
+}
+
 // UnlinkedCitation is a raw citation fetched from the database for linking.
 type UnlinkedCitation struct {
 	ID           uuid.UUID
@@ -78,19 +95,25 @@ const (
 	TierUSReporterAbsent  = "us_reporter_absent"  // no probed reporter spelling appears in any US source
 	TierUSDiffVolsMissing = "us_diffvols_missing" // reporter renumbers in CAP, but no reporters_diffvols row covers this volume
 	TierUSVolumeAbsent    = "us_volume_absent"    // reporter present, this volume never appears
-	TierUSPageAbsent      = "us_page_absent"      // reporter and volume present, page is not a first-page cite
+	TierUSPageAbsent      = "us_page_absent"      // reporter and volume present, page is not a first-page cite and no case's range covers it
+	TierUSPageAmbiguous   = "us_page_ambiguous"   // the page falls in a range, but more than one case starts at that range's first page
+	TierUSPageGap         = "us_page_gap"         // the page falls past the end of the preceding case, in a hole in CAP's coverage
 
 	// no_match, UK route (English Reports).
 	TierUKReporterAbsent = "uk_reporter_absent"
 	TierUKVolumeAbsent   = "uk_volume_absent"
 	TierUKPageAbsent     = "uk_page_absent"
+	TierUKPageAmbiguous  = "uk_page_ambiguous"
+	TierUKPageGap        = "uk_page_gap"
 
 	// linked_*: which probe produced the link.
 	TierCAPDirect             = "cap_direct"               // cap.citations, under the normalized cite
 	TierCAPFreelaw            = "cap_freelaw"              // freelaw.cite_to_cap, under the normalized cite
 	TierCAPAltSpelling        = "cap_alt_spelling"         // cap.citations, under a reporters_abbreviations alternate
 	TierCAPFreelawAltSpelling = "cap_freelaw_alt_spelling" // freelaw.cite_to_cap, under an alternate
+	TierCAPPageInterior       = "cap_page_interior"        // cap.citations page range, pin cite to an interior page
 	TierCodeDirect            = "code_direct"              // legalhist.code_reporter, under the cleaned cite
 	TierCodeAltSpelling       = "code_alt_spelling"        // legalhist.code_reporter, under an alternate
 	TierERDirect              = "er_direct"                // english_reports.cases
+	TierERPageInterior        = "er_page_interior"         // english_reports.cases page range, pin cite to an interior page
 )

--- a/go/citations/linker_store.go
+++ b/go/citations/linker_store.go
@@ -49,6 +49,19 @@ type LinkerStore interface {
 	// as cite string -> case ID.
 	LoadEnglishReportsCitations(ctx context.Context) (map[string]string, error)
 
+	// LoadCAPCaseSpans loads every CAP first-page cite together with the page
+	// length of the case it names, for the page-range index that resolves pin
+	// cites. Unlike LoadCAPCitations this keeps ambiguous cites: two cases sharing
+	// a first page is exactly what the index has to detect in order to refuse the
+	// match, so dropping them here would turn a knowable ambiguity into a silent
+	// wrong answer.
+	LoadCAPCaseSpans(ctx context.Context) ([]CaseSpan[int64], error)
+
+	// LoadERCaseSpans loads every English Reports first-page cite — both er_cite
+	// and er_parallel_cite — for the same purpose. Length is always 0: the table
+	// records no page range, so spans there can only be bounded by the next cite.
+	LoadERCaseSpans(ctx context.Context) ([]CaseSpan[string], error)
+
 	// SaveLinkResults batch-inserts multiple link results in a single query.
 	SaveLinkResults(ctx context.Context, results []*LinkResult) error
 

--- a/go/citations/linker_store_db.go
+++ b/go/citations/linker_store_db.go
@@ -319,6 +319,96 @@ func (s *LinkerDBStore) LoadEnglishReportsCitations(ctx context.Context) (map[st
 	return m, nil
 }
 
+// LoadCAPCaseSpans loads the first-page cites that the page-range index is built
+// from, with each case's own page count.
+//
+// Only official and nominative cites are loaded. vendor and split cites are
+// excluded because they are not "{volume} {reporter} {page}" at all — a vendor
+// cite like "1996 WL 12345" parses as page 12345 and would wreck the volume it
+// landed in. parallel cites are excluded on measurement rather than principle:
+// they are safe (a reporter-volume key only ever receives pages in that
+// reporter's own pagination) but add 1.28M cite strings for +1.5% of hits.
+//
+// Ambiguous cites are deliberately kept, unlike LoadCAPCitations; see the
+// interface comment.
+func (s *LinkerDBStore) LoadCAPCaseSpans(ctx context.Context) ([]CaseSpan[int64], error) {
+	// The cite is parsed in Go rather than with regexp_match here: doing it
+	// server-side over all 6.9M rows costs about nine minutes, against seconds for
+	// the plain join.
+	query := `
+	SELECT c.cite, c."case", k.first_page, k.last_page
+	FROM cap.citations c
+	JOIN cap.cases k ON k.id = c."case"
+	WHERE c.type IN ('official', 'nominative')
+	`
+	rows, err := s.DB.Query(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("loading CAP case spans: %w", err)
+	}
+	defer rows.Close()
+
+	spans := make([]CaseSpan[int64], 0, 7_000_000)
+	for rows.Next() {
+		var cite string
+		var caseID int64
+		var firstPage, lastPage *int
+		if err := rows.Scan(&cite, &caseID, &firstPage, &lastPage); err != nil {
+			return nil, fmt.Errorf("scanning CAP case span: %w", err)
+		}
+		spans = append(spans, CaseSpan[int64]{
+			Cite:   cite,
+			ID:     caseID,
+			Length: pageLength(firstPage, lastPage),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating CAP case spans: %w", err)
+	}
+	return spans, nil
+}
+
+// pageLength converts a first/last page pair into the number of pages the case
+// occupies, or 0 when either is NULL or the pair is inverted (167 rows in CAP
+// have last_page < first_page). The +1 matters: CAP's ranges share their boundary
+// page with the next case 72.8% of the time, so last-first+1 overshoots by one
+// there and is exact under the other convention — taking the minimum with the
+// distance to the next cite clamps it correctly either way.
+func pageLength(firstPage, lastPage *int) int {
+	if firstPage == nil || lastPage == nil || *lastPage < *firstPage {
+		return 0
+	}
+	return *lastPage - *firstPage + 1
+}
+
+// LoadERCaseSpans loads the English Reports first-page cites, under both the E.R.
+// keying and the nominate parallel keying. Each reporter-volume key receives only
+// pages in its own pagination, so the two systems never mix.
+func (s *LinkerDBStore) LoadERCaseSpans(ctx context.Context) ([]CaseSpan[string], error) {
+	query := `SELECT id, er_cite, er_parallel_cite FROM english_reports.cases`
+	rows, err := s.DB.Query(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("loading English Reports case spans: %w", err)
+	}
+	defer rows.Close()
+
+	spans := make([]CaseSpan[string], 0, 250_000)
+	for rows.Next() {
+		var id, erCite string
+		var erParallel *string
+		if err := rows.Scan(&id, &erCite, &erParallel); err != nil {
+			return nil, fmt.Errorf("scanning English Reports case span: %w", err)
+		}
+		spans = append(spans, CaseSpan[string]{Cite: erCite, ID: id})
+		if erParallel != nil {
+			spans = append(spans, CaseSpan[string]{Cite: *erParallel, ID: id})
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating English Reports case spans: %w", err)
+	}
+	return spans, nil
+}
+
 // SaveLinkResults batch-inserts multiple link results in a single statement.
 //
 // Rather than build a VALUES list with up to batchSize*9 placeholders (which


### PR DESCRIPTION
Closes #242. Closes #243.

Links pin cites — citations to an interior page of a case — by page-range matching, on both the CAP and English Reports routes. Together these are the two largest `no_match` tiers.

## Expected effect

Predicted from a replay of the rule over the current `no_match` pool (20,379,052 citations, all tiered). These are what to check the run against:

| tier | before | after (predicted) |
|---|---:|---:|
| `us_page_absent` | 6,694,635 | ~2.6M |
| **`cap_page_interior`** | — | **~3.5M** |
| `us_page_gap` | — | ~965K |
| `us_page_ambiguous` | — | ~136K |
| `uk_page_absent` | 3,087,354 | ~360K |
| **`er_page_interior`** | — | **~2.2M** |
| `uk_page_gap` | — | ~441K |
| `uk_page_ambiguous` | — | ~281K |

**~5.7M new links**, inside both issues' original estimates (#242 said 6–8M for the pool, #243 said 2–3M). `us_diffvols_missing` and the `*_reporter_absent` / `*_volume_absent` tiers should not move.

Reversible with a single `DELETE FROM moml_citations.citation_links WHERE match_tier IN ('cap_page_interior','er_page_interior')`.

## Why spans are built from cite strings, not `cap.cases.first_page`

The construction in #242's issue body — containment on `first_page`/`last_page` — is wrong, and this is the finding that shaped the design. Measured across all 41,178 CAP reporter-volumes / 6,919,525 cases:

**CAP holds two different paginations.** `cases.first_page`/`last_page` describe the scanned printing; the page inside `citations.cite` is the pagination the citation uses. Identical in 93.3% of volumes (91.2% of cases), but 2,770 volumes drift — chiefly early reprints, which is where treatise citation is densest.

Replaying both rules over real pin cites:

| | volumes where every cite page == `first_page` | volumes with a pagination offset |
|---|---:|---:|
| citations | 3,188,138 | 340,418 |
| `first_page`/`last_page` agrees | **99.37%** | 53.67% |
| picks the **wrong case** | 3 citations | **27.51%** (93,653) |
| finds >1 case | 0.63% | 10.65% |
| finds no case | 0.01% | 8.17% |

Volume 17 of `Mass.` is the canonical case — a printing running ~110 pages behind the cite pagination:

| official cite | `first_page` | `last_page` | length | gap to next cite | `bound` |
|---|---:|---:|---:|---:|---:|
| `17 Mass. 470` | 382 | 388 | 7 | 8 | 7 |
| `17 Mass. 478` | 388 | 416 | 29 | **36** | **29** |
| `17 Mass. 585` | 473 | 478 | 6 | 6 | 6 |
| `17 Mass. 591` | 478 | 490 | 13 | — | 13 |

`17 Mass. 479` → containment gives 479 ∈ [478, 490] → *Bean v. Parker*, actually cited `17 Mass. 591`. Citation space gives the case cited `17 Mass. 478`, *Foster, Executors*. Both are in `TestRangeIndexLookup`.

## The bound

```
bound(c) = min( next_distinct_cite_page - c,  last_page - first_page + 1 )
```

The length is used as a *length*, never as an endpoint — a length is a difference between two pages in one system, so it survives the offset an absolute end page does not.

The `min` is what stops a case in front of a hole from swallowing it. **CAP's ranges overlap by design**: across 6.87M adjacent case pairs, 72.8% have `next.first_page == prev.last_page` (printed reporters run cases continuously, so A ends on the page where B begins), 25.7% tile cleanly, ~1% leave holes. So `last-first+1` overshoots by one under the common convention and the gap clamps it, while it is exact under the other. The minimum therefore equals the gap whenever coverage is complete and bites only on a genuine gap — in volume 17 that is pages 507–513, reported `us_page_gap` rather than attached to *Foster*.

Where no length exists — the English Reports record none at all, and 0.05% of CAP cases have a NULL page — spans fall back to `maxSpanPages = 40`, just above the 99th percentile of the distance between consecutive CAP cite pages (37).

## Deliberate refusals

Each recorded as a tier rather than linked, so the residue stays visible on the dashboard:

- **`us/uk_page_ambiguous`** — more than one case begins on the covering span's first page. The ER index needs this far more than CAP's: 21.92% of its distinct cite pages carry >1 case, against 9.17% for CAP.
- **`us/uk_page_gap`** — the page is past the case's end, in a hole. This is the candidate pool for #99.
- **`us_diffvols_missing`** — range matching is skipped entirely. Every probe carries a volume known to be untranslated, and the wrong volume of the right reporter is densely populated, so a hit would be confident and fabricated. Measured: suppresses 45,077 such links.
- **Exact first-page cites are left alone.** Reaching the range index means the exact cascade already probed that string and missed — i.e. `cap.citations` dropped it for belonging to more than one case, the deliberate policy from #250. Re-resolving it here would undo that on strictly less evidence, since this index sees only official and nominative cites while the drop was judged across all types.
- **No volume is ever guessed.** The volume-1 retry stays limited to `single_vol` reporters. 2.9M `no_match` citations carry no volume at all (#261); resolving those against volume 1 would fabricate links.

## Placement and safety

Matching runs only after every exact form of every volume form has missed, so it can only turn a `no_match` into a link, never rewire one. It reuses the `probes` list the cascade already built rather than re-deriving which forms to try — the same discipline `citeIndex` uses, so index and cascade cannot drift apart.

`status` stays `linked_cap` / `linked_english_reports`, so every `LIKE 'linked%'` consumer and `ResetUnlinked` keep working; the tier is what identifies the method. `CiteLinked` is nil on these rows because no cite string matched.

The index is checked for self-consistency at startup before any citation is linked — spans ascending, bounds ≥ 1, no overlap with the next case. The failure mode of getting the arithmetic wrong is silent mislinking at scale, not a crash.

**No migration.** All six tier values were forward-declared in `chk_citation_links_match_tier`, and `TestMatchTierConstantsAreAllowedBySQL` enforces it.

## Loading

Scoped to `official` and `nominative`. `vendor` and `split` are excluded because they are not cites — `1996 WL 12345` parses as page 12345 and would wreck the volume it landed in. `parallel` is excluded on measurement rather than principle: it is safe by construction (a reporter-volume key only ever receives pages in that reporter's own pagination) but adds 1.28M cite strings for **+1.5%** of hits.

Ambiguous cites are deliberately *kept* here, unlike `LoadCAPCitations` — two cases sharing a first page is exactly what the index must detect in order to refuse the match, so dropping them would turn a knowable ambiguity into a silent wrong answer.

## Memory

The CAP index holds ~5.6M spans across ~51K reporter-volume keys at 32 bytes each (~180 MB steady state); the ER index is negligible. Peak is higher during load, since the `[]CaseSpan` slice and its cite strings (~350 MB) are live until indexing finishes — the references are dropped immediately afterward so they can be collected before linking starts.

⚠️ Worth watching on the first run: `slurm/cite-linker.sh` was right-sized to 6GB in 9da9cfd against the pre-change footprint. This adds roughly 500–600 MB at peak.

## Testing

`go build ./... && go vet ./... && go test ./...` all pass. New `cite-linker/ranges_test.go` covers the `17 Mass. 479` drift case, shared-boundary vs clean-tiling bounds, ambiguous start pages, coverage holes, the volume-final case, the no-length fallback, unparsable cites, probe preference across alternate spellings, and self-consistency. `TestLinkCitation` gains nine cascade-level cases, including the two negative ones that matter most — the diffvols guard and the volume-less non-guess.

The validation both issues proposed — replay over already-linked cites and require agreement — would not have exercised this path at all, since those link by string equality and never enter the interval lookup. The startup self-consistency check is the substitute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
