### PR TITLE
slurm: right-size cite-linker, at 32 cores and 12GB

### DIFF
--- a/slurm/cite-linker.sh
+++ b/slurm/cite-linker.sh
@@ -2,15 +2,15 @@
 
 # Run the citation linker to link detected citations to cases
 
-# Resources are sized for the routine run below, from job 9215377: 8m12s wall,
-# 7m37s of CPU time (0.93 cores average), 2.6GB peak RAM. The work waits on the
-# database, not on cores, and --workers is a count of DB connections rather than
-# threads, so 4 cores still carries 32 concurrent queries. Memory is bounded and
-# nearly independent of how many citations are pending: the lookup tables are the
-# bulk of it, and the streaming reader keeps only --workers batches in flight.
-# A routine run that does hit the wall time is safe to resubmit, so the time
-# limit is a short-queue optimization, not a cliff. Raise --mem if the CAP or
-# FreeLaw tables grow enough to push peak RAM past ~4GB.
+# Resources are informed by job 9215377: 8m12s wall, 7m37s of CPU time (0.93
+# cores average), 2.6GB peak RAM. Cores are held at 32 to match --workers=32 and
+# memory at 12GB, both above what that run needed: the linker waits on the
+# database rather than on cores, but peak RAM tracks the pre-loaded lookup
+# tables, which grow with CAP and FreeLaw, so one incremental run's 2.6GB is a
+# floor rather than a ceiling. Memory does not scale with how many citations are
+# pending — the streaming reader keeps only --workers batches in flight. The wall
+# time is sized for the routine run below, where hitting it is safe to resubmit,
+# so the limit is a short-queue optimization rather than a cliff.
 
 #SBATCH --job-name=cite-linker
 #SBATCH --output=/scratch/%u/logs/%j-%x-%N.out
@@ -43,9 +43,8 @@
 # re-linked; only linked_* rows are kept. Re-comment it afterward — leaving
 # --reset live would wipe and re-do those rows on every subsequent run, including
 # on a resubmit after a timeout, throwing away all partial progress.
-# It re-processes tens of millions of rows through the per-citation path rather
-# than the handful a routine run sees, and it is the one case where a timeout is
-# expensive: because --reset starts by deleting, a resubmit restarts from scratch
-# instead of resuming. Cores and memory need no override — neither scales with the
-# row count.
+# The reset run re-processes tens of millions of rows through the per-citation
+# path rather than the handful a routine run sees, and it is the one case where a
+# timeout is expensive: because --reset starts by deleting, a resubmit restarts
+# from scratch instead of resuming rather than picking up where it left off.
 # ~/legal-modernism/bin/cite-linker --reset --batch-size=8000 --workers=32 --lock-timeout=1m

--- a/slurm/cite-linker.sh
+++ b/slurm/cite-linker.sh
@@ -2,14 +2,24 @@
 
 # Run the citation linker to link detected citations to cases
 
+# Resources are sized for the routine run below, from job 9215377: 8m12s wall,
+# 7m37s of CPU time (0.93 cores average), 2.6GB peak RAM. The work waits on the
+# database, not on cores, and --workers is a count of DB connections rather than
+# threads, so 4 cores still carries 32 concurrent queries. Memory is bounded and
+# nearly independent of how many citations are pending: the lookup tables are the
+# bulk of it, and the streaming reader keeps only --workers batches in flight.
+# A routine run that does hit the wall time is safe to resubmit, so the time
+# limit is a short-queue optimization, not a cliff. Raise --mem if the CAP or
+# FreeLaw tables grow enough to push peak RAM past ~4GB.
+
 #SBATCH --job-name=cite-linker
 #SBATCH --output=/scratch/%u/logs/%j-%x-%N.out
 #SBATCH --error=/scratch/%u/logs/%j-%x-%N.log
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
-#SBATCH --cpus-per-task=24
-#SBATCH --time=06:00:00
-#SBATCH --mem=12GB
+#SBATCH --cpus-per-task=4
+#SBATCH --time=01:00:00
+#SBATCH --mem=6GB
 #SBATCH --partition=normal
 #SBATCH --mail-user lmullen@gmu.edu
 #SBATCH --mail-type BEGIN
@@ -33,4 +43,14 @@
 # re-linked; only linked_* rows are kept. Re-comment it afterward — leaving
 # --reset live would wipe and re-do those rows on every subsequent run, including
 # on a resubmit after a timeout, throwing away all partial progress.
+#
+# Submit this path with a longer wall time than the directive above:
+#
+#     sbatch --time=06:00:00 slurm/cite-linker.sh
+#
+# It re-processes tens of millions of rows through the per-citation path rather
+# than the handful a routine run sees, and it is the one case where a timeout is
+# expensive: because --reset starts by deleting, a resubmit restarts from scratch
+# instead of resuming. Cores and memory need no override — neither scales with the
+# row count.
 # ~/legal-modernism/bin/cite-linker --reset --batch-size=8000 --workers=32 --lock-timeout=1m

--- a/slurm/cite-linker.sh
+++ b/slurm/cite-linker.sh
@@ -17,9 +17,9 @@
 #SBATCH --error=/scratch/%u/logs/%j-%x-%N.log
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
-#SBATCH --cpus-per-task=4
+#SBATCH --cpus-per-task=32
 #SBATCH --time=01:00:00
-#SBATCH --mem=6GB
+#SBATCH --mem=12GB
 #SBATCH --partition=normal
 #SBATCH --mail-user lmullen@gmu.edu
 #SBATCH --mail-type BEGIN
@@ -43,11 +43,6 @@
 # re-linked; only linked_* rows are kept. Re-comment it afterward — leaving
 # --reset live would wipe and re-do those rows on every subsequent run, including
 # on a resubmit after a timeout, throwing away all partial progress.
-#
-# Submit this path with a longer wall time than the directive above:
-#
-#     sbatch --time=06:00:00 slurm/cite-linker.sh
-#
 # It re-processes tens of millions of rows through the per-citation path rather
 # than the handful a routine run sees, and it is the one case where a timeout is
 # expensive: because --reset starts by deleting, a resubmit restarts from scratch


### PR DESCRIPTION
Supersedes #260 — this branch contains #260's commit plus the hand-tuned sizing on top, so the two PRs touch the same lines and #260 should be closed if this one is merged.

Sized from job `9215377` (8m12s wall, 7m37s CPU time = 0.93 cores average, 2.6GB peak RAM) against a prior request of 24 cores, 12GB, and six hours.

| Directive | Was | Now |
|---|---|---|
| `--cpus-per-task` | 24 | 32 |
| `--mem` | 12GB | 12GB (unchanged) |
| `--time` | 06:00:00 | 01:00:00 |

**Cores** move to 32 to match `--workers=32`. **Memory** holds at 12GB: peak RAM tracks the pre-loaded lookup tables, which grow with CAP and FreeLaw, so a single incremental run's 2.6GB is a floor rather than a ceiling. The real saving is the **wall time**, which the measured runtime does not come close to using.

The added comments record where the numbers came from, so the next re-sizing starts from evidence rather than guesswork.

## One thing to decide before merging

The wall time drops to 1 hour, and this branch also removes the note that told you to submit the `--reset` path with `sbatch --time=06:00:00`. Those two together reintroduce a trap on that path:

- A routine run that hits the wall time is harmless — batches commit as they go, so a resubmit picks up where it left off.
- A `--reset` run is not. It begins by deleting every non-linked row, so a timeout means a resubmit restarts from scratch rather than resuming. Under a 1-hour limit, a reset pass over tens of millions of rows through the per-citation path (which is why 4103d92 raised the limit to six hours after removing the bulk pre-pass) would likely never finish, and each attempt would discard the previous one's progress.

The file still warns that a reset timeout is expensive, but nothing now tells you to raise the limit. Worth either restoring the `sbatch --time=...` note or giving the reset invocation its own longer directive.

## Testing

Not submitted to hopper — I can't reach the scheduler, so this is right-sized from the reported job stats rather than confirmed by a run. `bash -n` passes; the directives and comments are the only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)